### PR TITLE
Non-windows system-memory fetch fix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,3 @@
 # cfg(not(windows))), so this line is inert there and no per-machine path is committed.
 # Windows points the build at FFmpeg via FFMPEG_LIBS_DIR / FFMPEG_INCLUDE_DIR set outside
 # this file — see scripts/win-dev-env.ps1 and docs/GUIDE.md §8.
-[env]
-FFMPEG_PKG_CONFIG_PATH = "/opt/homebrew/opt/ffmpeg@7/lib/pkgconfig"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,16 @@
-# ffmpeg@7 is keg-only (deliberately not linked); builds resolve it explicitly.
-# CI installs the same formula, so this path is machine-portable across macOS.
+# Deliberately no [env] block here — do not add one for FFmpeg (K-204).
 #
-# macOS only. rusty_ffmpeg ignores FFMPEG_PKG_CONFIG_PATH on Windows (that branch is
-# cfg(not(windows))), so this line is inert there and no per-machine path is committed.
-# Windows points the build at FFmpeg via FFMPEG_LIBS_DIR / FFMPEG_INCLUDE_DIR set outside
-# this file — see scripts/win-dev-env.ps1 and docs/GUIDE.md §8.
+# This file used to set FFMPEG_PKG_CONFIG_PATH to the macOS Homebrew keg path. Cargo's
+# [env] has no per-target form, so that path was injected on Linux too, and rusty_ffmpeg's
+# build script *panics* when FFMPEG_PKG_CONFIG_PATH names a directory that does not exist
+# ("which does not exist") rather than falling back to pkg-config's default search. Every
+# Linux contributor therefore had to delete this line, or export the variable over it,
+# before a fresh clone would build. Two of them did.
+#
+# The arrangement now: each platform points the build at FFmpeg from outside this file.
+# macOS exports FFMPEG_PKG_CONFIG_PATH at the keg-only ffmpeg@7 (CI does it per job,
+# developers per shell — docs/GUIDE.md §8). Linux needs nothing: the distro's FFmpeg 7
+# development packages sit on pkg-config's default search path, which is exactly what
+# rusty_ffmpeg probes when the variable is unset. Windows uses FFMPEG_LIBS_DIR /
+# FFMPEG_INCLUDE_DIR (rusty_ffmpeg's pkg-config branch is cfg(not(windows)), so it never
+# reads this variable there) — see scripts/win-dev-env.ps1.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - name: Install FFmpeg (keg-only, matches .cargo/config.toml)
-        run: brew install ffmpeg@7
+      # ffmpeg@7 is keg-only, so pkg-config cannot find it on its default search
+      # path; the build is pointed at the keg explicitly. This lives here, not in
+      # .cargo/config.toml, because Cargo's [env] has no per-target form and the
+      # macOS path injected on Linux made rusty_ffmpeg's build script panic (K-204).
+      - name: Install FFmpeg (keg-only) and point pkg-config at it
+        run: |
+          brew install ffmpeg@7
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: FFmpeg version for the cache key (Cellar paths are versioned;
               a cached rusty_ffmpeg build script must not outlive its keg)
         id: ffver
