### PR TITLE
Windows dev setup: build kiriko-media with FFmpeg 7.1 + LLVM 18

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,9 @@
 # ffmpeg@7 is keg-only (deliberately not linked); builds resolve it explicitly.
 # CI installs the same formula, so this path is machine-portable across macOS.
+#
+# macOS only. rusty_ffmpeg ignores FFMPEG_PKG_CONFIG_PATH on Windows (that branch is
+# cfg(not(windows))), so this line is inert there and no per-machine path is committed.
+# Windows points the build at FFmpeg via FFMPEG_LIBS_DIR / FFMPEG_INCLUDE_DIR set outside
+# this file — see scripts/win-dev-env.ps1 and docs/GUIDE.md §8.
 [env]
 FFMPEG_PKG_CONFIG_PATH = "/opt/homebrew/opt/ffmpeg@7/lib/pkgconfig"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,48 @@ jobs:
       - run: cargo test --workspace
 
   windows:
-    name: tests (Windows — the shipping target)
+    name: tests (Windows — the shipping target, with media)
     runs-on: windows-latest
+    env:
+      # BtbN "shared, GPL" build: GPL matches Kiriko's licence, shared gives the
+      # import libs + DLLs rsmpeg links against, n7.1 matches the macOS keg ffmpeg@7.
+      FFMPEG_ASSET: ffmpeg-n7.1-latest-win64-gpl-shared-7.1
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      # FFmpeg 7.1 dev libs for kiriko-media. rusty_ffmpeg links the import libs in
+      # FFMPEG_LIBS_DIR and reads headers from FFMPEG_INCLUDE_DIR (it ignores
+      # pkg-config on Windows); the DLLs and the ffmpeg CLI (test fixtures) go on
+      # PATH. See docs/impl/phase-0-kickoff.md slice 4 and docs/GUIDE.md.
+      - name: Install FFmpeg 7.1 (BtbN shared build)
+        shell: pwsh
+        run: |
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$env:FFMPEG_ASSET.zip"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
+          Expand-Archive "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
+          $root = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
+          "FFMPEG_LIBS_DIR=$root\lib"        >> $env:GITHUB_ENV
+          "FFMPEG_INCLUDE_DIR=$root\include" >> $env:GITHUB_ENV
+          "$root\bin"                        >> $env:GITHUB_PATH
+      # bindgen (via rusty_ffmpeg) needs libclang. Pin LLVM 18: bindgen 0.71 emits
+      # broken opaque structs against very new libclang (20+). Installed to a temp
+      # dir so it never clashes with any LLVM preinstalled on the runner.
+      - name: Install LLVM 18 (libclang for bindgen)
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "18.1.8"
+          directory: ${{ runner.temp }}/llvm
+      - name: Point bindgen at libclang
+        shell: pwsh
+        run: |
+          "LIBCLANG_PATH=$env:RUNNER_TEMP\llvm\bin" >> $env:GITHUB_ENV
       - uses: Swatinem/rust-cache@v2
-      # TODO(media-on-windows): kiriko-media needs FFmpeg dev libs here (BtbN
-      # shared build + FFMPEG_LIBS_DIR/FFMPEG_INCLUDE_DIR). Until the desktop
-      # dev setup lands, Windows builds without the media feature — tracked in
-      # docs/impl/phase-0-kickoff.md slice 4 notes.
-      - run: cargo test -p kiriko-core -p kiriko-project
-      # check (not test): kiriko-ui's dev-deps include the media fixtures,
-      # and dev-deps ignore feature flags; ui tests run on the macOS job.
-      - run: cargo check -p kiriko-ui --no-default-features
-      - run: cargo check -p kiriko-app --no-default-features
+      # The shipping target runs the full gate, media included — this is the parity
+      # the desktop-dev setup unlocked (previously Windows built --no-default-features).
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace
 
   coverage:
     name: engine-crate coverage gate

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Three companion pieces:
   reference code, traps, and test plans.
 - [docs/research/](docs/research/) — the research notes that informed the specs.
 
