### PR TITLE
TF-30, TF-29 Graph editor: adjustment layer param keyframes invisible, keyframes aligned to timeline

### DIFF
--- a/buildartix.sh
+++ b/buildartix.sh
@@ -1,0 +1,4 @@
+export LIBCLANG_PATH=/usr/lib/llvm18/lib
+export LLVM_CONFIG_PATH=/usr/lib/llvm18/bin/llvm-config
+export FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig
+RUSTC_WRAPPER="" cargo run -p lumit-app

--- a/crates/lumit-ui/src/app_state/mod.rs
+++ b/crates/lumit-ui/src/app_state/mod.rs
@@ -915,6 +915,8 @@ pub struct AppState {
     pub pen_path: Vec<lumit_core::mask::Vertex>,
     /// Property shown in the graph editor.
     pub graph_prop: Option<lumit_core::model::TransformProp>,
+    /// Effect parameter shown in the graph editor: (effect index, param index).
+    pub graph_effect: Option<(usize, usize)>,
     /// In-flight keyframe drag: (key index, provisional layer-time, value).
     pub graph_edit: Option<(usize, f64, f64)>,
     /// In-flight marquee (rubber-band) drag on the graph's background:
@@ -1230,6 +1232,7 @@ impl Default for AppState {
             selected_layer: None,
             selected_clip: None,
             graph_prop: None,
+            graph_effect: None,
             graph_edit: None,
             graph_marquee: None,
             graph_selection: None,

--- a/crates/lumit-ui/src/shell/dock_tests.rs
+++ b/crates/lumit-ui/src/shell/dock_tests.rs
@@ -1736,3 +1736,69 @@ fn drag_secs_follows_the_displayed_zoom() {
     // A degenerate px_per_sec never divides by zero.
     assert!(drag_secs(50.0, 0.0).is_finite());
 }
+
+// Graph editor reads effect param keyframes (TF-30) and aligns with timeline
+// positions via start_offset conversion (TF-25).
+#[test]
+fn effect_keyframes_graph_and_align() {
+    use lumit_core::anim::{Animation, Property, SideInterp};
+    use lumit_core::model::{
+        EffectInstance, EffectKey, EffectNamespace, EffectParam, EffectValue, Layer, LayerKind,
+    };
+
+    let layer = Layer {
+        id: uuid::Uuid::nil(),
+        name: "Test".into(),
+        kind: LayerKind::Adjustment,
+        in_point: lumit_core::time::CompTime(rational_at(0.0)),
+        out_point: lumit_core::time::CompTime(rational_at(10.0)),
+        start_offset: lumit_core::time::CompTime(rational_at(2.0)),
+        transform: Default::default(),
+        matte: None,
+        parent: None,
+        label: 0,
+        volume_db: Property::zero(),
+        blend: Default::default(),
+        masks: vec![],
+        effects: vec![EffectInstance {
+            id: uuid::Uuid::nil(),
+            effect: EffectKey {
+                namespace: EffectNamespace::Builtin,
+                match_name: "test".into(),
+                version: 0,
+                extra: serde_json::Map::new(),
+            },
+            enabled: true,
+            params: vec![EffectParam {
+                id: "v".into(),
+                value: EffectValue::Float(Property {
+                    animation: Animation::Keyframed(vec![lumit_core::anim::Keyframe {
+                        time: rational_at(0.0),
+                        value: 10.0,
+                        interp_in: SideInterp::Linear,
+                        interp_out: SideInterp::Linear,
+                    }]),
+                    extra: serde_json::Map::new(),
+                }),
+                extra: serde_json::Map::new(),
+            }],
+            sample_temporally: true,
+            extra: serde_json::Map::new(),
+        }],
+        switches: Default::default(),
+        extra: serde_json::Map::new(),
+    };
+
+    let k = &layer.effects[0].params[0];
+    assert!(matches!(&k.value, EffectValue::Float(p) if p.is_animated()));
+
+    // Alignment: x_of converts layer time to comp time via start_offset.
+    let off = layer.start_offset.0.to_f64();
+    let x_of = |t: f64| 100.0 + ((t + off - 0.0) * 50.0) as f32;
+    assert!((x_of(0.0) - 200.0).abs() < 1e-6); // 100 + 2*50 = 200
+    assert!((x_of(-1.0) - 150.0).abs() < 1e-6); // 100 + 1*50 = 150
+
+    // t_of allows negative layer times before the layer start.
+    let t_of = |x: f32| (0.0 + (x - 100.0) as f64 / 50.0).clamp(0.0, 20.0) - off;
+    assert!((t_of(150.0) - (-1.0)).abs() < 1e-6);
+}

--- a/crates/lumit-ui/src/shell/dock_tests.rs
+++ b/crates/lumit-ui/src/shell/dock_tests.rs
@@ -1758,24 +1758,53 @@ fn rational_at_signed_preserves_negative_times() {
 #[test]
 fn effect_param_reads_keyframes_for_the_graph() {
     use lumit_core::anim::{Animation, Property};
-    use lumit_core::model::{EffectParam, EffectValue};
+    use lumit_core::model::{EffectInstance, EffectKey, EffectNamespace, EffectParam, EffectValue, Layer, LayerKind};
 
-    let param = EffectParam {
-        id: "x".into(),
-        value: EffectValue::Float(Property {
-            animation: Animation::Keyframed(vec![lumit_core::anim::Keyframe {
-                time: rational_at(1.0),
-                value: 42.0,
-                interp_in: lumit_core::anim::SideInterp::Linear,
-                interp_out: lumit_core::anim::SideInterp::Linear,
-            }]),
+    let layer = Layer {
+        id: uuid::Uuid::nil(),
+        name: "T".into(),
+        kind: LayerKind::Adjustment,
+        in_point: lumit_core::time::CompTime(rational_at(0.0)),
+        out_point: lumit_core::time::CompTime(rational_at(10.0)),
+        start_offset: lumit_core::time::CompTime(rational_at(0.0)),
+        transform: Default::default(),
+        matte: None,
+        parent: None,
+        label: 0,
+        volume_db: Property::zero(),
+        blend: Default::default(),
+        masks: vec![],
+        effects: vec![EffectInstance {
+            id: uuid::Uuid::nil(),
+            effect: EffectKey {
+                namespace: EffectNamespace::Builtin,
+                match_name: "test".into(),
+                version: 0,
+                extra: serde_json::Map::new(),
+            },
+            enabled: true,
+            params: vec![EffectParam {
+                id: "x".into(),
+                value: EffectValue::Float(Property {
+                    animation: Animation::Keyframed(vec![lumit_core::anim::Keyframe {
+                        time: rational_at(1.0),
+                        value: 42.0,
+                        interp_in: lumit_core::anim::SideInterp::Linear,
+                        interp_out: lumit_core::anim::SideInterp::Linear,
+                    }]),
+                    extra: serde_json::Map::new(),
+                }),
+                extra: serde_json::Map::new(),
+            }],
+            sample_temporally: true,
             extra: serde_json::Map::new(),
-        }),
+        }],
+        switches: Default::default(),
         extra: serde_json::Map::new(),
     };
 
-    // Same extraction chain graph_plot uses (indexed, not by id).
-    let p = &param;
+    // The extraction chain graph_plot uses: layer.effects.get(ei)?.params.get(pi)?.
+    let p = layer.effects.get(0).unwrap().params.get(0).unwrap();
     let EffectValue::Float(prop) = &p.value else { panic!("not float") };
     let Animation::Keyframed(ks) = &prop.animation else { panic!("not keyframed") };
     assert_eq!(ks.len(), 1);

--- a/crates/lumit-ui/src/shell/dock_tests.rs
+++ b/crates/lumit-ui/src/shell/dock_tests.rs
@@ -1737,68 +1737,76 @@ fn drag_secs_follows_the_displayed_zoom() {
     assert!(drag_secs(50.0, 0.0).is_finite());
 }
 
-// Graph editor reads effect param keyframes (TF-30) and aligns with timeline
-// positions via start_offset conversion (TF-25).
+// The signed rational constructor preserves negative seconds; the unsigned
+// one clamps them — proving rational_at_signed is needed for negative
+// keyframe times (TF-25 regression guard).
 #[test]
-fn effect_keyframes_graph_and_align() {
-    use lumit_core::anim::{Animation, Property, SideInterp};
-    use lumit_core::model::{
-        EffectInstance, EffectKey, EffectNamespace, EffectParam, EffectValue, Layer, LayerKind,
+fn rational_at_signed_preserves_negative_times() {
+    // unsigned: clamps
+    assert!((rational_at(-1.0).to_f64() - 0.0).abs() < 1e-6);
+    // signed: preserves
+    assert!((rational_at_signed(-1.0).to_f64() + 1.0).abs() < 1e-6);
+    assert!((rational_at_signed(-2.5).to_f64() + 2.5).abs() < 1e-6);
+    // signed negative rounds to the flick grid
+    let r = rational_at_signed(-1.0);
+    assert!((r.to_f64() + 1.0).abs() < 1e-6);
+    assert!(r.num() < 0); // numerator is negative
+}
+
+// The graph_plot data path reads keyframes from
+// layer.effects[ei].params[pi] when it is an EffectValue::Float (TF-30).
+#[test]
+fn effect_param_reads_keyframes_for_the_graph() {
+    use lumit_core::anim::{Animation, Property};
+    use lumit_core::model::{EffectParam, EffectValue};
+
+    let param = EffectParam {
+        id: "x".into(),
+        value: EffectValue::Float(Property {
+            animation: Animation::Keyframed(vec![lumit_core::anim::Keyframe {
+                time: rational_at(1.0),
+                value: 42.0,
+                interp_in: lumit_core::anim::SideInterp::Linear,
+                interp_out: lumit_core::anim::SideInterp::Linear,
+            }]),
+            extra: serde_json::Map::new(),
+        }),
+        extra: serde_json::Map::new(),
     };
+
+    // Same extraction chain graph_plot uses (indexed, not by id).
+    let p = &param;
+    let EffectValue::Float(prop) = &p.value else { panic!("not float") };
+    let Animation::Keyframed(ks) = &prop.animation else { panic!("not keyframed") };
+    assert_eq!(ks.len(), 1);
+    assert!((ks[0].value - 42.0).abs() < 1e-6);
+}
+
+// A layer's start_offset round-trips through to_f64() on its internal
+// Rational — the prerequisite for the TF-25 x_of/t_of conversion.
+#[test]
+fn layer_start_offset_round_trips_to_f64() {
+    use lumit_core::model::{Layer, LayerKind};
 
     let layer = Layer {
         id: uuid::Uuid::nil(),
-        name: "Test".into(),
+        name: "T".into(),
         kind: LayerKind::Adjustment,
         in_point: lumit_core::time::CompTime(rational_at(0.0)),
         out_point: lumit_core::time::CompTime(rational_at(10.0)),
-        start_offset: lumit_core::time::CompTime(rational_at(2.0)),
+        start_offset: lumit_core::time::CompTime(rational_at_signed(2.0)),
         transform: Default::default(),
         matte: None,
         parent: None,
         label: 0,
-        volume_db: Property::zero(),
+        volume_db: lumit_core::anim::Property::zero(),
         blend: Default::default(),
         masks: vec![],
-        effects: vec![EffectInstance {
-            id: uuid::Uuid::nil(),
-            effect: EffectKey {
-                namespace: EffectNamespace::Builtin,
-                match_name: "test".into(),
-                version: 0,
-                extra: serde_json::Map::new(),
-            },
-            enabled: true,
-            params: vec![EffectParam {
-                id: "v".into(),
-                value: EffectValue::Float(Property {
-                    animation: Animation::Keyframed(vec![lumit_core::anim::Keyframe {
-                        time: rational_at(0.0),
-                        value: 10.0,
-                        interp_in: SideInterp::Linear,
-                        interp_out: SideInterp::Linear,
-                    }]),
-                    extra: serde_json::Map::new(),
-                }),
-                extra: serde_json::Map::new(),
-            }],
-            sample_temporally: true,
-            extra: serde_json::Map::new(),
-        }],
+        effects: vec![],
         switches: Default::default(),
         extra: serde_json::Map::new(),
     };
 
-    let k = &layer.effects[0].params[0];
-    assert!(matches!(&k.value, EffectValue::Float(p) if p.is_animated()));
-
-    // Alignment: x_of converts layer time to comp time via start_offset.
     let off = layer.start_offset.0.to_f64();
-    let x_of = |t: f64| 100.0 + ((t + off - 0.0) * 50.0) as f32;
-    assert!((x_of(0.0) - 200.0).abs() < 1e-6); // 100 + 2*50 = 200
-    assert!((x_of(-1.0) - 150.0).abs() < 1e-6); // 100 + 1*50 = 150
-
-    // t_of allows negative layer times before the layer start.
-    let t_of = |x: f32| (0.0 + (x - 100.0) as f64 / 50.0).clamp(0.0, 20.0) - off;
-    assert!((t_of(150.0) - (-1.0)).abs() < 1e-6);
+    assert!((off - 2.0).abs() < 1e-6);
 }

--- a/crates/lumit-ui/src/shell/graph.rs
+++ b/crates/lumit-ui/src/shell/graph.rs
@@ -867,22 +867,47 @@ pub(crate) fn graph_plot(
     } else {
         None
     };
+    // Effect parameter keys: read from the layer's effect param (TF-30).
+    let effect_keys: Option<Vec<Keyframe>> = app.graph_effect.and_then(|(ei, pi)| {
+        let p = layer.effects.get(ei)?.params.get(pi)?;
+        if let lumit_core::model::EffectValue::Float(prop) = &p.value {
+            Some(match &prop.animation {
+                Animation::Keyframed(ks) => ks.clone(),
+                _ => Vec::new(),
+            })
+        } else {
+            None
+        }
+    });
+    let effect_static = app
+        .graph_effect
+        .and_then(|(ei, pi)| {
+            let p = layer.effects.get(ei)?.params.get(pi)?;
+            if let lumit_core::model::EffectValue::Float(prop) = &p.value {
+                Some(prop.value_at(0.0))
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0.0);
     // A still (Static) property has no keys yet: graph a flat line at its value
     // that you can double-click to add the first keyframe to (Mack). The Time
     // channel always has ≥ 2 boundary keys, so its static value is just the
     // first key (only used if a curve were somehow empty).
     let empty_keys: Vec<Keyframe> = Vec::new();
-    let (keys, static_val): (&Vec<Keyframe>, f64) = match &retime_keys {
-        Some(ks) => (ks, ks.first().map_or(0.0, |k| k.value)),
-        None => {
-            let slot = layer.transform.get(current);
-            let sv = slot.value_at(0.0);
-            match &slot.animation {
-                Animation::Keyframed(k) => (k, sv),
-                _ => (&empty_keys, sv),
-            }
+    let (keys, static_val): (&Vec<Keyframe>, f64) = if let Some(ks) = &effect_keys {
+        (ks, ks.first().map_or(effect_static, |k| k.value))
+    } else if let Some(ks) = &retime_keys {
+        (ks, ks.first().map_or(0.0, |k| k.value))
+    } else {
+        let slot = layer.transform.get(current);
+        let sv = slot.value_at(0.0);
+        match &slot.animation {
+            Animation::Keyframed(k) => (k, sv),
+            _ => (&empty_keys, sv),
         }
     };
+    let is_effect = app.graph_effect.is_some();
 
     // The marquee selection for this channel. A selection made on any other
     // layer/property, or one whose time pins no longer line up with the keys
@@ -890,7 +915,7 @@ pub(crate) fn graph_plot(
     // touching the wrong keyframes.
     let selection: Vec<usize> = match &app.graph_selection {
         Some(s)
-            if s.layer == layer_id && s.retime == is_retime && (is_retime || s.prop == current) =>
+            if s.layer == layer_id && (is_effect || (s.retime == is_retime && (is_retime || s.prop == current))) =>
         {
             match s.indices_for(keys) {
                 Some(sel) => sel,
@@ -946,7 +971,7 @@ pub(crate) fn graph_plot(
         nudge_selected_values(&mut shown, &selection, delta);
     } else if let Some((idx, kt, kv)) = app.graph_edit {
         if let Some(k) = shown.get_mut(idx) {
-            k.time = rational_at(kt);
+            k.time = rational_at_signed(kt);
             k.value = kv;
         }
         shown.sort_by_key(|k| k.time);
@@ -1017,11 +1042,14 @@ pub(crate) fn graph_plot(
     let (vmin, vmax) = app.graph_view_y.unwrap_or(auto_fit);
     // x follows the shared timeline axis (K-079): the same pixels-per-second and
     // scrolled left edge as the lane bars, so panning/zooming the timeline moves
-    // the curve in step. Keys outside the view clip to the lane area.
-    let x_of = |t: f64| rect.left() + ((t - view_start) * px_per_sec) as f32;
+    // the curve in step. Key times are layer-local; adding start_offset converts
+    // to comp time so they align with the lane bars (TF-25).
+    let off = layer.start_offset.0.to_f64();
+    let x_of = |t: f64| rect.left() + ((t + off - view_start) * px_per_sec) as f32;
     let y_of = |v: f64| rect.bottom() - (((v - vmin) / (vmax - vmin)) as f32) * rect.height();
     let t_of = |x: f32| {
-        (view_start + (x - rect.left()) as f64 / px_per_sec.max(1e-6)).clamp(0.0, duration)
+        let ct = (view_start + (x - rect.left()) as f64 / px_per_sec.max(1e-6)).clamp(0.0, duration);
+        ct - off
     };
     let v_of = |y: f32| {
         vmin + ((rect.bottom() - y) / rect.height()).clamp(0.0, 1.0) as f64 * (vmax - vmin)
@@ -1096,7 +1124,7 @@ pub(crate) fn graph_plot(
         if let Some(p) = bg.interact_pointer_pos() {
             let mut new_keys = keys.clone();
             new_keys.push(Keyframe {
-                time: rational_at(t_of(p.x)),
+                time: rational_at_signed(t_of(p.x)),
                 value: v_of(p.y),
                 interp_in: SideInterp::Linear,
                 interp_out: SideInterp::Linear,
@@ -1130,8 +1158,9 @@ pub(crate) fn graph_plot(
     let vis_span = (vis_hi - vis_lo).max(1e-6);
     let values: Vec<(f64, f64)> = (0..=samples)
         .map(|i| {
-            let t = vis_lo + vis_span * i as f64 / samples as f64;
-            (t, sample_at(t))
+            let ct = vis_lo + vis_span * i as f64 / samples as f64;
+            let lt = ct - off;
+            (lt, sample_at(lt))
         })
         .collect();
     // The speed lens scales to its own sampled range; `speed_of` inverts the
@@ -1204,7 +1233,13 @@ pub(crate) fn graph_plot(
     {
         // The Time channel reads in seconds of source; transform props use
         // their own unit (%, °, or none).
-        let unit = if is_retime { "s" } else { prop_unit(current) };
+        let unit = if is_effect {
+            ""
+        } else if is_retime {
+            "s"
+        } else {
+            prop_unit(current)
+        };
         if app.graph_speed_view {
             graph_y_axis(ui, theme, rect, s_lo, s_hi, |v| {
                 format!("{}{unit}/s", fmt_axis_value(v, s_hi - s_lo))
@@ -1654,7 +1689,7 @@ pub(crate) fn graph_plot(
                         // delta — a single undo step; times are untouched.
                         nudge_selected_values(&mut new_keys, &selection, kv - key.value);
                     } else {
-                        let nt = rational_at(kt.max(0.0));
+                        let nt = rational_at_signed(kt);
                         new_keys[i].time = nt;
                         new_keys[i].value = kv;
                         new_keys.sort_by_key(|k| k.time);
@@ -1828,7 +1863,29 @@ pub(crate) fn graph_plot(
     ui.set_clip_rect(saved_clip);
 
     if let Some(new_keys) = pending {
-        let op = if is_retime {
+        let op = if let Some((ei, pi)) = app.graph_effect {
+            let animation = if new_keys.is_empty() {
+                Animation::Static(static_val)
+            } else {
+                Animation::Keyframed(new_keys)
+            };
+            let mut effects = layer.effects.clone();
+            if let Some(e) = effects.get_mut(ei) {
+                if let Some(p) = e.params.get_mut(pi) {
+                    p.value = lumit_core::model::EffectValue::Float(
+                        lumit_core::anim::Property {
+                            animation,
+                            extra: serde_json::Map::new(),
+                        },
+                    );
+                }
+            }
+            lumit_core::Op::SetLayerEffects {
+                comp: comp.id,
+                layer: layer_id,
+                effects,
+            }
+        } else if is_retime {
             // Rebuild the Retime store from the edited Time keyframes (K-078).
             // Fewer than two keys (or otherwise unbuildable) can't be a retime,
             // so that edit is dropped and the existing store kept.

--- a/crates/lumit-ui/src/shell/inspector/effect_rows.rs
+++ b/crates/lumit-ui/src/shell/inspector/effect_rows.rs
@@ -769,17 +769,44 @@ pub(crate) fn effects_rows(
                                 animation,
                                 extra: serde_json::Map::new(),
                             });
+                        // Follow the graph to this effect param (TF-30).
+                        app.selected_layer = Some(layer.id);
+                        app.graph_effect = Some((idx, pi));
+                        app.graph_prop = None;
+                        app.graph_retime = false;
+                        app.graph_reset_fit();
                         *pending = Some(commit(effects));
                     }
                     // The ◄ ◆ ► navigator, once the param is animated — the effect
                     // twin of the transform rows' `keyframe_nav` (the reported bug:
                     // effect params had a stopwatch but no navigator).
                     effect_param_nav(&mut c, ctx, idx, pi, prop, pending, nav_jump);
-                    c.label(
-                        egui::RichText::new(ps.label)
-                            .small()
-                            .color(ctx.theme.text_muted),
-                    );
+                    let graph_hl = app.selected_layer == Some(layer.id)
+                        && app.graph_effect == Some((idx, pi));
+                    let name_clicked = c
+                        .add(
+                            egui::Label::new(
+                                egui::RichText::new(ps.label).small().color(
+                                    if graph_hl {
+                                        ctx.theme.accent
+                                    } else {
+                                        ctx.theme.text_muted
+                                    },
+                                ),
+                            )
+                            .sense(egui::Sense::click()),
+                        )
+                        .on_hover_text("Graph this parameter")
+                        .clicked();
+                    if name_clicked
+                        && !ui.input(|i| i.modifiers.shift || i.modifiers.command || i.modifiers.ctrl)
+                    {
+                        app.selected_layer = Some(layer.id);
+                        app.graph_effect = Some((idx, pi));
+                        app.graph_prop = None;
+                        app.graph_retime = false;
+                        app.graph_reset_fit();
+                    }
                     // Value box on the shared value column (owner EC3): snugly
                     // right of the row's midline, the DoF Focus eyedropper after.
                     snap_to_value_column(&mut c);


### PR DESCRIPTION
#### Problem TF-30: 
Keyframes on an adjustment layer's effect parameters are invisible in the graph editor. Clicking an effect parameter row or adding keyframes via the stopwatch shows a flat transform property line instead of the effect's curve.

#### Problem TF-25: 
Keyframe glyphs, the blue curve, and the playhead in the graph editor are misaligned with the timeline lane bars. The offset grows proportionally with the layer's start_offset (e.g., moving a layer right shifts everything).

**Root Causes:**
1. No graph support for effect parameters (TF-30): The graph editor only supported two channel types — transform properties (graph_prop) and the Retime channel (graph_retime). Effect parameters (Float, Point, Colour) had no graph path at all. Clicking an effect param row in the inspector set selected_layer but never touched graph_prop, so the graph stayed on whatever transform property was last selected. Effect param keyframes existed in the data model and displayed as lane diamonds, but the graph editor never read them.
2. Missing start_offset conversion (TF-25): graph_plot computed X positions with x_of(t) = rect.left() + (t - view_start) * px_per_sec, where t is layer-local keyframe time. But view_start is comp time. The missing conversion — layer time → comp time via t + start_offset — shifted every keyframe, curve segment, and the playhead by -start_offset * px_per_sec pixels relative to the lane bars.

---

#### Solution
Effect param graphing (TF-30):
- Added graph_effect: Option<(usize, usize)> to AppState, mutually exclusive with graph_prop and graph_retime
- graph_plot auto-detects app.graph_effect — no parameter threading through the function signature. Reads keyframes from layer.effects[ei].params[pi] when set; commits edits through SetLayerEffects (cloning the stack, modifying the target param)
- Clicking a Float effect parameter label sets graph_effect, clears graph_prop/graph_retime, and calls graph_reset_fit(). The label highlights in accent when it is the active graphed channel
- Stopwatch click on an effect param auto-follows the graph to that parameter
Axis alignment (TF-25):
- x_of(t) = rect.left() + ((t + start_offset - view_start) * px_per_sec) — adds start_offset to convert layer-local time to comp time
- t_of(x) = clamp(view_start + (x - rect.left()) / px_per_sec, 0, duration) - start_offset — inverse converts comp time back to layer time
- Curve sampling evaluates sample_at(ct - start_offset) at comp-time sampling points instead of raw comp time
- rational_at_signed replaces rational_at at all three graph keyframe time sites (provisional display, double-click add, drag commit) so the t_of output (which can be negative) round-trips through Rational losslessly
Known bug (not fixed)
Cannot drag an existing keyframe before the layer's initial start — when a layer is moved or trimmed right (positive start_offset), keyframes stop following the mouse cursor at the left edge of the layer bar. The graph's t_of returns negative layer times (correct), rational_at_signed preserves them (correct), and the commit stores them correctly. However, the interact widget's interact_pointer_pos() returns None once the pointer moves left of the graph rect into the outline column, freezing the keyframe's screen position mid-drag. Extending the layer's out-point doesn't change the stopping point. A fallback to ui.input(|i| i.pointer.hover_pos()) in the drag handlers was attempted but did not resolve the issue; deeper investigation into egui's clip rect / interaction boundary is needed.

---

#### Known bug (not fixed)
Cannot drag an existing keyframe before the layer's initial start - when a layer is moved or trimmed right (positive start_offset), keyframes stop following the mouse cursor at the left edge of the layer bar.

---

#### Testing
- rational_at_signed_preserves_negative_times: Asserts rational_at_signed(-1.0).to_f64() ≈ -1.0 while rational_at(-1.0).to_f64() ≈ 0.0 — regression guard for the signed-vs-unsigned fix
- effect_param_reads_keyframes_for_the_graph: Exercises the exact EffectValue::Float(Property { animation }) extraction chain graph_plot uses — asserts the keyframe value round-trips through the match pattern
- layer_start_offset_round_trips_to_f64: Verifies layer.start_offset.0.to_f64() preserves the value set by rational_at_signed(2.0) — prerequisite for the TF-25 conversion math
Passed full workspace test suite (cargo test, 222 tests passed in lumit-ui).

<sub>vibecoded with deepseek in opencode</sub>