@@ -121,7 +127,16 @@ jobs:
           # pkg-config would emit -L/-I paths that do not exist here. Point
           # them at where we actually unpacked.
           sed -i "s|^prefix=.*|prefix=$root|" "$root"/lib/pkgconfig/*.pc
-          echo "FFMPEG_PKG_CONFIG_PATH=$root/lib/pkgconfig" >> "$GITHUB_ENV"
+          # PKG_CONFIG_PATH, *not* FFMPEG_PKG_CONFIG_PATH (K-204). Setting the
+          # latter takes rusty_ffmpeg's explicit-override branch, which is the one
+          # macOS and Windows need and which no Linux contributor uses: a distro
+          # install puts the .pc files on pkg-config's ordinary search path and
+          # leaves the variable unset. Exporting the override here was masking
+          # exactly that — it is how a broken .cargo/config.toml passed CI while
+          # every fresh Linux clone failed. Adding to PKG_CONFIG_PATH exercises
+          # the contributor's code path with a pinned FFmpeg 7.1 (the runner's
+          # own distro still ships FFmpeg 6, so the tarball stays).
+          echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$root/lib" >> "$GITHUB_ENV"
           echo "$root/bin" >> "$GITHUB_PATH"
       # bindgen wants LLVM 18 exactly (newer libclang makes it emit opaque FFI
@@ -179,7 +194,9 @@ jobs:
           # The tarball's .pc files carry the build machine's prefix; point them
           # at where we unpacked (mirrors the `linux` job).
           sed -i "s|^prefix=.*|prefix=$root|" "$root"/lib/pkgconfig/*.pc
-          echo "FFMPEG_PKG_CONFIG_PATH=$root/lib/pkgconfig" >> "$GITHUB_ENV"
+          # PKG_CONFIG_PATH, not FFMPEG_PKG_CONFIG_PATH — the contributor's path
+          # (K-204); see the `linux` job for why.
+          echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$root/lib" >> "$GITHUB_ENV"
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
@@ -260,8 +277,12 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Install FFmpeg (keg-only, matches .cargo/config.toml)
-        run: brew install ffmpeg@7
+      # Keg-only, as in the `check` job above: point pkg-config at the keg here
+      # rather than in .cargo/config.toml (K-204).
+      - name: Install FFmpeg (keg-only) and point pkg-config at it
+        run: |
+          brew install ffmpeg@7
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: FFmpeg version for the cache key
         id: ffver
         run: echo "v=$(brew list --versions ffmpeg@7 | awk '{print $2}')" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ bindings, so 18 is pinned on every platform). Development is Windows-first.
 - **Windows**: unzip a [BtbN FFmpeg 7.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)
 under `%USERPROFILE%\ffmpeg\` , run `winget install LLVM. LLVM -- version 18.1.8`,
 then `. .\scripts\win-dev-env.ps1 -Persist` to wire it up.
-**macOS**: `brew install ffmpeg@7`, then `cargo test -- workspace`. The repo's
-`.cargo/config.toml` points the build at the keg.
+**macOS**: `brew install ffmpeg@7`, then, because that formula is keg-only,
+`export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"` in the
+shell you build from (K-204). Then `cargo test --workspace`.
 **Linux** (K-082): install the FFmpeg 7 development packages plus `pkg-config`
 and `clang`. Debian 13 / Ubuntu 24.10 or newer:
 `sudo apt install pkg-config clang libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev libavdevice-dev`
 Arch / Artix: `sudo pacman -S ffmpeg pkgconf clang18 llvm18` (the unversioned
 `clang` package is LLVM 19+ and produces broken bindings).
-Two environment variables are needed on Linux, in the shell you build from:
+FFmpeg needs no environment variable on Linux — the development packages put
+their `.pc` files on `pkg-config`'s default search path, which is where the
+build looks. One variable may still be needed, in the shell you build from:
 ```sh
 export LIBCLANG_PATH=/usr/lib/llvm18/lib          # Debian/Ubuntu: /usr/lib/llvm-18/lib
-export FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig  # wherever libavcodec.pc lives
 ```
-`LIBCLANG_PATH` is only required where the default `clang` is newer than 18;
-`FFMPEG_PKG_CONFIG_PATH` overrides the macOS Homebrew path that
-`.cargo/config.toml` sets for everyone. FFmpeg **7.x** is required;
+It is only required where the default `clang` is newer than 18. FFmpeg **7.x** is required;
 distributions still shipping FFmpeg 6 (Ubuntu 24.04 LTS included) need a newer
 release or a self-built FFmpeg first.
 

--- a/crates/lumit-bridge/src/api/system.rs
+++ b/crates/lumit-bridge/src/api/system.rs
@@ -31,7 +31,23 @@ pub fn system_memory_bytes() -> u64 {
         }
         0
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
+            for line in meminfo.lines() {
+                if line.starts_with("MemTotal:") {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() >= 2 {
+                        if let Ok(kb) = parts[1].parse::<u64>() {
+                            return kb * 1024;
+                        }
+                    }
+                }
+            }
+        }
+        0
+    }
+    #[cfg(not(any(windows, target_os = "linux")))]
     {
         0
     }

--- a/crates/lumit-bridge/src/api/system.rs
+++ b/crates/lumit-bridge/src/api/system.rs
@@ -47,7 +47,36 @@ pub fn system_memory_bytes() -> u64 {
         }
         0
     }
-    #[cfg(not(any(windows, target_os = "linux")))]
+    #[cfg(target_os = "macos")]
+    {
+        extern "C" {
+            fn sysctlbyname(
+                name: *const std::os::raw::c_char,
+                oldp: *mut std::os::raw::c_void,
+                oldlenp: *mut usize,
+                newp: *mut std::os::raw::c_void,
+                newlen: usize,
+            ) -> std::os::raw::c_int;
+        }
+
+        let mut memsize: u64 = 0;
+        let mut len = std::mem::size_of::<u64>();
+        let name = c"hw.memsize";
+        let ret = unsafe {
+            sysctlbyname(
+                name.as_ptr(),
+                &mut memsize as *mut _ as *mut _,
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if ret == 0 && memsize > 0 {
+            return memsize;
+        }
+        0
+    }
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
     {
         0
     }

--- a/crates/lumit-bridge/src/api/system.rs
+++ b/crates/lumit-bridge/src/api/system.rs
@@ -8,9 +8,17 @@
 //! pretending, so a platform without an implementation is honest rather than
 //! wrong.
 //!
-//! Windows is the shipped target (K-033) and is the only one implemented:
-//! `GlobalMemoryStatusEx` for installed RAM, and the first DXGI adapter's
-//! dedicated video memory for VRAM.
+//! Windows is the shipped target (K-033), but installed RAM is answerable on
+//! every supported desktop target (K-082), so all three answer it (K-204):
+//! `GlobalMemoryStatusEx` on Windows, `MemTotal:` from `/proc/meminfo` on
+//! Linux, and the `hw.memsize` sysctl on macOS. Windows and macOS report the
+//! installed total; Linux's `MemTotal` is *usable* RAM, which excludes what
+//! firmware and an integrated GPU reserved before the kernel booted (about
+//! 15.5 GB on a 16 GB host). That errs low, which is the safe direction for a
+//! budget ceiling — the same choice `video_memory_bytes` makes below.
+//!
+//! Video memory stays Windows-only: the first DXGI adapter's dedicated video
+//! memory, with 0 elsewhere.
 
 use flutter_rust_bridge::frb;
 
@@ -62,6 +70,11 @@ pub fn system_memory_bytes() -> u64 {
         let mut memsize: u64 = 0;
         let mut len = std::mem::size_of::<u64>();
         let name = c"hw.memsize";
+        // SAFETY: `name` is a NUL-terminated literal that outlives the call;
+        // `memsize` is a zeroed u64 and `len` its size, which matches
+        // `hw.memsize`'s uint64_t, so sysctl has room for exactly what it
+        // writes; `newp`/`newlen` are the documented null/0 for a read. The
+        // return code is checked before `memsize` is trusted.
         let ret = unsafe {
             sysctlbyname(
                 name.as_ptr(),

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -3091,9 +3091,9 @@ fn an_effect_is_modified_on_arrival_and_animated_only_once_keyed() {
 
 #[test]
 fn system_memory_bytes_reports_non_zero_on_supported_platforms() {
-    #[cfg(any(windows, target_os = "linux"))]
+    #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
     {
         let mem = crate::api::system::system_memory_bytes();
-        assert!(mem > 0, "system memory should be positive on Linux/Windows");
+        assert!(mem > 0, "system memory should be positive on Linux/macOS/Windows");
     }
 }

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -2764,6 +2764,10 @@ fn rename_label_and_matte_each_undo_in_one_step() {
         "one undo step removes the matte"
     );
 }
+<<<<<<< HEAD
+=======
+}
+>>>>>>> d05ba1a (feat(bridge): implement system_memory_bytes for Linux via /proc/meminfo)
 
 // ---------------------------------------------------------------------------
 // The keymap (docs/07 §15, K-199)
@@ -3083,4 +3087,13 @@ fn an_effect_is_modified_on_arrival_and_animated_only_once_keyed() {
             .is_empty(),
         "nothing on it is keyframed yet"
     );
+}
+
+#[test]
+fn system_memory_bytes_reports_non_zero_on_supported_platforms() {
+    #[cfg(any(windows, target_os = "linux"))]
+    {
+        let mem = crate::api::system::system_memory_bytes();
+        assert!(mem > 0, "system memory should be positive on Linux/Windows");
+    }
 }

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -2764,10 +2764,6 @@ fn rename_label_and_matte_each_undo_in_one_step() {
         "one undo step removes the matte"
     );
 }
-<<<<<<< HEAD
-=======
-}
->>>>>>> d05ba1a (feat(bridge): implement system_memory_bytes for Linux via /proc/meminfo)
 
 // ---------------------------------------------------------------------------
 // The keymap (docs/07 §15, K-199)
@@ -3094,6 +3090,9 @@ fn system_memory_bytes_reports_non_zero_on_supported_platforms() {
     #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
     {
         let mem = crate::api::system::system_memory_bytes();
-        assert!(mem > 0, "system memory should be positive on Linux/macOS/Windows");
+        assert!(
+            mem > 0,
+            "system memory should be positive on Linux/macOS/Windows"
+        );
     }
 }

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -2992,3 +2992,52 @@ the theme's surface.
 
 **The Scopes toolbar drops its frame readout.** The playhead's position is the Timeline's
 and the Viewer's to state; a third copy above the trace only competed with it.
+
+**K-204 · DECIDED · Installed memory is answerable on all three targets, and no tracked
+file carries one platform's absolute path.** From two outside contributors (2026-07-29),
+whose pull request is where both halves of this came from.
+
+**The build fix first, because it was the real breakage.** `.cargo/config.toml` carried an
+`[env]` block setting `FFMPEG_PKG_CONFIG_PATH` to the macOS Homebrew keg
+(`/opt/homebrew/opt/ffmpeg@7/lib/pkgconfig`), because ffmpeg@7 is keg-only and pkg-config
+cannot otherwise find it. Cargo's `[env]` has no per-target form, so every platform got it.
+On Linux that directory does not exist, and rusty_ffmpeg's build script does not shrug and
+fall back — it panics outright ("FFMPEG_PKG_CONFIG_PATH is set to `…`, which does not
+exist"), so a fresh clone could not build at all until the line was deleted or overridden.
+Two contributors independently deleted it. The `[env]` block is therefore **gone**, and each
+platform is pointed at FFmpeg from outside the repo: macOS exports
+`FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"` (per CI job, per
+developer shell), Linux exports nothing because the distro's FFmpeg 7 development packages
+already sit on pkg-config's default search path, and Windows keeps `FFMPEG_LIBS_DIR` /
+`FFMPEG_INCLUDE_DIR` (rusty_ffmpeg's pkg-config branch is `cfg(not(windows))`, so it never
+read the variable there). Moving the discovery into a build script of our own was
+considered and rejected: the discovery lives in rusty_ffmpeg's build script, which is a
+dependency of ours and therefore runs *before* anything we could write, and
+`cargo::rustc-env` reaches our own compilation rather than a dependency's build script.
+There is no seam without forking, so the fix is the honest one — the platform with the
+unusual requirement states it, instead of every other platform undoing it.
+
+**CI was masking the defect, which is the part that must not recur.** Both Linux jobs
+exported `FFMPEG_PKG_CONFIG_PATH` themselves before building, and Cargo's `[env]` without
+`force = true` does not override an already-set variable — so CI took rusty_ffmpeg's
+explicit-override branch and stayed green while every real Linux clone failed. Contributors
+were doing CI's job. The Linux jobs now export **`PKG_CONFIG_PATH`** instead, which is what
+a distro install produces implicitly, so the branch a contributor actually takes is the
+branch that gets tested, and re-adding the `[env]` line would now turn the Linux jobs red.
+The pinned FFmpeg 7.1 tarball stays: the runner's own distribution still ships FFmpeg 6.
+The standing lesson is the general one — a CI job that pre-sets what a contributor would
+not have set is not testing the contributor's build.
+
+**`system_memory_bytes()` now answers on Linux and macOS too**, extending the Windows-only
+implementation K-194 recorded (that entry's "both answer 0 off Windows" is superseded for
+this function only; `video_memory_bytes()` stays Windows-only and still answers 0
+elsewhere). K-082 already makes Linux and macOS supported build targets, so this fills in a
+target that was supported rather than adding one. `MemTotal:` from `/proc/meminfo` on
+Linux, the `hw.memsize` sysctl on macOS, both falling through to 0 if the file, the field,
+or the call does not yield a number. One honesty note recorded rather than corrected:
+Linux's `MemTotal` is *usable* RAM, excluding what firmware and an integrated GPU reserved
+before the kernel booted — about 15.5 GB on a 16 GB machine. It errs low, and low is the
+safe direction for a cache-budget ceiling, which is the same reasoning K-194 already
+applied to reporting the first adapter's video memory. Regression test:
+`system_memory_bytes_reports_non_zero_on_supported_platforms` in
+`crates/lumit-bridge/src/api/tests.rs`.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2149,9 +2149,25 @@ There are two moving parts, and it helps to know why each exists:
 
 ### On macOS
 
-FFmpeg comes from Homebrew: `brew install ffmpeg@7`. The repo's `.cargo/config.toml` already
-points the build at it, and macOS ships the translator (libclang) as part of its developer
-tools, so there's nothing else to set up — `cargo test --workspace` just works.
+FFmpeg comes from Homebrew: `brew install ffmpeg@7`. That formula is *keg-only* — Homebrew
+deliberately does not put it where the system looks by default, because it is an older
+version than the plain `ffmpeg` formula and linking it would shadow that. So the build has
+to be told where it went, once, in the terminal you build from:
+
+```sh
+export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"
+```
+
+Put that in your shell profile and every future terminal has it. macOS ships the translator
+(libclang) as part of its developer tools, so there is nothing else to set up — then
+`cargo test --workspace` works.
+
+This line used to live in the repo's `.cargo/config.toml` instead, so nobody had to type
+it. It was removed (K-204) because Cargo offers no way to make such a setting apply to one
+platform only: the macOS folder was being handed to Linux builds as well, where it does not
+exist, and the FFmpeg binding generator stops with an error rather than falling back. One
+platform's convenience was the other's broken build, and macOS is the one with the unusual
+requirement, so macOS is the one that says it out loud.
 
 ### On Linux (K-082)
 
@@ -2166,21 +2182,23 @@ distributions' plain `clang` package is a much newer LLVM, and as explained abov
 LLVM makes the translator produce nonsense, so the versioned packages are the ones to
 install.
 
-Two settings then have to be handed to the build, in the terminal you build from:
+Nothing about FFmpeg then has to be handed to the build: the packages put their `.pc`
+description files where `pkg-config` already looks, which is where the build asks. One
+setting may still be needed, and only on the distributions whose default translator is
+newer than 18:
 
 ```sh
 export LIBCLANG_PATH=/usr/lib/llvm18/lib          # Debian/Ubuntu: /usr/lib/llvm-18/lib
-export FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig  # wherever libavcodec.pc lives
 ```
 
-The first says "use the *18* translator, not whichever one is the default" — only needed
-where the default is newer than 18, which on Arch and Artix it always is. The second is an
-accident of the repo: `.cargo/config.toml` sets that variable to a macOS Homebrew folder
-for every platform, and Cargo gives no way to make it macOS-only, so on Linux it has to be
-overridden with the folder that actually holds FFmpeg's `.pc` description files (ask with
-`pkg-config --variable pc_path pkg-config` if `/usr/lib/pkgconfig` is not it). Put both
-lines in your shell profile and every future terminal has them. Then `cargo test
---workspace`, and `flutter run` from `flutter_ui/` to launch the app.
+That says "use the *18* translator, not whichever one is the default" — on Arch and Artix
+the default always is newer. Put it in your shell profile and every future terminal has it.
+Then `cargo test --workspace`, and `flutter run` from `flutter_ui/` to launch the app.
+
+Linux used to need a second export here, to undo a macOS folder the repo's
+`.cargo/config.toml` handed to every platform. That setting is gone (K-204) and Linux is
+plain again; if you are looking at an older checkout, deleting the `[env]` block from
+`.cargo/config.toml` is what the fix amounted to.
 
 One honest caveat: the build needs FFmpeg **7**, and some distributions still ship
 FFmpeg 6 — Ubuntu 24.04 LTS is the big one. On those, `cargo build` will complain about
@@ -2209,6 +2227,43 @@ The platform recipes above are exactly what CI does, written out by hand in
 Mesa's *lavapipe*, a Vulkan driver that renders on the CPU, so the GPU tests actually run on
 a machine with no graphics card in it. And a sixth job builds the Flatpak, which is how we
 know the packaging works and not just the code.
+
+A rule the FFmpeg episode above taught, worth stating on its own: **a CI job that sets up
+something a contributor would not have set up is not testing the contributor's build.** The
+Linux jobs used to hand the build an explicit FFmpeg location before compiling, which meant
+they never took the route a person with FFmpeg installed normally takes — and so they
+stayed green for weeks while nobody could actually clone the repository on Linux and build
+it. The jobs now leave that route alone and let the build find FFmpeg the ordinary way. If
+a step exists purely to make CI work, ask who else has to run it.
+
+### How Lumit knows how much memory your machine has (K-194, K-204)
+
+Settings → Performance lets you type a cache size in megabytes, which means the engine
+needs a real ceiling to check it against — offering to cache 64 GB on a 16 GB machine is
+just a way to make everything swap to disk and crawl. So the bridge has two small
+questions it can ask the operating system: how much RAM is installed, and how much memory
+the graphics card has.
+
+There is no one way to ask, because each operating system answers differently. Windows has
+a single call for it. macOS has a general-purpose "ask the kernel a named question"
+mechanism, and the question is called `hw.memsize`. Linux does not have a call at all: it
+exposes a plain text file, `/proc/meminfo`, whose first line reads something like
+`MemTotal: 16264532 kB`, and you read the number out of it. Three implementations, one
+answer, and — this is the important habit — **every one of them returns 0 rather than
+guessing** if the answer does not come back. The interface treats 0 as "not known here" and
+falls back to a documented ceiling of its own, which is honest, where a made-up number
+would quietly be wrong.
+
+One oddity you will notice: on a 16 GB Linux machine the number comes back as roughly
+15.5 GB, not 16. That is not a bug and it is not worth correcting. Linux reports the memory
+*the kernel can actually use*, and some was already taken before the kernel started — by
+the firmware, and by an integrated graphics chip carving out its share. The 16 GB is what
+you bought; the 15.5 GB is what is there to spend. For deciding how big a cache may be, the
+smaller of the two is the one you want, so reporting slightly low errs in the safe
+direction. The video-memory answer leans the same way for the same reason: on a machine
+with both an integrated and a discrete graphics chip it reports whichever the system lists
+first, which may be the smaller one — again, a ceiling that is too low costs you some
+speed, while one that is too high costs you the session.
 
 ## 9. The Flutter frontend, in plain terms
 


### PR DESCRIPTION
## Summary
Implements physical system memory detection (`system_memory_bytes()`) on Linux and macOS, replacing the previous unhandled `0` fallback that defaulted performance settings to a fixed 16 GB ceiling. Additionally cleans up `.cargo/config.toml` to prevent broken Cargo builds on Linux systems.

## Changes
- **Linux (`crates/lumit-bridge/src/api/system.rs`)**:
  Added `#[cfg(target_os = "linux")]` implementation reading `MemTotal:` from `/proc/meminfo`. Compatible across all Linux distributions and init systems.
- **macOS (`crates/lumit-bridge/src/api/system.rs`)**:
  Added `#[cfg(target_os = "macos")]` implementation using `sysctlbyname("hw.memsize", ...)` via C FFI without external dependencies.
- **Cargo Config (`.cargo/config.toml`)**:
  Removed hardcoded macOS Homebrew `FFMPEG_PKG_CONFIG_PATH` variable to prevent Cargo build failures on Linux systems.
- **Tests (`crates/lumit-bridge/src/api/tests.rs`)**:
  Added unit test `system_memory_bytes_reports_non_zero_on_supported_platforms` covering Linux, macOS, and Windows targets.

## Testing & Verification
- Tested on Linux: accurately reports available system RAM (e.g. `15.5 GB` on a 16 GB host with 512 MB reserved for iGPU VRAM).
- Unit test `system_memory_bytes_reports_non_zero_on_supported_platforms` passed.
- Cargo builds on Linux execute cleanly without `FFMPEG_PKG_CONFIG_PATH` errors.


<sub>vibecoded with antigravity<sub>