+## Building
+
+Kiriko builds on Windows and macOS with the stable Rust toolchain. The one outside
+dependency is **FFmpeg 7.1** (video/audio decode), plus **LLVM 18** on Windows for the
+binding generator.
+
+- **macOS**: `brew install ffmpeg@7`, then `cargo test --workspace`. The repo's
+  `.cargo/config.toml` points the build at the keg.
+- **Windows**: unzip a [BtbN FFmpeg 7.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)
+  under `%USERPROFILE%\ffmpeg\`, `winget install LLVM.LLVM --version 18.1.8`, then
+  `. .\scripts\win-dev-env.ps1 -Persist` to wire it up. `cargo run -p kiriko-app` launches.
+
+Full step-by-step, in plain English: [docs/GUIDE.md](docs/GUIDE.md) §8.
+
 ## Licence
 
 [GPLv3](LICENSE). Forks stay open; contributions welcome once implementation begins.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -498,3 +498,52 @@ unknown-field survival, autosave rotation, version refusal.
 
 When you hit something not covered here, ask any session "explain X in GUIDE.md terms and
 add it to the guide" — that's the standing arrangement.
+
+## 8. Building and running it on your machine
+
+To turn the source into a running app you need the Rust toolchain and one outside
+dependency: **FFmpeg**, the library that actually decodes and encodes video and audio.
+Kiriko doesn't reinvent that wheel; `kiriko-media` talks to FFmpeg. So the build needs
+FFmpeg present, and everyday `cargo` commands need to know where it is.
+
+There are two moving parts, and it helps to know why each exists:
+
+- **FFmpeg itself** — the video/audio engine. We use version 7.1. On Windows it comes as a
+  folder with three important sub-folders: `lib` (the "how to call in" stubs the build links
+  against), `include` (the description of what's callable), and `bin` (the actual `.dll`
+  files the finished app loads while it runs, plus the `ffmpeg` command-line tool the tests
+  use to make sample clips).
+- **libclang** — a translator. FFmpeg is written in C, and something has to read FFmpeg's
+  C descriptions and generate the matching Rust ones automatically. That translator is a
+  piece of the LLVM toolchain called libclang. One gotcha, learned the hard way: use
+  **LLVM 18**. A much newer LLVM makes the translator quietly produce nonsense (it turns
+  whole data structures into blanks), and the build fails with confusing errors. Pinning 18
+  avoids it.
+
+### On Windows (the shipping platform)
+
+1. Download `ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip` from the
+   [BtbN FFmpeg builds](https://github.com/BtbN/FFmpeg-Builds/releases) page and unzip it
+   under your user folder, e.g. `C:\Users\you\ffmpeg\`. (GPL because Kiriko is GPL; "shared"
+   because we want the `.dll` files.)
+2. Install LLVM 18 and the Rust toolchain: `winget install LLVM.LLVM --version 18.1.8` and
+   `winget install Rustlang.Rustup`. Rust's default Windows setup links with Visual Studio's
+   C++ build tools, so having Visual Studio (or the standalone Build Tools) installed matters.
+3. From the repo root, run `. .\scripts\win-dev-env.ps1 -Persist`. That one script finds the
+   FFmpeg folder and LLVM, points the build at them, and (`-Persist`) remembers the settings
+   so every future terminal already knows. The leading dot is required — it means "apply
+   these to my current shell", not "run and forget".
+4. Now the normal commands work: `cargo run -p kiriko-app` to launch, `cargo test --workspace`
+   to run the whole test suite.
+
+### On macOS
+
+FFmpeg comes from Homebrew: `brew install ffmpeg@7`. The repo's `.cargo/config.toml` already
+points the build at it, and macOS ships the translator (libclang) as part of its developer
+tools, so there's nothing else to set up — `cargo test --workspace` just works.
+
+### What the robots check
+
+Every push, CI rebuilds and retests everything on both macOS and Windows, media included, so
+"it builds on my machine" can never quietly drift from "it builds for real". The Windows
+recipe above is exactly what CI does, written out by hand in `.github/workflows/ci.yml`.

--- a/docs/impl/phase-0-kickoff.md
+++ b/docs/impl/phase-0-kickoff.md
@@ -75,6 +75,28 @@ untouched for its dependents). Windows CI builds `--no-default-features` (no med
 FFmpeg dev libs are set up there — the route is a BtbN shared build plus
 `FFMPEG_LIBS_DIR`/`FFMPEG_INCLUDE_DIR`, first task of desktop-dev setup.
 
+**Slice 4 update (2026-07-14) — media builds on Windows:** the desktop-dev setup landed.
+kiriko-media, and with it the whole workspace, now builds, lints, tests, and runs on
+Windows with the `media` feature on. The recipe:
+
+- **FFmpeg 7.1 dev libs**: BtbN `ffmpeg-n7.1-latest-win64-gpl-shared-7.1` (GPL matches our
+  licence; shared gives the import libs + DLLs). Point `FFMPEG_LIBS_DIR` at its `lib`,
+  `FFMPEG_INCLUDE_DIR` at its `include`, and put `bin` on `PATH` for the DLLs and the
+  ffmpeg CLI the test fixtures shell out to. rusty_ffmpeg's build script ignores
+  `FFMPEG_PKG_CONFIG_PATH` entirely on Windows (that branch is `cfg(not(windows))`), so the
+  macOS pkg-config path in `.cargo/config.toml` is inert here and needs no change.
+- **libclang for bindgen**: rusty_ffmpeg 0.16 generates its FFI with bindgen 0.71, which
+  needs `libclang` (`LIBCLANG_PATH`). Pin **LLVM 18** — against very new libclang (tested
+  with 22) bindgen 0.71 silently emits opaque structs (`AVFormatContext` and friends become
+  `{ _address: u8 }`), and rsmpeg then fails to compile against them. LLVM 18.1.8 generates
+  correct bindings.
+- **Local convenience**: `scripts/win-dev-env.ps1` discovers both and exports the variables
+  (`-Persist` to keep them). CI does the equivalent inline (see `.github/workflows/ci.yml`
+  `windows` job), pinning LLVM 18 via `install-llvm-action` into a temp dir.
+
+Windows CI now runs the full `clippy --workspace --all-targets` + `test --workspace` gate,
+media included — the shipping target no longer trails macOS.
+
 ## Slice 5 — decode → Viewer (runs: you can SEE footage)
 
 `kiriko-gpu` device + pool + NV12→linear shader + display-transform blit

--- a/scripts/win-dev-env.ps1
+++ b/scripts/win-dev-env.ps1
@@ -1,0 +1,132 @@
+<#
+.SYNOPSIS
+    Set up the environment variables Kiriko's media crate needs to build on Windows.
+
+.DESCRIPTION
+    kiriko-media links FFmpeg 7.1 through rsmpeg. On Windows, rusty_ffmpeg's build
+    script links the import libraries named by FFMPEG_LIBS_DIR / FFMPEG_INCLUDE_DIR
+    and generates its FFI with bindgen, which needs libclang (LIBCLANG_PATH). At run
+    time the FFmpeg DLLs (and the ffmpeg CLI used by the test fixtures) must be on PATH.
+
+    This script finds a BtbN FFmpeg 7.1 "shared, GPL" build and an LLVM install, then
+    exports those variables for the current shell. Pass -Persist to also write them to
+    your user environment so every new terminal has them.
+
+    Nothing here hard-codes a machine-specific path: the FFmpeg build is discovered by
+    convention (see -FfmpegDir) and LLVM at its standard install location.
+
+.PARAMETER FfmpegDir
+    The extracted FFmpeg build directory (the folder containing bin\, lib\, include\).
+    If omitted, the script searches, in order:
+      $env:KIRIKO_FFMPEG_DIR
+      %USERPROFILE%\ffmpeg\ffmpeg-n7.1-*-win64-gpl-shared-*
+      C:\ffmpeg\ffmpeg-n7.1-*-win64-gpl-shared-*
+
+.PARAMETER Persist
+    Also store the variables at User scope (like setx) so future shells inherit them.
+
+.EXAMPLE
+    . .\scripts\win-dev-env.ps1
+    Dot-source it (note the leading dot) to set the variables in your current shell.
+
+.EXAMPLE
+    . .\scripts\win-dev-env.ps1 -Persist
+    Set them for this shell and persist them for all future shells.
+
+.NOTES
+    Get the FFmpeg build from https://github.com/BtbN/FFmpeg-Builds/releases (the
+    "ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip" asset) and extract it under
+    %USERPROFILE%\ffmpeg\. Install LLVM 18 (winget install LLVM.LLVM --version 18.1.8):
+    bindgen 0.71 mis-generates opaque structs against very new libclang, so pin 18.
+    See docs/GUIDE.md "Building on Windows" and docs/impl/phase-0-kickoff.md slice 4.
+#>
+[CmdletBinding()]
+param(
+    [string]$FfmpegDir,
+    [switch]$Persist
+)
+
+function Find-FfmpegDir {
+    param([string]$Explicit)
+
+    $candidates = @()
+    if ($Explicit)               { $candidates += $Explicit }
+    if ($env:KIRIKO_FFMPEG_DIR)  { $candidates += $env:KIRIKO_FFMPEG_DIR }
+
+    foreach ($base in @("$env:USERPROFILE\ffmpeg", 'C:\ffmpeg')) {
+        if (Test-Path $base) {
+            $match = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -like 'ffmpeg-n7.1-*win64-gpl-shared*' } |
+                Sort-Object Name -Descending | Select-Object -First 1
+            if ($match) { $candidates += $match.FullName }
+        }
+    }
+
+    foreach ($c in $candidates) {
+        if ($c -and (Test-Path "$c\lib") -and (Test-Path "$c\include") -and (Test-Path "$c\bin")) {
+            return (Resolve-Path $c).Path
+        }
+    }
+    return $null
+}
+
+function Find-LibclangDir {
+    $candidates = @()
+    if ($env:LIBCLANG_PATH) { $candidates += $env:LIBCLANG_PATH }
+    $candidates += 'C:\Program Files\LLVM\bin'
+    $candidates += 'C:\Program Files\LLVM\lib'
+    foreach ($c in $candidates) {
+        if ($c -and (Test-Path (Join-Path $c 'libclang.dll'))) { return $c }
+    }
+    return $null
+}
+
+$ff = Find-FfmpegDir -Explicit $FfmpegDir
+if (-not $ff) {
+    Write-Error @"
+Could not find an FFmpeg 7.1 shared/GPL build.
+Download ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip from
+https://github.com/BtbN/FFmpeg-Builds/releases and extract it under %USERPROFILE%\ffmpeg\,
+or pass -FfmpegDir <path-to-the-extracted-folder>.
+"@
+    return
+}
+
+$clang = Find-LibclangDir
+if (-not $clang) {
+    Write-Error @"
+Could not find libclang.dll (needed by bindgen).
+Install LLVM 18:  winget install LLVM.LLVM --version 18.1.8
+(Very new libclang, e.g. 22, makes bindgen 0.71 emit broken opaque bindings — pin 18.)
+"@
+    return
+}
+
+$libs    = "$ff\lib"
+$include = "$ff\include"
+$bin     = "$ff\bin"
+
+$env:FFMPEG_LIBS_DIR    = $libs
+$env:FFMPEG_INCLUDE_DIR = $include
+$env:LIBCLANG_PATH      = $clang
+if (($env:Path -split ';') -notcontains $bin) {
+    $env:Path = "$bin;$env:Path"
+}
+
+Write-Host "Kiriko Windows dev environment set for this shell:" -ForegroundColor Green
+Write-Host "  FFMPEG_LIBS_DIR    = $libs"
+Write-Host "  FFMPEG_INCLUDE_DIR = $include"
+Write-Host "  LIBCLANG_PATH      = $clang"
+Write-Host "  PATH              += $bin"
+
+if ($Persist) {
+    [Environment]::SetEnvironmentVariable('FFMPEG_LIBS_DIR',    $libs,    'User')
+    [Environment]::SetEnvironmentVariable('FFMPEG_INCLUDE_DIR', $include, 'User')
+    [Environment]::SetEnvironmentVariable('LIBCLANG_PATH',      $clang,   'User')
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (($userPath -split ';') -notcontains $bin) {
+        $newPath = if ([string]::IsNullOrEmpty($userPath)) { $bin } else { "$userPath;$bin" }
+        [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    }
+    Write-Host "Persisted to your user environment (new terminals will inherit them)." -ForegroundColor Green
+}


### PR DESCRIPTION
Lands the "first task of desktop-dev setup" (docs/impl/phase-0-kickoff.md slice 4): the whole workspace now builds, lints, tests, and runs on **Windows with the media feature on**, closing the gap where Windows CI built `--no-default-features`.

## What changed
- **CI (`.github/workflows/ci.yml`)**: the Windows job installs a BtbN FFmpeg 7.1 shared/GPL build + **LLVM 18** (into a temp dir, no clash with any preinstalled LLVM) and runs the full `clippy --workspace --all-targets -D warnings` + `test --workspace` gate — the shipping target no longer trails macOS.
- **`scripts/win-dev-env.ps1`** (new): discovers the FFmpeg build + LLVM and exports `FFMPEG_LIBS_DIR`/`FFMPEG_INCLUDE_DIR`/`LIBCLANG_PATH` (+ ffmpeg `bin` on PATH); `-Persist` keeps them. Auto-detects by convention — no machine-specific path committed.
- **`.cargo/config.toml`**: note that `FFMPEG_PKG_CONFIG_PATH` is macOS-only (rusty_ffmpeg ignores it on Windows).
- **docs**: GUIDE.md §8 "Building on Windows" (plain English, K-007), README Building section, phase-0-kickoff slice-4 resolution note.

## Why LLVM is pinned to 18
bindgen 0.71 (via rusty_ffmpeg) silently emits **opaque** FFI structs against very new libclang — with LLVM 22, `AVFormatContext` became `{ _address: u8 }` and rsmpeg failed to compile. LLVM 18.1.8 generates correct bindings.

## Verified locally (Windows, media on)
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — all green
- `kiriko-media` tests 7/7 (real decode/encode/DLL load); `kiriko.exe` builds and runs

The CI change itself is validated by this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)