### PR TITLE
Shake: Amplitude does not affect rotation Bug Fixed

### DIFF
--- a/crates/lumit-core/src/fx/resolved.rs
+++ b/crates/lumit-core/src/fx/resolved.rs
@@ -1167,7 +1167,7 @@ fn resolve_one(
         "shake" => {
             let amp_pct = (e.float_at("amplitude", lt).unwrap_or(1.5) as f32).max(0.0);
             let freq = e.float_at("frequency", lt).unwrap_or(8.0).max(0.0);
-            let rot_amount = (e.float_at("rotation", lt).unwrap_or(1.0) as f32).max(0.0);
+            let rot_amount = (e.float_at("rotation", lt).unwrap_or(1.0) as f32).max(0.0) * (amp_pct / 1.5);
             // Per-axis wobble (twirl group, K-146): amount multipliers scale
             // the master Amplitude, frequency multipliers the master rate.
             // Defaults of 1 reproduce the old uniform x/y shake exactly.

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -4636,3 +4636,38 @@ fn cpu_scanlines_darken_a_periodic_band() {
     assert_eq!(red_at(&inter, 8), 1.0, "period 2 (even) unflipped again");
     assert_eq!(red_at(&inter, 10), 0.5, "period 2 (even) unflipped again");
 }
+#[test]
+fn shake_amplitude_scales_the_rotation_wobble() {
+    let rotation_at = |amp: f64| {
+        let e = shake_at_amplitude(amp);
+        let r = resolve_stack(
+            std::slice::from_ref(&e),
+            0.4,
+            1000.0,
+            1.0,
+            &MarkerContext::NONE,
+        );
+        let Resolved::Shake { rotation_deg, .. } = r[0] else {
+            panic!("expected a Shake");
+        };
+        rotation_deg
+    };
+
+    // A non-zero wobble at this frame, or the ratio below would prove nothing.
+    let nominal = rotation_at(1.5);
+    assert!(
+        nominal.abs() > 1e-4,
+        "expected a rotating frame to test against"
+    );
+
+    // Twice the amplitude, twice the rotation wobble.
+    let louder = rotation_at(3.0);
+    assert!(
+        (louder - 2.0 * nominal).abs() < 1e-4,
+        "double the amplitude should double the rotation wobble (got {louder} vs {nominal})",
+    );
+
+    // Amplitude 0 stills the shake completely — rotation included. Before TF-28
+    // the rotation ignored amplitude, so this frame still rotated: this guard
+    // fails without the fix.
+    assert_eq!(rotation_at(0.0), 0.0, "zero amplitude leaves no rotation");

--- a/docs/08-EFFECTS.md
+++ b/docs/08-EFFECTS.md
@@ -439,7 +439,7 @@ exponentially over Decay seconds, so shakes hit on the beat and settle.
 | Decay | 0.05–2 s | 0.35 s |
 | Seed | seed | per-instance |
 
-The master Amplitude and Frequency drive the overall translational sway; the **Per-axis
+The master Amplitude sets the shake's overall intensity — it scales the rotation wobble andg the translational sway and Frequency drives the overall rate; the **Per-axis
 wobble** twirl (K-146) biases each axis and adds depth. X and Y amount/frequency are
 dimensionless multipliers on the master values (×1 reproduces the plain uniform shake); Z
 is the depth/scale shake — Z amount is a scale-pump per cent (the old Zoom pump, same


### PR DESCRIPTION
https://github.com/luminalmvm/Lumit/blob/b27178ae5b368778b88d5c13943c7c18e86f1f7a/docs/test-feedback-log.md?plain=1#L517-L518

This PR fixed it by multiplying `amp_pct / 1.5`, where 1.5 is the default value of amplitude, so that rotation would not be affected when Amplitude is set to the default value

Also add a test and change the docs