### PR TITLE
The dropper reads a value at a pixel, and the picker applies live (K-210)

### DIFF
--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -982,9 +982,14 @@ impl CompositionReference {
         }))
     }
 
-    /// Ask the worker for the pixels under the dropper: a `grid × grid` patch of
-    /// `frame` centred on `(x, y)` in this composition's own pixel grid
-    /// (docs/07 §6.1).
+    /// Ask the worker for the pixels under the dropper: a `window × window`
+    /// square of `frame` centred on `(x, y)` in this composition's own pixel
+    /// grid (docs/07 §6.1).
+    ///
+    /// A window rather than the nine pixels the magnifier shows, because the
+    /// pointer moves and the picture does not: the caller reads its grid out of
+    /// the window it already holds and asks again only when the pointer nears
+    /// the window's edge, the frame changes, or an edit lands.
     ///
     /// `layer` reads that layer **alone** rather than the composite — what a
     /// depth pick does, since a depth pass is usually hidden and so never
@@ -998,7 +1003,7 @@ impl CompositionReference {
         frame: u64,
         x: u32,
         y: u32,
-        grid: u32,
+        window: u32,
         scale: f32,
         layer: Option<LayerReference>,
     ) -> Result<(), BridgeError> {
@@ -1008,7 +1013,7 @@ impl CompositionReference {
             scale,
             x,
             y,
-            grid,
+            window,
             layer,
         }))
     }

--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -12,7 +12,8 @@ use crate::api::{
     layer::LayerReference,
     state::{LumitBridgeState, PROJECTS},
     worker_thread::{
-        RenderCompRequest, RenderCompRequestWithPreview, RenderScopeRequest, WorkerRequest,
+        RenderCompRequest, RenderCompRequestWithPreview, RenderScopeRequest, SamplePixelsRequest,
+        WorkerRequest,
         WorkerRequest::{RenderComp, RenderCompWithPreview},
     },
     BridgeError,
@@ -978,6 +979,37 @@ impl CompositionReference {
             scale,
             kind,
             colours: packed,
+        }))
+    }
+
+    /// Ask the worker for the pixels under the dropper: a `grid × grid` patch of
+    /// `frame` centred on `(x, y)` in this composition's own pixel grid
+    /// (docs/07 §6.1).
+    ///
+    /// `layer` reads that layer **alone** rather than the composite — what a
+    /// depth pick does, since a depth pass is usually hidden and so never
+    /// appears in the composite at all. The answer arrives as
+    /// `WorkerResponse::Sampled`, on the stream the frames and traces already
+    /// ride; a frame with nothing to read publishes nothing, and the magnifier
+    /// keeps what it had.
+    #[frb(sync)]
+    pub fn sample_pixels(
+        &self,
+        frame: u64,
+        x: u32,
+        y: u32,
+        grid: u32,
+        scale: f32,
+        layer: Option<LayerReference>,
+    ) -> Result<(), BridgeError> {
+        self.dispatch(WorkerRequest::SamplePixels(SamplePixelsRequest {
+            comp: self.clone(),
+            frame,
+            scale,
+            x,
+            y,
+            grid,
+            layer,
         }))
     }
 

--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -983,8 +983,19 @@ impl CompositionReference {
     }
 
     /// Ask the worker for the pixels under the dropper: a `window × window`
-    /// square of `frame` centred on `(x, y)` in this composition's own pixel
-    /// grid (docs/07 §6.1).
+    /// square of `frame` centred on the point `(u, v)` of the picture, each a
+    /// fraction from 0 to 1 (docs/07 §6.1).
+    ///
+    /// **A fraction, not a pixel, and that is the point.** The picture actually
+    /// read may be a reduced-resolution preview, so its pixel grid is neither
+    /// the composition's nor anything the caller can know in advance. The reply
+    /// says which raster it cut from (`width`, `height`) and where in that
+    /// raster the window's centre landed, and every pixel the caller then names
+    /// is in that same raster. Asking in composition pixels and indexing the
+    /// reply with them is a real bug that has been made unwritable here: with a
+    /// fitted Viewer the two grids differ by the preview scale, and the
+    /// magnifier showed one repeated edge pixel — a flat colour where the
+    /// picture should be.
     ///
     /// A window rather than the nine pixels the magnifier shows, because the
     /// pointer moves and the picture does not: the caller reads its grid out of
@@ -1001,8 +1012,8 @@ impl CompositionReference {
     pub fn sample_pixels(
         &self,
         frame: u64,
-        x: u32,
-        y: u32,
+        u: f64,
+        v: f64,
         window: u32,
         scale: f32,
         layer: Option<LayerReference>,
@@ -1011,8 +1022,8 @@ impl CompositionReference {
             comp: self.clone(),
             frame,
             scale,
-            x,
-            y,
+            u,
+            v,
             window,
             layer,
         }))

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -123,32 +123,39 @@ pub struct BridgeScopeTrace {
     pub rgba: Vec<u8>,
 }
 
-/// The pixels under the dropper: a small square patch of the picture, centred
-/// on the point the pointer is over (docs/07 §6.1).
+/// The pixels under the dropper: a square window of the picture, centred on the
+/// point the pointer was over when it was asked for (docs/07 §6.1).
 ///
-/// Tiny by construction — a 9×9 patch is 324 bytes, against a 1080p frame's
-/// 8 MiB — so it crosses the boundary as plain pixels without breaking the
-/// K-183 rule that *frames* only ever cross as GPU handles. It is the answer to
-/// a question about a few pixels, not a picture to display.
+/// **A window rather than the nine pixels the magnifier shows**, so the pointer
+/// can move without asking again: the frontend cuts the magnifier's grid out of
+/// what it already has, and re-reads only when the pointer approaches the edge
+/// of it. That turns a sweep across the picture from a request per mouse move
+/// into a handful.
+///
+/// Small by construction — 129×129 is 66 KiB, against a 1080p frame's 8 MiB —
+/// so it crosses the boundary as plain pixels without breaking the K-183 rule
+/// that *frames* only ever cross as GPU handles. It is the answer to a question
+/// about a few pixels, not a picture to display.
 #[frb(non_opaque)]
 pub struct BridgeSampledPixels {
-    /// The patch's side length in pixels: `grid × grid`, always odd, so there is
-    /// a single centre pixel.
-    pub grid: u32,
-    /// Tightly packed display-ready sRGB RGBA8, `grid * grid * 4`, row-major
-    /// from the top-left of the patch. Edge pixels repeat where the patch runs
-    /// off the picture, so it is always exactly this size.
+    /// The window's side length in pixels: `window × window`, always odd, so
+    /// there is a single centre pixel.
+    pub window: u32,
+    /// Tightly packed display-ready sRGB RGBA8, `window * window * 4`,
+    /// row-major from the top-left of the window. Edge pixels repeat where the
+    /// window runs off the picture, so it is always exactly this size and can
+    /// be indexed without a border case.
     pub rgba: Vec<u8>,
-    /// The raster the patch was taken from, and where in it the centre pixel
-    /// sits — what the caption reports, and what a position pick writes.
+    /// The raster the window was taken from, and where in it the centre pixel
+    /// sits — which is what says where in the picture the window lies.
     pub width: u32,
     pub height: u32,
     pub x: u32,
     pub y: u32,
-    /// Which frame this is of, so a patch that arrives after the playhead has
+    /// Which frame this is of, so a window that arrives after the playhead has
     /// moved on can be recognised as stale rather than drawn.
     pub frame: u64,
-    /// True when the patch is of one layer rendered alone rather than of the
+    /// True when the window is of one layer rendered alone rather than of the
     /// composite — a depth pass being read for a focal point, say.
     pub layer_alone: bool,
 }

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -123,6 +123,36 @@ pub struct BridgeScopeTrace {
     pub rgba: Vec<u8>,
 }
 
+/// The pixels under the dropper: a small square patch of the picture, centred
+/// on the point the pointer is over (docs/07 §6.1).
+///
+/// Tiny by construction — a 9×9 patch is 324 bytes, against a 1080p frame's
+/// 8 MiB — so it crosses the boundary as plain pixels without breaking the
+/// K-183 rule that *frames* only ever cross as GPU handles. It is the answer to
+/// a question about a few pixels, not a picture to display.
+#[frb(non_opaque)]
+pub struct BridgeSampledPixels {
+    /// The patch's side length in pixels: `grid × grid`, always odd, so there is
+    /// a single centre pixel.
+    pub grid: u32,
+    /// Tightly packed display-ready sRGB RGBA8, `grid * grid * 4`, row-major
+    /// from the top-left of the patch. Edge pixels repeat where the patch runs
+    /// off the picture, so it is always exactly this size.
+    pub rgba: Vec<u8>,
+    /// The raster the patch was taken from, and where in it the centre pixel
+    /// sits — what the caption reports, and what a position pick writes.
+    pub width: u32,
+    pub height: u32,
+    pub x: u32,
+    pub y: u32,
+    /// Which frame this is of, so a patch that arrives after the playhead has
+    /// moved on can be recognised as stale rather than drawn.
+    pub frame: u64,
+    /// True when the patch is of one layer rendered alone rather than of the
+    /// composite — a depth pass being read for a focal point, say.
+    pub layer_alone: bool,
+}
+
 /// What the render worker publishes for one frame. Which frame variant a build
 /// can actually produce is decided at compile time by the zero-copy features —
 /// see `worker_thread::publish_frame` — but both are always declared, so the
@@ -137,6 +167,10 @@ pub enum WorkerResponse {
     /// A scope trace, which rides the same stream as the frames so the panel
     /// needs no second channel.
     Scope(BridgeScopeTrace),
+    /// The pixels under the dropper — the answer to one
+    /// `CompositionReference::sample_pixels`, riding the same stream for the
+    /// same reason a trace does.
+    Sampled(BridgeSampledPixels),
     /// Playback finished on its own — it ran off the end of the composition.
     ///
     /// Sent so the transport can show itself stopped without the frontend having

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -148,6 +148,11 @@ pub struct BridgeSampledPixels {
     pub rgba: Vec<u8>,
     /// The raster the window was taken from, and where in it the centre pixel
     /// sits — which is what says where in the picture the window lies.
+    ///
+    /// **This raster, not the composition's.** The picture read may be a
+    /// reduced-resolution preview, so these are the only coordinates in which
+    /// the window can be indexed; a caller holding composition pixels must map
+    /// through `width`/`height` rather than assume they line up.
     pub width: u32,
     pub height: u32,
     pub x: u32,

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -76,6 +76,23 @@ pub struct WorkerState {
     /// When the last request arrived — the fill waits out a ~200 ms lull
     /// after it (docs/06 §5.5), so a scrub in progress is never contended.
     last_request: std::time::Instant,
+    /// The one soloed-layer render the dropper is reading, against the
+    /// `(comp, frame, layer, generation)` it was made for — see
+    /// [`sample_layer_alone`]. One entry, because the dropper only ever reads
+    /// one layer at a time and a pointer drag asks for the same one on every
+    /// move.
+    layer_sample: Option<LayerSample>,
+}
+
+/// One soloed-layer render, held for the dropper (see [`sample_layer_alone`]).
+#[frb(ignore)]
+struct LayerSample {
+    /// `(comp, frame, layer, framecache generation)` — what this render is of.
+    /// The generation is what retires it when an edit lands.
+    stamp: (Uuid, u64, Uuid, u64),
+    width: u32,
+    height: u32,
+    rgba: Vec<u8>,
 }
 
 /// Apply cross-thread cache controls and keep the cache-bar mirror fresh —
@@ -217,6 +234,8 @@ pub enum WorkerRequest {
     RenderComp(RenderCompRequest),
     RenderCompWithPreview(RenderCompRequestWithPreview),
     TraceScope(RenderScopeRequest),
+    /// Read the pixels under the dropper (docs/07 §6.1).
+    SamplePixels(SamplePixelsRequest),
     /// Start playing. The worker paces itself from here until it is stopped or
     /// runs off the end.
     Play(PlayRequest),
@@ -525,6 +544,37 @@ pub struct RenderScopeRequest {
     pub colours: [[u8; 3]; 5],
 }
 
+/// One read of the pixels under the dropper — the magnifier's request.
+///
+/// **Why the worker answers it and not a plain synchronous call.** The pixels
+/// only exist where the renderer does, and the renderer is owned outright by
+/// this thread (no lock, by design). A sync call would either have to render on
+/// Dart's UI isolate or reach across a lock at the one place docs/14 forbids
+/// one. So the dropper asks the way the Scopes panel asks, and paints what comes
+/// back.
+#[frb(ignore)]
+pub struct SamplePixelsRequest {
+    pub comp: CompositionReference,
+    pub frame: u64,
+    pub scale: f32,
+    /// The centre pixel, in the composition's own full-resolution pixel grid.
+    /// Clamped to the picture the sample is actually taken from, so a click on
+    /// the very edge still answers.
+    pub x: u32,
+    pub y: u32,
+    /// The patch's side length, forced odd and capped at [`MAX_GRID`].
+    pub grid: u32,
+    /// Read this layer *alone* instead of the composite — what a depth pick
+    /// does, so a hidden depth pass (which never shows in the composite) can
+    /// still be read. `None` samples the composite.
+    pub layer: Option<LayerReference>,
+}
+
+/// The largest patch the dropper ever asks for, and the magnifier's grid: 9×9
+/// (K-210). The sampled region can never exceed what is shown.
+#[frb(ignore)]
+pub const MAX_GRID: u32 = 9;
+
 #[frb(ignore)]
 pub struct RenderCompRequestWithPreview {
     pub comp: CompositionReference,
@@ -595,6 +645,7 @@ fn worker_loop(
         published_vram: (0, 0, 0),
         fill_exhausted: true,
         last_request: std::time::Instant::now(),
+        layer_sample: None,
     };
 
     loop {
@@ -982,7 +1033,8 @@ fn handle_requests(
         if crate::framecache::generation() != state.seen_generation {
             crate::framecache::note_stale_serve();
         }
-        let (pictures, scope, superseded) = drain_to_newest(request, receiver, classify_request);
+        let (pictures, scope, sample, superseded) =
+            drain_to_newest(request, receiver, classify_request);
         // Deliberately not logged. Superseding is the normal, healthy case —
         // it is how a drag stays attached to the pointer — and a line per
         // completed render is console I/O on the worker thread for something
@@ -995,9 +1047,10 @@ fn handle_requests(
         //
         // A frame that cannot be rendered is dropped, not fatal: the worker has
         // to survive to serve the next request.
-        for request in pictures.into_iter().chain(scope) {
+        for request in pictures.into_iter().chain(scope).chain(sample) {
             let outcome = match request {
                 WorkerRequest::RenderComp(req) => render_comp(req, state, stream),
+                WorkerRequest::SamplePixels(req) => sample_pixels(req, state, stream),
                 // Named for what it does rather than "render", so the three
                 // variants do not all share a prefix that says nothing.
                 WorkerRequest::TraceScope(req) => trace_scope(req, state, stream),
@@ -1033,6 +1086,7 @@ fn handle_requests(
 fn classify_request(r: &WorkerRequest) -> DrainClass {
     match r {
         WorkerRequest::TraceScope(_) => DrainClass::Scope,
+        WorkerRequest::SamplePixels(_) => DrainClass::Sample,
         WorkerRequest::Play(_) | WorkerRequest::StopPlayback => DrainClass::PictureKeepAll,
         WorkerRequest::RenderComp(_) | WorkerRequest::RenderCompWithPreview(_) => {
             DrainClass::PictureNewestWins
@@ -1051,6 +1105,12 @@ enum DrainClass {
     PictureKeepAll,
     /// A trace; the newest survives, served after the pictures.
     Scope,
+    /// A dropper read; the newest survives, served after the pictures — and in
+    /// its own lane, not the trace's. The two are different questions, and a
+    /// Scopes panel open while the dropper is armed must not make either one
+    /// throw the other away (the same reasoning that gave a trace its own lane
+    /// against a frame).
+    Sample,
 }
 
 /// Take everything queued and keep what its class says to keep.
@@ -1059,22 +1119,28 @@ enum DrainClass {
 /// `WorkerRequest` needs a live project behind it, and the rule being tested has
 /// nothing to do with rendering.
 ///
-/// Returns `(pictures_in_order, scope, superseded_count)`.
+/// Returns `(pictures_in_order, scope, sample, superseded_count)`.
 #[frb(ignore)]
 fn drain_to_newest<T>(
     first: T,
     receiver: &Receiver<T>,
     classify: impl Fn(&T) -> DrainClass,
-) -> (Vec<T>, Option<T>, usize) {
+) -> (Vec<T>, Option<T>, Option<T>, usize) {
     let mut kept: Vec<T> = Vec::new();
     let mut newest_wins: Option<T> = None;
     let mut scope = None;
+    let mut sample = None;
     let mut superseded = 0usize;
     let mut newest = Some(first);
     while let Some(item) = newest.take() {
         match classify(&item) {
             DrainClass::Scope => {
                 if scope.replace(item).is_some() {
+                    superseded += 1;
+                }
+            }
+            DrainClass::Sample => {
+                if sample.replace(item).is_some() {
                     superseded += 1;
                 }
             }
@@ -1090,7 +1156,7 @@ fn drain_to_newest<T>(
     // A surviving newest-wins picture runs after the kept ones: the kept ones
     // were asked for earlier, and order is part of every-frame's contract.
     kept.extend(newest_wins);
-    (kept, scope, superseded)
+    (kept, scope, sample, superseded)
 }
 
 fn render_comp(
@@ -1239,6 +1305,200 @@ fn trace_scope(
         Err(err) => eprintln!("Scope trace failed: {err}"),
     }
     Ok(())
+}
+
+/// Answer one dropper read: find the pixels, cut the patch, publish it.
+///
+/// The picture comes from the same three places a trace's does, in the same
+/// order: the frame already banked in RAM, else a render of it (banked, so the
+/// next pointer move over the same frame is free). A **layer** read is the one
+/// that cannot reuse either: it needs that layer alone, which is not what the
+/// composite shows, so it renders the composition with the layer soloed and
+/// keeps the result in `layer_sample` — one entry, so dragging the pointer
+/// across the picture renders once, not once per move.
+#[frb(ignore)]
+fn sample_pixels(
+    req: SamplePixelsRequest,
+    state: &mut WorkerState,
+    stream: &mut WorkerResponseStream,
+) -> Result<(), BridgeError> {
+    let document = {
+        let document = state.project.state()?;
+        let document = document.read().map_err(|_| BridgeError::ReadFailed)?;
+        document.store.snapshot()
+    };
+
+    let layer_alone = req.layer.is_some();
+    let held = match &req.layer {
+        Some(layer) => sample_layer_alone(&document, layer.layer_id, &req, state),
+        None => match crate::framecache::best_frame(req.comp.id, req.frame) {
+            Some(held) => Some(held),
+            None => {
+                let key = crate::framecache::frame_key(req.comp.id, req.frame, req.scale);
+                let mut render = || {
+                    state
+                        .renderer
+                        .render_preview(
+                            &document,
+                            req.comp.id,
+                            req.frame,
+                            quality_for(req.scale),
+                            req.scale,
+                            None,
+                        )
+                        .ok()
+                        .map(|(rgba, width, height)| (width, height, rgba))
+                };
+                crate::framecache::get_or_render(key, &mut render)
+            }
+        },
+    };
+
+    // Nothing to read: the dropper says so on screen rather than the worker
+    // going quiet, so no reply is itself the answer — the magnifier keeps the
+    // last patch it had until a new one arrives.
+    let Some((width, height, rgba)) = held else {
+        return Ok(());
+    };
+
+    // The request is in the composition's own pixel grid; the picture in hand
+    // may be a reduced-resolution preview, so the point is carried across as a
+    // fraction rather than assumed to line up.
+    let comp_size = document
+        .comp(req.comp.id)
+        .map(|c| (c.width.max(1), c.height.max(1)));
+    let (cw, ch) = comp_size.unwrap_or((width.max(1), height.max(1)));
+    let u = f64::from(req.x) / f64::from(cw);
+    let v = f64::from(req.y) / f64::from(ch);
+
+    let Some(patch) = cut_patch(&rgba, width, height, u, v, req.grid) else {
+        return Ok(());
+    };
+    _ = stream.add(WorkerResponse::Sampled(
+        crate::api::state::BridgeSampledPixels {
+            grid: patch.grid,
+            rgba: patch.rgba,
+            width,
+            height,
+            x: patch.x,
+            y: patch.y,
+            frame: req.frame,
+            layer_alone,
+        },
+    ));
+    Ok(())
+}
+
+/// The composition rendered with one layer soloed — that layer alone, in its
+/// own place, on nothing.
+///
+/// Held in `state.layer_sample` against `(comp, frame, layer, generation)`: the
+/// dropper asks again on every pointer move, and re-compositing the whole
+/// composition per move is not a thing to do while someone is dragging a
+/// pointer. An edit bumps the framecache generation, which retires the entry
+/// with everything else the document just invalidated.
+#[frb(ignore)]
+fn sample_layer_alone(
+    document: &lumit_core::Document,
+    layer: Uuid,
+    req: &SamplePixelsRequest,
+    state: &mut WorkerState,
+) -> Option<(u32, u32, Vec<u8>)> {
+    let stamp = (
+        req.comp.id,
+        req.frame,
+        layer,
+        crate::framecache::generation(),
+    );
+    if let Some(held) = &state.layer_sample {
+        if held.stamp == stamp {
+            return Some((held.width, held.height, held.rgba.clone()));
+        }
+    }
+
+    // A patched *copy* of the snapshot: soloing for the read must never be
+    // something the document remembers, so nothing here goes near `commit`.
+    let mut patched = lumit_core::Document::clone(document);
+    let comp = patched.comp_mut(req.comp.id)?;
+    for l in &mut comp.layers {
+        l.switches.solo = l.id == layer;
+        // Soloed and still hidden is nothing at all — and a depth pass is very
+        // often hidden, which is exactly why this read exists.
+        if l.id == layer {
+            l.switches.visible = true;
+        }
+    }
+
+    let (rgba, w, h) = state
+        .renderer
+        .render_preview(
+            &patched,
+            req.comp.id,
+            req.frame,
+            quality_for(req.scale),
+            req.scale,
+            None,
+        )
+        .ok()?;
+    state.layer_sample = Some(LayerSample {
+        stamp,
+        width: w,
+        height: h,
+        rgba: rgba.clone(),
+    });
+    Some((w, h, rgba))
+}
+
+/// A patch cut out of a picture: the pixels, and where its centre landed.
+#[frb(ignore)]
+pub(crate) struct Patch {
+    pub grid: u32,
+    pub rgba: Vec<u8>,
+    pub x: u32,
+    pub y: u32,
+}
+
+/// Cut a `grid × grid` patch centred on the fraction `(u, v)` of a picture.
+///
+/// `grid` is forced odd and capped at [`MAX_GRID`] here rather than trusted:
+/// the centre pixel must be a single pixel for the magnifier's centre cell to
+/// mean anything, and the payload must stay small enough to be a reading rather
+/// than a picture. Pixels off the edge repeat the edge, so the patch is always
+/// exactly `grid × grid` and the caller never has a ragged square to draw.
+#[frb(ignore)]
+pub(crate) fn cut_patch(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    u: f64,
+    v: f64,
+    grid: u32,
+) -> Option<Patch> {
+    if width == 0 || height == 0 || rgba.len() < (width as usize * height as usize * 4) {
+        return None;
+    }
+    let grid = grid.clamp(1, MAX_GRID) | 1;
+    let w = width as i64;
+    let h = height as i64;
+    let cx = ((u * width as f64) as i64).clamp(0, w - 1);
+    let cy = ((v * height as f64) as i64).clamp(0, h - 1);
+    let half = i64::from(grid / 2);
+
+    let mut out = Vec::with_capacity((grid * grid * 4) as usize);
+    for dy in 0..i64::from(grid) {
+        for dx in 0..i64::from(grid) {
+            let px = (cx - half + dx).clamp(0, w - 1);
+            let py = (cy - half + dy).clamp(0, h - 1);
+            let i = ((py * w + px) * 4) as usize;
+            out.extend_from_slice(&rgba[i..i + 4]);
+        }
+    }
+    Some(Patch {
+        grid,
+        rgba: out,
+        x: cx as u32,
+        y: cy as u32,
+    })
 }
 
 /// Render one frame and publish it to Dart — always as a GPU handle (K-183).
@@ -1605,6 +1865,7 @@ mod tests {
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     enum Req {
         Adaptive(u32),
+        Sample(u32),
         // Kept-in-order requests — standing in for the transport commands
         // (Play, Stop), the only keep-all class since scrubs became
         // newest-wins in every mode.
@@ -1617,6 +1878,7 @@ mod tests {
             Req::Adaptive(_) => DrainClass::PictureNewestWins,
             Req::EveryFrame(_) => DrainClass::PictureKeepAll,
             Req::Scope(_) => DrainClass::Scope,
+            Req::Sample(_) => DrainClass::Sample,
         }
     }
 
@@ -1667,7 +1929,7 @@ mod tests {
         tx.send(Req::Scope(9)).unwrap();
         drop(tx);
 
-        let (pictures, scope, superseded) = drain_to_newest(Req::Adaptive(0), &rx, classify);
+        let (pictures, scope, _, superseded) = drain_to_newest(Req::Adaptive(0), &rx, classify);
         assert_eq!(
             pictures,
             vec![Req::Adaptive(3)],
@@ -1688,7 +1950,7 @@ mod tests {
         }
         drop(tx);
 
-        let (pictures, scope, superseded) = drain_to_newest(Req::Adaptive(0), &rx, classify);
+        let (pictures, scope, _, superseded) = drain_to_newest(Req::Adaptive(0), &rx, classify);
         assert_eq!(pictures, vec![Req::Adaptive(5)]);
         assert_eq!(scope, None, "nothing asked for a trace");
         assert_eq!(superseded, 5);
@@ -1702,7 +1964,7 @@ mod tests {
         tx.send(Req::Scope(3)).unwrap();
         drop(tx);
 
-        let (pictures, scope, superseded) = drain_to_newest(Req::Scope(1), &rx, classify);
+        let (pictures, scope, _, superseded) = drain_to_newest(Req::Scope(1), &rx, classify);
         assert!(pictures.is_empty());
         assert_eq!(scope, Some(Req::Scope(3)));
         assert_eq!(superseded, 2);
@@ -1714,7 +1976,7 @@ mod tests {
         let (tx, rx) = channel::<Req>();
         drop(tx);
 
-        let (pictures, scope, superseded) = drain_to_newest(Req::Adaptive(7), &rx, classify);
+        let (pictures, scope, _, superseded) = drain_to_newest(Req::Adaptive(7), &rx, classify);
         assert_eq!(pictures, vec![Req::Adaptive(7)]);
         assert_eq!(scope, None);
         assert_eq!(superseded, 0);
@@ -1733,7 +1995,7 @@ mod tests {
         tx.send(Req::Scope(1)).unwrap();
         drop(tx);
 
-        let (pictures, scope, superseded) = drain_to_newest(Req::EveryFrame(1), &rx, classify);
+        let (pictures, scope, _, superseded) = drain_to_newest(Req::EveryFrame(1), &rx, classify);
         assert_eq!(
             pictures,
             vec![
@@ -1747,5 +2009,87 @@ mod tests {
         );
         assert_eq!(scope, Some(Req::Scope(1)));
         assert_eq!(superseded, 0, "nothing every-frame was thrown away");
+    }
+
+    /// A dropper read has its own lane. The Scopes panel and an armed dropper
+    /// are often open together — the panel asks every 120 ms and the magnifier
+    /// asks on every pointer move — and neither question is the other's
+    /// replacement, so neither may supersede the other or a frame.
+    #[test]
+    fn a_dropper_read_and_a_trace_do_not_supersede_each_other() {
+        let (tx, rx) = channel();
+        tx.send(Req::Scope(1)).unwrap();
+        tx.send(Req::Sample(7)).unwrap();
+        tx.send(Req::Sample(8)).unwrap();
+        drop(tx);
+
+        let (pictures, scope, sample, superseded) =
+            drain_to_newest(Req::Adaptive(4), &rx, classify);
+        assert_eq!(pictures, vec![Req::Adaptive(4)], "the frame survives both");
+        assert_eq!(
+            scope,
+            Some(Req::Scope(1)),
+            "and the trace survives the reads"
+        );
+        assert_eq!(
+            sample,
+            Some(Req::Sample(8)),
+            "reads collapse among themselves — only where the pointer is now matters"
+        );
+        assert_eq!(superseded, 1, "one older read, and nothing else");
+    }
+
+    /// The patch is always exactly `grid × grid`, odd, and centred on the pixel
+    /// the fraction names — including hard against an edge, where the picture
+    /// runs out and the edge pixel repeats. A ragged square would leave the
+    /// magnifier drawing whatever was in memory next.
+    #[test]
+    fn a_patch_is_square_odd_and_clamped_to_the_picture() {
+        // 2×2: red, green / blue, white.
+        let rgba = vec![
+            255, 0, 0, 255, 0, 255, 0, 255, //
+            0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        let patch = super::cut_patch(&rgba, 2, 2, 0.0, 0.0, 3).expect("a picture to read");
+        assert_eq!(patch.grid, 3);
+        assert_eq!(patch.rgba.len(), 3 * 3 * 4);
+        assert_eq!((patch.x, patch.y), (0, 0), "the top-left pixel");
+        // The centre cell is the pixel asked for; the row above repeats it,
+        // because there is no row above.
+        assert_eq!(
+            &patch.rgba[16..20],
+            &[255, 0, 0, 255],
+            "centre is the red pixel"
+        );
+        assert_eq!(
+            &patch.rgba[0..4],
+            &[255, 0, 0, 255],
+            "off the top-left, the edge repeats"
+        );
+        assert_eq!(
+            &patch.rgba[20..24],
+            &[0, 255, 0, 255],
+            "and the neighbour is the green one"
+        );
+
+        // An even grid is forced odd, and an oversized one capped, so the
+        // magnifier's centre cell always means one pixel.
+        assert_eq!(
+            super::cut_patch(&rgba, 2, 2, 0.5, 0.5, 4)
+                .expect("cut")
+                .grid,
+            5
+        );
+        assert_eq!(
+            super::cut_patch(&rgba, 2, 2, 0.5, 0.5, 99)
+                .expect("cut")
+                .grid,
+            super::MAX_GRID
+        );
+
+        // A picture with fewer bytes than it claims is refused rather than read
+        // past the end of.
+        assert!(super::cut_patch(&[0, 0, 0, 255], 2, 2, 0.0, 0.0, 1).is_none());
+        assert!(super::cut_patch(&rgba, 0, 0, 0.0, 0.0, 1).is_none());
     }
 }

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -562,18 +562,25 @@ pub struct SamplePixelsRequest {
     /// the very edge still answers.
     pub x: u32,
     pub y: u32,
-    /// The patch's side length, forced odd and capped at [`MAX_GRID`].
-    pub grid: u32,
+    /// The window's side length in pixels, forced odd and capped at
+    /// [`MAX_WINDOW`]. Bigger than the magnifier's own grid on purpose: the
+    /// frontend follows the pointer inside what it already has, and asks again
+    /// only when the pointer nears the edge of it.
+    pub window: u32,
     /// Read this layer *alone* instead of the composite — what a depth pick
     /// does, so a hidden depth pass (which never shows in the composite) can
     /// still be read. `None` samples the composite.
     pub layer: Option<LayerReference>,
 }
 
-/// The largest patch the dropper ever asks for, and the magnifier's grid: 9×9
-/// (K-210). The sampled region can never exceed what is shown.
+/// The largest window one read may carry: 129×129 pixels, 66 KiB.
+///
+/// Chosen to be worth a read — a pointer can travel sixty pixels in any
+/// direction before the frontend needs another one — while staying far below
+/// the size at which a pixel payload stops being a reading and becomes a frame
+/// transport (a 1080p frame is 8 MiB, and 8.8 ms in the codec: K-183).
 #[frb(ignore)]
-pub const MAX_GRID: u32 = 9;
+pub const MAX_WINDOW: u32 = 129;
 
 #[frb(ignore)]
 pub struct RenderCompRequestWithPreview {
@@ -1307,15 +1314,24 @@ fn trace_scope(
     Ok(())
 }
 
-/// Answer one dropper read: find the pixels, cut the patch, publish it.
+/// Answer one dropper read: find the pixels, cut the window, publish it.
 ///
-/// The picture comes from the same three places a trace's does, in the same
-/// order: the frame already banked in RAM, else a render of it (banked, so the
-/// next pointer move over the same frame is free). A **layer** read is the one
-/// that cannot reuse either: it needs that layer alone, which is not what the
-/// composite shows, so it renders the composition with the layer soloed and
-/// keeps the result in `layer_sample` — one entry, so dragging the pointer
-/// across the picture renders once, not once per move.
+/// **A window, not a pixel.** The reply carries a whole square of the picture —
+/// [`MAX_WINDOW`] a side — so the frontend can follow the pointer through it
+/// without asking again. One read then serves a whole sweep of the pointer and
+/// every change of sample size, instead of a request, a render lookup and a
+/// stream message per mouse move. It stays a *reading* rather than a picture:
+/// 129×129 is 66 KiB, a fraction of a millisecond in the codec, against 8 MiB
+/// for a 1080p frame (K-183's reason for deleting the read-back transport).
+///
+/// The picture comes from the same places a trace's does, in the same order:
+/// the frame already banked in RAM — read **in place**, never cloned, since
+/// cutting a window out of eight megabytes by copying all eight is the cost
+/// this is here to avoid — else a render of it, banked so the next read of the
+/// same frame is free. A **layer** read is the one that can reuse neither: it
+/// needs that layer alone, which is not what the composite shows, so it renders
+/// the composition with the layer soloed and keeps the result in
+/// `layer_sample`.
 #[frb(ignore)]
 fn sample_pixels(
     req: SamplePixelsRequest,
@@ -1329,54 +1345,64 @@ fn sample_pixels(
     };
 
     let layer_alone = req.layer.is_some();
-    let held = match &req.layer {
-        Some(layer) => sample_layer_alone(&document, layer.layer_id, &req, state),
-        None => match crate::framecache::best_frame(req.comp.id, req.frame) {
-            Some(held) => Some(held),
-            None => {
-                let key = crate::framecache::frame_key(req.comp.id, req.frame, req.scale);
-                let mut render = || {
-                    state
-                        .renderer
-                        .render_preview(
-                            &document,
-                            req.comp.id,
-                            req.frame,
-                            quality_for(req.scale),
-                            req.scale,
-                            None,
-                        )
-                        .ok()
-                        .map(|(rgba, width, height)| (width, height, rgba))
-                };
-                crate::framecache::get_or_render(key, &mut render)
-            }
-        },
-    };
 
-    // Nothing to read: the dropper says so on screen rather than the worker
-    // going quiet, so no reply is itself the answer — the magnifier keeps the
-    // last patch it had until a new one arrives.
-    let Some((width, height, rgba)) = held else {
-        return Ok(());
-    };
-
-    // The request is in the composition's own pixel grid; the picture in hand
-    // may be a reduced-resolution preview, so the point is carried across as a
+    // The point arrives in the composition's own pixel grid; the picture in
+    // hand may be a reduced-resolution preview, so it is carried across as a
     // fraction rather than assumed to line up.
-    let comp_size = document
+    let (cw, ch) = document
         .comp(req.comp.id)
-        .map(|c| (c.width.max(1), c.height.max(1)));
-    let (cw, ch) = comp_size.unwrap_or((width.max(1), height.max(1)));
+        .map(|c| (c.width.max(1), c.height.max(1)))
+        .unwrap_or((1, 1));
     let u = f64::from(req.x) / f64::from(cw);
     let v = f64::from(req.y) / f64::from(ch);
 
-    let Some(patch) = cut_patch(&rgba, width, height, u, v, req.grid) else {
+    let cut = match &req.layer {
+        Some(layer) => sample_layer_alone(&document, layer.layer_id, &req, state)
+            .and_then(|(w, h, rgba)| cut_patch(&rgba, w, h, u, v, req.window).map(|p| (p, w, h))),
+        None => {
+            // In place, under the cache lock: a bounded copy of the window's
+            // own pixels, not of the frame around them.
+            let held = crate::framecache::with_best_frame(req.comp.id, req.frame, |rgba, w, h| {
+                cut_patch(rgba, w, h, u, v, req.window).map(|p| (p, w, h))
+            })
+            .flatten();
+            match held {
+                Some(cut) => Some(cut),
+                // Nothing banked for this frame: render it once (banked, so a
+                // re-read of the same frame is free) and cut from that.
+                None => {
+                    let key = crate::framecache::frame_key(req.comp.id, req.frame, req.scale);
+                    let mut render = || {
+                        state
+                            .renderer
+                            .render_preview(
+                                &document,
+                                req.comp.id,
+                                req.frame,
+                                quality_for(req.scale),
+                                req.scale,
+                                None,
+                            )
+                            .ok()
+                            .map(|(rgba, width, height)| (width, height, rgba))
+                    };
+                    crate::framecache::get_or_render(key, &mut render).and_then(|(w, h, rgba)| {
+                        cut_patch(&rgba, w, h, u, v, req.window).map(|p| (p, w, h))
+                    })
+                }
+            }
+        }
+    };
+
+    // Nothing to read: no reply is itself the answer — the magnifier keeps the
+    // window it had until a new one arrives, rather than blanking.
+    let Some((patch, width, height)) = cut else {
         return Ok(());
     };
+
     _ = stream.add(WorkerResponse::Sampled(
         crate::api::state::BridgeSampledPixels {
-            grid: patch.grid,
+            window: patch.window,
             rgba: patch.rgba,
             width,
             height,
@@ -1449,22 +1475,25 @@ fn sample_layer_alone(
     Some((w, h, rgba))
 }
 
-/// A patch cut out of a picture: the pixels, and where its centre landed.
+/// A window cut out of a picture: the pixels, and where its centre landed.
 #[frb(ignore)]
 pub(crate) struct Patch {
-    pub grid: u32,
+    pub window: u32,
     pub rgba: Vec<u8>,
     pub x: u32,
     pub y: u32,
 }
 
-/// Cut a `grid × grid` patch centred on the fraction `(u, v)` of a picture.
+/// Cut a `window × window` square centred on the fraction `(u, v)` of a
+/// picture.
 ///
-/// `grid` is forced odd and capped at [`MAX_GRID`] here rather than trusted:
-/// the centre pixel must be a single pixel for the magnifier's centre cell to
-/// mean anything, and the payload must stay small enough to be a reading rather
-/// than a picture. Pixels off the edge repeat the edge, so the patch is always
-/// exactly `grid × grid` and the caller never has a ragged square to draw.
+/// `window` is forced odd and capped at [`MAX_WINDOW`] here rather than
+/// trusted: the centre must be a single pixel for the magnifier's centre cell
+/// to mean anything, and the payload must stay small enough to be a reading
+/// rather than a picture. Pixels off the edge repeat the edge, so the square is
+/// always exactly `window × window` and the caller never has a ragged one to
+/// draw — and the frontend can index it without a bounds case at the picture's
+/// border.
 #[frb(ignore)]
 pub(crate) fn cut_patch(
     rgba: &[u8],
@@ -1472,12 +1501,12 @@ pub(crate) fn cut_patch(
     height: u32,
     u: f64,
     v: f64,
-    grid: u32,
+    window: u32,
 ) -> Option<Patch> {
     if width == 0 || height == 0 || rgba.len() < (width as usize * height as usize * 4) {
         return None;
     }
-    let grid = grid.clamp(1, MAX_GRID) | 1;
+    let grid = window.clamp(1, MAX_WINDOW) | 1;
     let w = width as i64;
     let h = height as i64;
     let cx = ((u * width as f64) as i64).clamp(0, w - 1);
@@ -1494,7 +1523,7 @@ pub(crate) fn cut_patch(
         }
     }
     Some(Patch {
-        grid,
+        window: grid,
         rgba: out,
         x: cx as u32,
         y: cy as u32,
@@ -2039,19 +2068,20 @@ mod tests {
         assert_eq!(superseded, 1, "one older read, and nothing else");
     }
 
-    /// The patch is always exactly `grid × grid`, odd, and centred on the pixel
-    /// the fraction names — including hard against an edge, where the picture
-    /// runs out and the edge pixel repeats. A ragged square would leave the
-    /// magnifier drawing whatever was in memory next.
+    /// The window is always exactly `window × window`, odd, and centred on the
+    /// pixel the fraction names — including hard against an edge, where the
+    /// picture runs out and the edge pixel repeats. A ragged square would leave
+    /// the magnifier drawing whatever was in memory next, and the frontend
+    /// indexes this square without a border case.
     #[test]
-    fn a_patch_is_square_odd_and_clamped_to_the_picture() {
+    fn a_window_is_square_odd_and_clamped_to_the_picture() {
         // 2×2: red, green / blue, white.
         let rgba = vec![
             255, 0, 0, 255, 0, 255, 0, 255, //
             0, 0, 255, 255, 255, 255, 255, 255,
         ];
         let patch = super::cut_patch(&rgba, 2, 2, 0.0, 0.0, 3).expect("a picture to read");
-        assert_eq!(patch.grid, 3);
+        assert_eq!(patch.window, 3);
         assert_eq!(patch.rgba.len(), 3 * 3 * 4);
         assert_eq!((patch.x, patch.y), (0, 0), "the top-left pixel");
         // The centre cell is the pixel asked for; the row above repeats it,
@@ -2072,20 +2102,26 @@ mod tests {
             "and the neighbour is the green one"
         );
 
-        // An even grid is forced odd, and an oversized one capped, so the
-        // magnifier's centre cell always means one pixel.
+        // An even window is forced odd, and one past the cap is capped, so the
+        // centre cell always means one pixel and the payload stays a reading.
         assert_eq!(
             super::cut_patch(&rgba, 2, 2, 0.5, 0.5, 4)
                 .expect("cut")
-                .grid,
+                .window,
             5
         );
         assert_eq!(
-            super::cut_patch(&rgba, 2, 2, 0.5, 0.5, 99)
+            super::cut_patch(&rgba, 2, 2, 0.5, 0.5, 9999)
                 .expect("cut")
-                .grid,
-            super::MAX_GRID
+                .window,
+            super::MAX_WINDOW
         );
+        // And the cap really is a cap on the payload: the biggest reply the
+        // dropper can ask for stays two orders of magnitude below a frame
+        // (8 MiB at 1080p, K-183), which is what keeps this a reading.
+        let biggest = super::cut_patch(&rgba, 2, 2, 0.5, 0.5, u32::MAX).expect("cut");
+        assert_eq!(biggest.window, super::MAX_WINDOW);
+        assert!(biggest.rgba.len() < 100_000, "{}", biggest.rgba.len());
 
         // A picture with fewer bytes than it claims is refused rather than read
         // past the end of.

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -557,11 +557,11 @@ pub struct SamplePixelsRequest {
     pub comp: CompositionReference,
     pub frame: u64,
     pub scale: f32,
-    /// The centre pixel, in the composition's own full-resolution pixel grid.
-    /// Clamped to the picture the sample is actually taken from, so a click on
-    /// the very edge still answers.
-    pub x: u32,
-    pub y: u32,
+    /// Where to read, as a fraction of the picture: `(0, 0)` its top-left,
+    /// `(1, 1)` its bottom-right. **Not a pixel** — see [`sample_pixels`] for
+    /// why the caller cannot name one.
+    pub u: f64,
+    pub v: f64,
     /// The window's side length in pixels, forced odd and capped at
     /// [`MAX_WINDOW`]. Bigger than the magnifier's own grid on purpose: the
     /// frontend follows the pointer inside what it already has, and asks again
@@ -1346,15 +1346,12 @@ fn sample_pixels(
 
     let layer_alone = req.layer.is_some();
 
-    // The point arrives in the composition's own pixel grid; the picture in
-    // hand may be a reduced-resolution preview, so it is carried across as a
-    // fraction rather than assumed to line up.
-    let (cw, ch) = document
-        .comp(req.comp.id)
-        .map(|c| (c.width.max(1), c.height.max(1)))
-        .unwrap_or((1, 1));
-    let u = f64::from(req.x) / f64::from(cw);
-    let v = f64::from(req.y) / f64::from(ch);
+    // The point arrives as a FRACTION of the picture, not as a pixel of
+    // anything, and that is deliberate: the picture actually read may be a
+    // reduced-resolution preview, so its pixel grid is not the composition's
+    // and neither side can name a pixel in the other's. The reply says which
+    // raster it cut from, and every pixel the caller then names is in that one.
+    let (u, v) = (req.u.clamp(0.0, 1.0), req.v.clamp(0.0, 1.0));
 
     let cut = match &req.layer {
         Some(layer) => sample_layer_alone(&document, layer.layer_id, &req, state)

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -169,6 +169,42 @@ pub(crate) fn best_frame(comp: uuid::Uuid, frame: u64) -> Option<(u32, u32, Vec<
     })
 }
 
+/// Read from the finest held picture of `comp` at `frame` **without copying
+/// it**: `read` is handed the pixels, the width and the height, and whatever it
+/// returns is the answer.
+///
+/// The dropper's reason for existing. [`best_frame`] clones the whole frame —
+/// eight megabytes at 1080p — which is the right shape for the Scopes, who then
+/// bin every pixel of it, and exactly the wrong one for a reader that wants a
+/// few hundred pixels out of the middle. `read` runs under the cache lock, so
+/// it must stay what the dropper's is: bounded, pure-CPU, and nowhere near the
+/// GPU or the FFI boundary (docs/14 §"no locks across GPU").
+///
+/// Stamps most-recently-used, like `best_frame`, and counts as neither a hit
+/// nor a miss for the same reason: those numbers describe how well the Viewer
+/// is being served.
+pub(crate) fn with_best_frame<R>(
+    comp: uuid::Uuid,
+    frame: u64,
+    read: impl FnOnce(&[u8], u32, u32) -> R,
+) -> Option<R> {
+    let comp_low = comp.as_u128() as u64;
+    with_cache(|c| {
+        let key = c
+            .map
+            .keys()
+            .filter(|k| {
+                (*k >> 64) as u64 == comp_low && ((*k >> 16) & 0xFFFF_FFFF_FFFF) as u64 == frame
+            })
+            .max()
+            .copied()?;
+        let entry = c.map.get_mut(&key)?;
+        c.clock += 1;
+        entry.last_used = c.clock;
+        Some(read(&entry.rgba, entry.width, entry.height))
+    })
+}
+
 /// Drop every held frame, because the document changed.
 ///
 /// **Why all of them, and not just the composition that was edited.** Deciding

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -1836,14 +1836,14 @@ fn wire__crate__api__composition__composition_reference_sample_pixels_impl(
             let api_frame = <u64>::sse_decode(&mut deserializer);
             let api_x = <u32>::sse_decode(&mut deserializer);
             let api_y = <u32>::sse_decode(&mut deserializer);
-            let api_grid = <u32>::sse_decode(&mut deserializer);
+            let api_window = <u32>::sse_decode(&mut deserializer);
             let api_scale = <f32>::sse_decode(&mut deserializer);
             let api_layer =
                 <Option<crate::api::layer::LayerReference>>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, BridgeError>((move || {
                 let output_ok = crate::api::composition::CompositionReference::sample_pixels(
-                    &api_that, api_frame, api_x, api_y, api_grid, api_scale, api_layer,
+                    &api_that, api_frame, api_x, api_y, api_window, api_scale, api_layer,
                 )?;
                 Ok(output_ok)
             })())
@@ -6537,7 +6537,7 @@ impl SseDecode for crate::api::layer::BridgeRevealKind {
 impl SseDecode for crate::api::state::BridgeSampledPixels {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_grid = <u32>::sse_decode(deserializer);
+        let mut var_window = <u32>::sse_decode(deserializer);
         let mut var_rgba = <Vec<u8>>::sse_decode(deserializer);
         let mut var_width = <u32>::sse_decode(deserializer);
         let mut var_height = <u32>::sse_decode(deserializer);
@@ -6546,7 +6546,7 @@ impl SseDecode for crate::api::state::BridgeSampledPixels {
         let mut var_frame = <u64>::sse_decode(deserializer);
         let mut var_layerAlone = <bool>::sse_decode(deserializer);
         return crate::api::state::BridgeSampledPixels {
-            grid: var_grid,
+            window: var_window,
             rgba: var_rgba,
             width: var_width,
             height: var_height,
@@ -8984,7 +8984,7 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::layer::BridgeRevealKind>
 impl flutter_rust_bridge::IntoDart for crate::api::state::BridgeSampledPixels {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.grid.into_into_dart().into_dart(),
+            self.window.into_into_dart().into_dart(),
             self.rgba.into_into_dart().into_dart(),
             self.width.into_into_dart().into_dart(),
             self.height.into_into_dart().into_dart(),
@@ -10291,7 +10291,7 @@ impl SseEncode for crate::api::layer::BridgeRevealKind {
 impl SseEncode for crate::api::state::BridgeSampledPixels {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <u32>::sse_encode(self.grid, serializer);
+        <u32>::sse_encode(self.window, serializer);
         <Vec<u8>>::sse_encode(self.rgba, serializer);
         <u32>::sse_encode(self.width, serializer);
         <u32>::sse_encode(self.height, serializer);

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -1834,8 +1834,8 @@ fn wire__crate__api__composition__composition_reference_sample_pixels_impl(
             let api_that =
                 <crate::api::composition::CompositionReference>::sse_decode(&mut deserializer);
             let api_frame = <u64>::sse_decode(&mut deserializer);
-            let api_x = <u32>::sse_decode(&mut deserializer);
-            let api_y = <u32>::sse_decode(&mut deserializer);
+            let api_u = <f64>::sse_decode(&mut deserializer);
+            let api_v = <f64>::sse_decode(&mut deserializer);
             let api_window = <u32>::sse_decode(&mut deserializer);
             let api_scale = <f32>::sse_decode(&mut deserializer);
             let api_layer =
@@ -1843,7 +1843,7 @@ fn wire__crate__api__composition__composition_reference_sample_pixels_impl(
             deserializer.end();
             transform_result_sse::<_, BridgeError>((move || {
                 let output_ok = crate::api::composition::CompositionReference::sample_pixels(
-                    &api_that, api_frame, api_x, api_y, api_window, api_scale, api_layer,
+                    &api_that, api_frame, api_u, api_v, api_window, api_scale, api_layer,
                 )?;
                 Ok(output_ok)
             })())

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1057667678;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2104535339;
 
 // Section: executor
 
@@ -1804,6 +1804,46 @@ fn wire__crate__api__composition__composition_reference_render_scope_impl(
                     api_scale,
                     api_kind,
                     api_colours,
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__composition__composition_reference_sample_pixels_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "composition_reference_sample_pixels",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that =
+                <crate::api::composition::CompositionReference>::sse_decode(&mut deserializer);
+            let api_frame = <u64>::sse_decode(&mut deserializer);
+            let api_x = <u32>::sse_decode(&mut deserializer);
+            let api_y = <u32>::sse_decode(&mut deserializer);
+            let api_grid = <u32>::sse_decode(&mut deserializer);
+            let api_scale = <f32>::sse_decode(&mut deserializer);
+            let api_layer =
+                <Option<crate::api::layer::LayerReference>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::composition::CompositionReference::sample_pixels(
+                    &api_that, api_frame, api_x, api_y, api_grid, api_scale, api_layer,
                 )?;
                 Ok(output_ok)
             })())
@@ -6494,6 +6534,30 @@ impl SseDecode for crate::api::layer::BridgeRevealKind {
     }
 }
 
+impl SseDecode for crate::api::state::BridgeSampledPixels {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_grid = <u32>::sse_decode(deserializer);
+        let mut var_rgba = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_width = <u32>::sse_decode(deserializer);
+        let mut var_height = <u32>::sse_decode(deserializer);
+        let mut var_x = <u32>::sse_decode(deserializer);
+        let mut var_y = <u32>::sse_decode(deserializer);
+        let mut var_frame = <u64>::sse_decode(deserializer);
+        let mut var_layerAlone = <bool>::sse_decode(deserializer);
+        return crate::api::state::BridgeSampledPixels {
+            grid: var_grid,
+            rgba: var_rgba,
+            width: var_width,
+            height: var_height,
+            x: var_x,
+            y: var_y,
+            frame: var_frame,
+            layer_alone: var_layerAlone,
+        };
+    }
+}
+
 impl SseDecode for crate::api::effect::BridgeScalar {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7436,9 +7500,14 @@ impl SseDecode for crate::api::state::WorkerResponse {
                 return crate::api::state::WorkerResponse::Scope(var_field0);
             }
             3 => {
-                return crate::api::state::WorkerResponse::PlaybackEnded;
+                let mut var_field0 =
+                    <crate::api::state::BridgeSampledPixels>::sse_decode(deserializer);
+                return crate::api::state::WorkerResponse::Sampled(var_field0);
             }
             4 => {
+                return crate::api::state::WorkerResponse::PlaybackEnded;
+            }
+            5 => {
                 return crate::api::state::WorkerResponse::CacheFilled;
             }
             _ => {
@@ -7469,44 +7538,44 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__footage__footage_reference_get_status_impl(
+        63 => wire__crate__api__footage__footage_reference_get_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__footage__footage_reference_media_info_impl(
+        64 => wire__crate__api__footage__footage_reference_media_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__footage__footage_reference_thumbnail_impl(
+        66 => wire__crate__api__footage__footage_reference_thumbnail_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
-        77 => {
+        73 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
+        78 => {
             wire__crate__api__keymap__keymap_reset_binding_impl(port, ptr, rust_vec_len, data_len)
         }
-        80 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
+        81 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        107 => wire__crate__api__layer__layer_reference_has_audio_impl(
+        108 => wire__crate__api__layer__layer_reference_has_audio_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        153 => wire__crate__api__project__project_reference_save_impl(
+        154 => wire__crate__api__project__project_reference_save_impl(
             port,
             ptr,
             rust_vec_len,
@@ -7572,110 +7641,111 @@ fn pde_ffi_dispatcher_sync_impl(
 48 => wire__crate__api__composition__composition_reference_render_frame_with_preview_impl(ptr, rust_vec_len, data_len),
 49 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
 50 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
-51 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
-52 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
-53 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
-54 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
-55 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
-56 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
-57 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
-58 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
-59 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
-60 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
-61 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
-64 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
-66 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
-67 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
-68 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
-69 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
-70 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
-71 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
-73 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
-75 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
-78 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
-79 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
-81 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
-83 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
-84 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
-85 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
-86 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
-87 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
-88 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
-89 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
-90 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
-91 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
-92 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
-93 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
-94 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
-95 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
-96 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
-97 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
-98 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
-99 => wire__crate__api__layer__layer_reference_get_retime_impl(ptr, rust_vec_len, data_len),
-100 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
-101 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
-102 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
-103 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
-104 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
-105 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
-106 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
-108 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
-109 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
-110 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
-111 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
-112 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
-113 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
-114 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
-115 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
-116 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
-117 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
-118 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
-119 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
-120 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
-121 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
-122 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
-123 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
-124 => wire__crate__api__layer__layer_reference_set_retime_enabled_impl(ptr, rust_vec_len, data_len),
-125 => wire__crate__api__layer__layer_reference_set_retime_interpolation_impl(ptr, rust_vec_len, data_len),
-126 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
-127 => wire__crate__api__layer__layer_reference_set_retime_reverse_impl(ptr, rust_vec_len, data_len),
-128 => wire__crate__api__layer__layer_reference_set_retime_speed_impl(ptr, rust_vec_len, data_len),
-129 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
-130 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
-131 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
-132 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
-133 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
-134 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
-135 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
-136 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
-137 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
-138 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
-139 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
-140 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
-141 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
-142 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
-143 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
-144 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
-145 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
-146 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
-147 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
-148 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
-149 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
-150 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
-151 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
-152 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
-154 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
-155 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
-156 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
-157 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
-158 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
-159 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
-160 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
-161 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
-162 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
-163 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
-164 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
-165 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
+51 => wire__crate__api__composition__composition_reference_sample_pixels_impl(ptr, rust_vec_len, data_len),
+52 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+53 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
+54 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
+55 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
+56 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
+57 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
+58 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
+59 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
+60 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
+61 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
+62 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
+65 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
+67 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
+68 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
+69 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
+70 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
+71 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
+72 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
+74 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
+76 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
+79 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
+80 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
+82 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
+84 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
+85 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
+86 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
+87 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
+88 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
+89 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
+90 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
+91 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
+92 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
+93 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
+94 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
+95 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
+96 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
+97 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
+98 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
+99 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
+100 => wire__crate__api__layer__layer_reference_get_retime_impl(ptr, rust_vec_len, data_len),
+101 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
+102 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
+103 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
+104 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
+105 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
+106 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
+107 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
+109 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
+110 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
+111 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
+112 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
+113 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
+114 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
+115 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
+116 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
+117 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
+118 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
+119 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
+120 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
+121 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
+122 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
+123 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
+124 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
+125 => wire__crate__api__layer__layer_reference_set_retime_enabled_impl(ptr, rust_vec_len, data_len),
+126 => wire__crate__api__layer__layer_reference_set_retime_interpolation_impl(ptr, rust_vec_len, data_len),
+127 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
+128 => wire__crate__api__layer__layer_reference_set_retime_reverse_impl(ptr, rust_vec_len, data_len),
+129 => wire__crate__api__layer__layer_reference_set_retime_speed_impl(ptr, rust_vec_len, data_len),
+130 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
+131 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
+132 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
+133 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
+134 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
+135 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
+136 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
+137 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
+138 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
+139 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
+140 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
+141 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
+142 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
+143 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
+144 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
+145 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
+146 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
+147 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
+148 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
+149 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
+150 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
+151 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
+152 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
+153 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
+155 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
+156 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
+157 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
+158 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
+159 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
+160 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
+161 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
+162 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
+163 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
+164 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
+165 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
+166 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -8911,6 +8981,33 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::layer::BridgeRevealKind>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::state::BridgeSampledPixels {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.grid.into_into_dart().into_dart(),
+            self.rgba.into_into_dart().into_dart(),
+            self.width.into_into_dart().into_dart(),
+            self.height.into_into_dart().into_dart(),
+            self.x.into_into_dart().into_dart(),
+            self.y.into_into_dart().into_dart(),
+            self.frame.into_into_dart().into_dart(),
+            self.layer_alone.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::state::BridgeSampledPixels
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::state::BridgeSampledPixels>
+    for crate::api::state::BridgeSampledPixels
+{
+    fn into_into_dart(self) -> crate::api::state::BridgeSampledPixels {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::effect::BridgeScalar {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -9411,8 +9508,11 @@ impl flutter_rust_bridge::IntoDart for crate::api::state::WorkerResponse {
             crate::api::state::WorkerResponse::Scope(field0) => {
                 [2.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::api::state::WorkerResponse::PlaybackEnded => [3.into_dart()].into_dart(),
-            crate::api::state::WorkerResponse::CacheFilled => [4.into_dart()].into_dart(),
+            crate::api::state::WorkerResponse::Sampled(field0) => {
+                [3.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::api::state::WorkerResponse::PlaybackEnded => [4.into_dart()].into_dart(),
+            crate::api::state::WorkerResponse::CacheFilled => [5.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -10188,6 +10288,20 @@ impl SseEncode for crate::api::layer::BridgeRevealKind {
     }
 }
 
+impl SseEncode for crate::api::state::BridgeSampledPixels {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.grid, serializer);
+        <Vec<u8>>::sse_encode(self.rgba, serializer);
+        <u32>::sse_encode(self.width, serializer);
+        <u32>::sse_encode(self.height, serializer);
+        <u32>::sse_encode(self.x, serializer);
+        <u32>::sse_encode(self.y, serializer);
+        <u64>::sse_encode(self.frame, serializer);
+        <bool>::sse_encode(self.layer_alone, serializer);
+    }
+}
+
 impl SseEncode for crate::api::effect::BridgeScalar {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -10943,11 +11057,15 @@ impl SseEncode for crate::api::state::WorkerResponse {
                 <i32>::sse_encode(2, serializer);
                 <crate::api::state::BridgeScopeTrace>::sse_encode(field0, serializer);
             }
-            crate::api::state::WorkerResponse::PlaybackEnded => {
+            crate::api::state::WorkerResponse::Sampled(field0) => {
                 <i32>::sse_encode(3, serializer);
+                <crate::api::state::BridgeSampledPixels>::sse_encode(field0, serializer);
+            }
+            crate::api::state::WorkerResponse::PlaybackEnded => {
+                <i32>::sse_encode(4, serializer);
             }
             crate::api::state::WorkerResponse::CacheFilled => {
-                <i32>::sse_encode(4, serializer);
+                <i32>::sse_encode(5, serializer);
             }
             _ => {
                 unimplemented!("");

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3232,6 +3232,25 @@ It is drawn in the application's overlay rather than in the panel's own stack, w
 lets it hang over whatever is beside the Viewer and so need no clamp. (Both reported by Mack
 on testing.)
 
+The **window's** edge is the one exception, and it is answered by flipping rather than sliding
+(Mack, asked for explicitly): the viewfinder goes to the other side of the pointer on whichever
+axis would run off — above instead of below, left instead of right, each axis independently —
+at the same distance, so it still never creeps over the pixel being read. Only a window with
+room for neither side clamps, because half a magnifier beats none. The bound is the **window's
+content area, not the display's**: an application cannot paint outside its own window, so a
+magnifier past the screen edge is one the window would have clipped anyway — and where the
+window sits on the display is not something Flutter reports without a windowing plugin, which
+would buy no extra room.
+
+**Living in the overlay means the panel's rebuilds are not the magnifier's.** Where it goes is
+worked out when the **pointer moves** — the one moment both trees are settled — and used
+afterwards as plain numbers. Asking render objects where they are from inside the overlay's own
+build, and marking that overlay dirty from inside the panel's build, are both wrong for the
+same reason, and an ordinary scroll over the Viewer did both: the wheel zooms the picture, the
+panel relays out, and the magnifier tried to place itself against a tree mid-rebuild — a red
+window and `'attached': is not true` (Mack, on testing). Nothing that places it touches a render
+object now, and a redraw asked for during a build is deferred to after the frame.
+
 **The strip under the grid says what is about to be taken, in the terms of the thing being
 picked.** A colour pick shows the colour and its numbers. A pick reading something else shows
 **the layer the numbers come from and the value found there** — a swatch of the composite

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3221,6 +3221,17 @@ radius: rounded under the round shape, square under the sharp one, with no shape
 widget. Shift+scroll no longer also zooms the Viewer — sizing the sample while the picture
 moves out from under the pointer is not two features, it is one broken one.
 
+**The magnifier belongs to the pointer being over the picture, and to nothing else.** It is
+shown only while the pointer is over the drawn image — arming shows nothing until then, and a
+fresh arm forgets where the last pick left the pointer, which it did not: the magnifier
+appeared the instant the tool was armed, sitting where the previous pick had happened. And it
+keeps one fixed offset from the pointer everywhere. It used to be clamped inside the Viewer,
+so approaching the bottom-right corner it crept over the very pixels being aimed at and then
+stopped following the pointer at all — a pick there is as ordinary as a pick anywhere else.
+It is drawn in the application's overlay rather than in the panel's own stack, which is what
+lets it hang over whatever is beside the Viewer and so need no clamp. (Both reported by Mack
+on testing.)
+
 **The strip under the grid says what is about to be taken, in the terms of the thing being
 picked.** A colour pick shows the colour and its numbers. A pick reading something else shows
 **the layer the numbers come from and the value found there** — a swatch of the composite

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3235,13 +3235,45 @@ holds one such render against `(comp, frame, layer, cache generation)` so draggi
 renders once rather than once per move. `depth_invert` is applied at the pick, so the caption
 and the committed number cannot disagree.
 
-**The pixels cross as a patch, not a frame.** A `sample_pixels` request answers with a 9×9
-patch — 324 bytes — on the same stream the frames and traces ride. This does not reopen the
-read-back transport K-183 deleted: the cap is enforced engine-side, and the payload is a
-reading about a few pixels rather than a picture to display. It is a worker request rather
-than a synchronous call because the pixels only exist where the renderer does, and the
+**The pixels cross as a window, not a frame — and not a pixel.** A `sample_pixels` request
+answers with a **129×129 square** of the picture (66 KiB) on the same stream the frames and
+traces ride, and the frontend cuts the magnifier's own 9×9 out of it. Moving the pointer and
+changing the sample size then cost nothing at all; a read happens only when the pointer nears
+the window's edge, the playhead moves, an edit lands, or a different layer is being read. The
+first cut of this asked per mouse move — a request, a cache lookup and a stream message at
+pointer rate, each one cloning the whole eight-megabyte frame to copy 81 pixels out of the
+middle (Mack, on testing: "a crazy number of calls"). Two fixes, both kept: the window, and
+`framecache::with_best_frame`, which hands a reader the pixels **in place** under the cache
+lock instead of cloning them — bounded, pure-CPU, nowhere near the GPU or the FFI boundary.
+
+The size is chosen to sit between the two failure modes. Whole-picture-once — the obvious
+answer — is 8 MiB at 1080p and 33 MiB at 4K, an 8.8 ms codec stall (35 ms at 4K) on arming and
+that much held while armed, which is the very transport K-183 deleted, reintroduced through a
+tool. A window is two orders of magnitude smaller, and one still lasts sixty pixels of pointer
+travel in any direction. The cap is enforced engine-side rather than trusted from the caller,
+so no request can turn this into a frame transport by the back door. It is a worker request
+rather than a synchronous call because the pixels only exist where the renderer does, and the
 renderer is owned outright by the worker thread — a sync call would have to render on Dart's
 UI isolate or take a lock across GPU work, both of which docs/14 forbids.
+
+**The picker's numbers are in the scale of the thing being edited, and a channel may exceed
+1.** A display colour — a theme colour, a solid's swatch — is eight bits, so it reads 0–255 and
+its hex is the same value said another way. A scene-linear colour in a float working depth
+(fp16 today, docs/06 §3.1) reads 0–1 for black to white, as decimals, and may go **above 1** or
+below 0 as far as the parameter's own declared range allows: several built-ins declare 0–4
+precisely because HDR tints are legal in linear light, and one declares −1 for a lift. A 0–255
+dial cannot express those at all, so the picker was silently clamping values the engine carries
+happily (Mack, on testing). The square and the strip stay 0–1 — they are a chromaticity
+picture — and an over-range colour is carried through them as a gain on its brightest channel,
+so dragging about on the square does not quietly throw the overshoot away.
+
+**The hex box stays, clipped, and says so.** Hex is an eight-bit display notation and cannot
+say 1.8. Hiding the box on the float scale loses the one notation people actually exchange
+colours in; showing a clipped hex silently would let it read as the truth. So it shows the
+colour clipped into 0–1, typing one sets exactly those values, and a line under the swatches
+appears whenever a channel is outside the range the swatch and the box can show. When the
+project depth switch lands (docs/06 §3.1, not built), an 8 bpc project is what puts an effect
+colour back on the 0–255 scale; nothing else needs to change.
 
 **The picker applies to the document as it changes.** R, G and B sit above the graph, each
 drag-scrubbable and typeable, and every edit — a number, the square, the strip, the hex box —

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3199,3 +3199,59 @@ applies to most of the geometry in an interface icon set. Not applied at even wi
 the stroke already covers whole pixels and the nudge is what would blur it. At fractional
 display scalings (150%) no offset makes a stroke whole; that is inherent and is stated in
 the note rather than papered over.
+
+
+**K-210 · DECIDED · The dropper reads a value at a pixel — not only a colour — and the
+picker applies live.** From Mack (2026-07-30), asking for the egui build's two tools back in
+Flutter, in the shape they had there.
+
+**The dropper is a pixel tool, not a colour tool.** It is armed from whatever wants a value
+at a point, and what it lifts is that thing's business: a colour for a Colour parameter, a
+*depth* for the depth-of-field focal point. The armed state therefore carries what is being
+read and a closure to write it, rather than naming a layer, an effect and a parameter index
+to be re-resolved on the far side of the picture — which is what the egui build did, and the
+source of its silent "the target has since moved" no-ops.
+
+**The magnifier is fixed at 9×9 with the region inside it.** Nine pixels a side, dashed rules
+between every pair, and a solid border round the pixels actually taken — the centre pixel
+alone by default, grown by Shift+scroll through 3×3, 5×5, 7×7, 9×9. The ladder is odd
+throughout so there is always one centre pixel, and never exceeds the grid, so the tool can
+never average over pixels it is not showing. The border's corners take the theme's control
+radius: rounded under the round shape, square under the sharp one, with no shape flag in the
+widget. Shift+scroll no longer also zooms the Viewer — sizing the sample while the picture
+moves out from under the pointer is not two features, it is one broken one.
+
+**The strip under the grid says what is about to be taken, in the terms of the thing being
+picked.** A colour pick shows the colour and its numbers. A pick reading something else shows
+**the layer the numbers come from and the value found there** — a swatch of the composite
+would be a colour nobody is choosing.
+
+**A layer pick samples that layer rendered alone.** The egui build read the depth from the
+composite's luma, or from a stashed copy of the layer's decoded pixels; the composite is
+wrong (a depth pass is nearly always hidden, so it contributes nothing to it) and the stash
+was a second path to keep in step. The worker instead renders the composition with that layer
+soloed and visible, on a *patched copy* of the snapshot that never goes near `commit`, and
+holds one such render against `(comp, frame, layer, cache generation)` so dragging the pointer
+renders once rather than once per move. `depth_invert` is applied at the pick, so the caption
+and the committed number cannot disagree.
+
+**The pixels cross as a patch, not a frame.** A `sample_pixels` request answers with a 9×9
+patch — 324 bytes — on the same stream the frames and traces ride. This does not reopen the
+read-back transport K-183 deleted: the cap is enforced engine-side, and the payload is a
+reading about a few pixels rather than a picture to display. It is a worker request rather
+than a synchronous call because the pixels only exist where the renderer does, and the
+renderer is owned outright by the worker thread — a sync call would have to render on Dart's
+UI isolate or take a lock across GPU work, both of which docs/14 forbids.
+
+**The picker applies to the document as it changes.** R, G and B sit above the graph, each
+drag-scrubbable and typeable, and every edit — a number, the square, the strip, the hex box —
+previews live and settles into one undoable edit, the same staged-drag shape the effect rows
+use. Because the live value *is* the document's, closing the picker needs no decision:
+clicking away from it keeps what is applied, and so does Apply. **Cancel** is the one button
+that changes anything on the way out — it writes back the colour the picker opened with. A
+plain "Close" was considered and rejected: with live application it would be indistinguishable
+from Apply, so it would be a button that promises a choice it does not have.
+
+**Not done here:** the x/y position pick for coordinate-valued parameter pairs. The magnifier
+carries the mode, but no Flutter row pairs x and y into one control yet, so there is nothing
+to arm it from; recorded in docs/TODO.md rather than half-wired.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3246,6 +3246,20 @@ middle (Mack, on testing: "a crazy number of calls"). Two fixes, both kept: the 
 `framecache::with_best_frame`, which hands a reader the pixels **in place** under the cache
 lock instead of cloning them — bounded, pure-CPU, nowhere near the GPU or the FFI boundary.
 
+**A read is asked for as a fraction of the picture, never as a pixel.** The picture the engine
+reads is a reduced-resolution preview whenever the Viewer is showing one, so its pixel grid is
+neither the composition's nor anything the frontend can know in advance. The first cut of the
+window asked in composition pixels and then indexed the reply with them: with a fitted Viewer
+the two grids differ by the preview scale, every index fell outside the window, each one
+clamped to the nearest edge — and the magnifier showed nine by nine of the *same* pixel, which
+reads as a flat average of the area (Mack, on testing: "just an average of all the values in
+it… and it might not be aligned"). The request now carries `(u, v)` in 0–1, the reply says
+which raster it cut from, and every pixel either side names is in that raster; asking in the
+wrong grid is no longer expressible. The clamp went too: a position outside the window answers
+**nothing** rather than its nearest edge, so the next such mistake shows as blank cells instead
+of a plausible colour. (Beyond the *picture's* border nothing changes — the window carries the
+picture's own edge repeats, so those positions are inside it and answer normally.)
+
 The size is chosen to sit between the two failure modes. Whole-picture-once — the obvious
 answer — is 8 MiB at 1080p and 33 MiB at 4K, an 8.8 ms codec stall (35 ms at 4K) on arming and
 that much held while armed, which is the very transport K-183 deleted, reintroduced through a

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -673,6 +673,22 @@ top**, each drag-scrubbable and typeable, then the saturation/value square, the 
 was/now pair and a hex field. Every one of those edits every other — type a number and the
 square moves; drag in the square and the numbers follow.
 
+**The numbers are in the scale of the thing being edited**, which is not always 0–255:
+
+- A **display colour** — a theme colour, a solid's swatch — is eight bits a channel, so it
+    reads **0–255** and its hex is the same value said another way.
+- A **scene-linear colour** in a float working depth (fp16 today, [06-RENDER-PIPELINE.md](06-RENDER-PIPELINE.md) §3.1)
+    reads **0–1 for black to white, as decimals**, and a channel may go **above 1** or below 0
+    as far as the parameter's own declared range allows — several built-ins declare 0–4 for
+    exactly this reason ("linear light: HDR tints are legal"), and one declares −1 for a lift.
+    A 0–255 dial cannot reach those values at all, which is what this scale is for.
+    When the project depth switch lands (§3.1, not built), an 8 bpc project is what puts an
+    effect colour on the 0–255 scale.
+- **The hex box is display-referred**, so on the float scale it shows the colour **clipped**
+    into 0–1, and the picker says so in a line under the swatches whenever a channel is
+    outside that. Typing a hex sets exactly those 0–1 values. The alternative — hiding the box
+    on the float scale — loses the one notation people actually exchange colours in.
+
 The picker **applies to the document as it changes**. A drag inside it previews continuously
 on the picture (the same live tick an Effect controls drag sends) and settles into one
 undoable edit when released; a typed number, a hex entry or a preset click is one settled
@@ -711,11 +727,15 @@ hidden, so what the composite shows at that pixel is not the number the effect u
 effect's `depth_invert` is applied at the pick, so the caption and the committed value cannot
 disagree.
 
-The pixels themselves come from the engine, a patch at a time
+The pixels themselves come from the engine, a **window** at a time
 (`CompositionReference::sample_pixels` → `WorkerResponse::Sampled`,
-[17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md)). A 9×9 patch is 324 bytes, so this does not
-reopen the read-back frame transport K-183 deleted; it is the answer to a question about a
-few pixels, not a picture.
+[17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md)): a 129×129 square of the picture, out of which
+the magnifier cuts its own 9×9 as the pointer moves. Moving the pointer, and changing the
+sample size, therefore cost **nothing** — no bridge call, no render, no message — and a new
+read happens only when the pointer nears the window's edge, the playhead moves, an edit lands,
+or a different layer is being read. A window is 66 KiB, so this does not reopen the read-back
+frame transport K-183 deleted (a 1080p frame is 8 MiB and 8.8 ms in the codec); it is the
+answer to a question about a few pixels, not a picture.
 
 Still to build here: the x/y **position** pick for coordinate-valued parameter pairs (the
 egui build's T14 viewfinder), and the on-Viewer crosshair handle for point parameters.

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -703,7 +703,13 @@ reads *depth*, not colour. Clicking it arms the tool; clicking it again, pressin
 pressing away from the picture puts it away. It lights while armed, so a dropper armed and
 forgotten is visible from across the panel.
 
-While armed, the Viewer grows a **magnifier** that follows the pointer:
+While armed, the Viewer grows a **magnifier** that follows the pointer. It is on screen only
+while the pointer is **over the picture** — arming the tool shows nothing until then, and a
+fresh arm never opens where the last pick left off — and it keeps **one fixed offset** from the
+pointer everywhere on the picture, drawn over whatever sits beside the Viewer rather than
+pushed back inside it near an edge (a pick in the bottom-right corner is as ordinary as any
+other, and the magnifier must not creep over the pixels being aimed at to make room for
+itself). It shows:
 
 - a **9×9 grid** of the pixels under the pointer, one enlarged square each, with **dashed
   rules between every pair** so pixel boundaries are legible;

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -709,7 +709,10 @@ fresh arm never opens where the last pick left off — and it keeps **one fixed 
 pointer everywhere on the picture, drawn over whatever sits beside the Viewer rather than
 pushed back inside it near an edge (a pick in the bottom-right corner is as ordinary as any
 other, and the magnifier must not creep over the pixels being aimed at to make room for
-itself). It shows:
+itself). The **window's** edge it does answer to, the way a tooltip does: it **flips to the
+other side of the pointer** on whichever axis would run off — above instead of below, left
+instead of right, each axis on its own — at the same distance, so it still never covers what
+is being read. It shows:
 
 - a **9×9 grid** of the pixels under the pointer, one enlarged square each, with **dashed
   rules between every pair** so pixel boundaries are legible;

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -730,7 +730,11 @@ disagree.
 The pixels themselves come from the engine, a **window** at a time
 (`CompositionReference::sample_pixels` → `WorkerResponse::Sampled`,
 [17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md)): a 129×129 square of the picture, out of which
-the magnifier cuts its own 9×9 as the pointer moves. Moving the pointer, and changing the
+the magnifier cuts its own 9×9 as the pointer moves. The read is asked for as a **fraction of
+the picture**, not as a pixel of the composition, and every pixel is then named in the raster
+the reply says it cut from — the picture read is a reduced-resolution preview whenever the
+Viewer is showing one, so the two grids are not the same and mixing them shows one repeated
+edge pixel where the picture should be. Moving the pointer, and changing the
 sample size, therefore cost **nothing** — no bridge call, no render, no message — and a new
 read happens only when the pointer nears the window's edge, the playhead moves, an edit lands,
 or a different layer is being read. A window is 66 KiB, so this does not reopen the read-back

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -666,6 +666,60 @@ Shows the **effect stack** of the selected layer (tab per recently viewed layer,
   Still to build here: drag-to-reorder by the effect's name, solo, rename, and the expression
   toggle.
 
+### 6.1 The colour picker and the dropper (K-210)
+
+**The picker.** A colour swatch opens the house picker: the **R, G and B numbers across the
+top**, each drag-scrubbable and typeable, then the saturation/value square, the hue strip, a
+was/now pair and a hex field. Every one of those edits every other — type a number and the
+square moves; drag in the square and the numbers follow.
+
+The picker **applies to the document as it changes**. A drag inside it previews continuously
+on the picture (the same live tick an Effect controls drag sends) and settles into one
+undoable edit when released; a typed number, a hex entry or a preset click is one settled
+edit on its own. So there is no state where the picker shows one colour and the composition
+shows another, and **clicking away from the picker closes it keeping what is applied** —
+nothing is waiting on a button. **Cancel** is the way back: it writes the colour the picker
+opened with and closes. **Apply** closes keeping the current one.
+
+**The dropper** is the pipette beside a swatch — and beside anything else that means "a value
+at a pixel", which is not only colour: the depth-of-field **focal point** carries one, and it
+reads *depth*, not colour. Clicking it arms the tool; clicking it again, pressing Escape, or
+pressing away from the picture puts it away. It lights while armed, so a dropper armed and
+forgotten is visible from across the panel.
+
+While armed, the Viewer grows a **magnifier** that follows the pointer:
+
+- a **9×9 grid** of the pixels under the pointer, one enlarged square each, with **dashed
+  rules between every pair** so pixel boundaries are legible;
+- a **solid border** round the pixels that will actually be taken — the **centre pixel alone**
+  by default, its corners taking the theme's control radius, so it is rounded under the round
+  shape and square under the sharp one;
+- **Shift+scroll** steps the sampled region 1×1 → 3×3 → 5×5 → 7×7 → 9×9 and back, never
+  wrapping and never exceeding the grid; the region is always odd, so there is always one
+  centre pixel. Shift+scroll does not also zoom the picture.
+- a **strip under the grid** saying what would be picked. For a colour pick that is the
+  averaged colour and its numbers; for a pick that is reading something else it is **the layer
+  the numbers are coming from and the value read off it** — a swatch of the composite would be
+  a colour nobody is choosing.
+
+Averages are taken in **scene-linear light**, not over display bytes, because that is the
+space a Colour parameter stores and what "the average of these pixels" physically means.
+
+A pick that reads a **layer** — the depth-of-field focal point reading its own depth pass —
+samples that layer **rendered alone**, not the composite: a depth pass is nearly always
+hidden, so what the composite shows at that pixel is not the number the effect uses. The
+effect's `depth_invert` is applied at the pick, so the caption and the committed value cannot
+disagree.
+
+The pixels themselves come from the engine, a patch at a time
+(`CompositionReference::sample_pixels` → `WorkerResponse::Sampled`,
+[17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md)). A 9×9 patch is 324 bytes, so this does not
+reopen the read-back frame transport K-183 deleted; it is the answer to a question about a
+few pixels, not a picture.
+
+Still to build here: the x/y **position** pick for coordinate-valued parameter pairs (the
+egui build's T14 viewfinder), and the on-Viewer crosshair handle for point parameters.
+
 ---
 
 ## 7. Effects & Presets

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -190,13 +190,16 @@ path, documented beside the types in
     surface plus its size (an NT handle there, an `IOSurfaceID` here). Only
     Linux needs more (fd, stride, offset, DRM format).
 - **Small stills still cross as pixels**, deliberately: footage thumbnails
-    (`BridgeRenderedFrame`), the 256×256 scope traces, and the dropper's 9×9
-    patches (`BridgeSampledPixels`, K-210 — 324 bytes). All are bounded and
-    rare, which is what makes the per-byte codec tolerable there. A patch is a
-    *reading*, not a picture: it answers "what is at this pixel", and the size
-    cap is enforced engine-side (`worker_thread::cut_patch`) rather than trusted
-    from the caller, so no request can turn this into a frame transport by the
-    back door.
+    (`BridgeRenderedFrame`), the 256×256 scope traces, and the dropper's
+    129×129 windows (`BridgeSampledPixels`, K-210 — 66 KiB). All are bounded and
+    rare, which is what makes the per-byte codec tolerable there. A window is a
+    *reading*, not a picture: it answers "what is around this pixel", and the
+    size cap is enforced engine-side (`worker_thread::cut_patch`, `MAX_WINDOW`)
+    rather than trusted from the caller, so no request can turn this into a
+    frame transport by the back door. It is deliberately **bigger than the nine
+    pixels the magnifier shows**: the frontend reads its grid out of the window
+    it already holds, so following the pointer costs no calls at all and a read
+    happens only when the pointer nears the window's edge.
 - **Readings ride the frame stream and have their own lane.** A scope trace
     (`WorkerResponse::Scope`) and a dropper patch (`WorkerResponse::Sampled`)
     come back on the worker's one response stream, so neither needs a second

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -190,8 +190,20 @@ path, documented beside the types in
     surface plus its size (an NT handle there, an `IOSurfaceID` here). Only
     Linux needs more (fd, stride, offset, DRM format).
 - **Small stills still cross as pixels**, deliberately: footage thumbnails
-    (`BridgeRenderedFrame`) and the 256×256 scope traces. Both are bounded and
-    rare, which is what makes the per-byte codec tolerable there.
+    (`BridgeRenderedFrame`), the 256×256 scope traces, and the dropper's 9×9
+    patches (`BridgeSampledPixels`, K-210 — 324 bytes). All are bounded and
+    rare, which is what makes the per-byte codec tolerable there. A patch is a
+    *reading*, not a picture: it answers "what is at this pixel", and the size
+    cap is enforced engine-side (`worker_thread::cut_patch`) rather than trusted
+    from the caller, so no request can turn this into a frame transport by the
+    back door.
+- **Readings ride the frame stream and have their own lane.** A scope trace
+    (`WorkerResponse::Scope`) and a dropper patch (`WorkerResponse::Sampled`)
+    come back on the worker's one response stream, so neither needs a second
+    channel. In the worker's drain policy each is its own class: a frame, a
+    trace and a patch are three different questions, and none may supersede
+    another — only its own kind, where the newest wins (a pointer that has moved
+    on makes the previous position worthless).
 
 ## Feature gates
 

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -199,7 +199,10 @@ path, documented beside the types in
     frame transport by the back door. It is deliberately **bigger than the nine
     pixels the magnifier shows**: the frontend reads its grid out of the window
     it already holds, so following the pointer costs no calls at all and a read
-    happens only when the pointer nears the window's edge.
+    happens only when the pointer nears the window's edge. The request names a
+    **fraction of the picture**, not a pixel, and the reply says which raster it
+    cut from: the engine may be working at preview resolution, so neither side
+    can name a pixel in the other's grid.
 - **Readings ride the frame stream and have their own lane.** A scope trace
     (`WorkerResponse::Scope`) and a dropper patch (`WorkerResponse::Sampled`)
     come back on the worker's one response stream, so neither needs a second

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -872,17 +872,27 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   invert** is ticked, the picked number is inverted to match, so what the strip says and what
   lands in Focus are the same thing.
 
+  **The numbers are in the scale of what you are editing.** A theme colour or a solid's swatch
+  is an ordinary eight-bit display colour, so it reads **0–255** and its hex is exactly the same
+  value written another way. An effect's colour is not: Lumit works in **linear light at float
+  precision**, where **0–1 is black to white** and a channel is free to go *above* 1 — a tint
+  brighter than white, which is a real thing in this kind of maths and something several effects
+  explicitly allow (up to 4, and one goes down to −1 for a lift). So those read as decimals, and
+  you can drag or type a channel past 1 as far as that parameter allows. A hex is an eight-bit
+  notation and cannot say "1.8", so on that scale the box shows the colour **clipped** into
+  0–1, and a line under the swatches tells you when that is happening — rather than the box
+  quietly claiming to be the whole truth.
+
   **How the pixels get there.** The Viewer's picture normally never leaves the graphics card
   (that is what makes playback cheap), so the dropper cannot simply look at what is on screen.
-  Instead it asks the engine a small question — "the nine-by-nine block of pixels around this
-  point of this frame" — and the engine sends back those 81 pixels, which is 324 bytes. That is
-  a reading, not a picture: sending a whole 1080p frame across that boundary would cost about
-  eight milliseconds, which is why nothing does it. The averaging is done in **light**, not in
-  screen values, which is why one white pixel among nine averages to a ninth of the light rather
-  than to mid-grey — and it means a picked colour matches what you sampled.
-
-  One honest note kept from before: the square and strip edit ordinary 0–1 colours, so a rare
-  "brighter than white" tint is clamped by them (the number boxes on the row still reach it).
+  Instead it asks the engine for a **window** of the picture — a 129-pixel square around where
+  you are pointing, about 66 KB — and then cuts the nine-by-nine it shows out of that window
+  itself. That is why moving the pointer feels free: it is reading pixels it already has, and
+  it only asks the engine again when you get near the edge of that window (or move the playhead,
+  or edit something). Sending a whole 1080p frame across that boundary would cost about eight
+  milliseconds every time, which is why nothing does it. The averaging is done in **light**, not
+  in screen values, which is why one white pixel among nine averages to a ninth of the light
+  rather than to mid-grey — and it means a picked colour matches what you sampled.
 
 - **LUT (K-114).** Drop this on a layer and press its **Select Cube LUT…** button to pick a
   `.cube` file — a colour recipe a colourist baked elsewhere (the loader below reads it) — and

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -838,24 +838,52 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   knowing (unchanged): "Effects and masks" applies the layer's *look* effects (keys, blurs, colour)
   but not its *time-based* ones — an Echo or motion-blur-from-movement on the referenced layer is
   treated as a still frame; the everyday cases are exact.
-- **Colour picker and eyedropper.** Every effect **Colour** parameter — a Flash tint, a Colour
-  balance wheel, the Matte key's Key colour, and so on — now shows a **clickable swatch**. Click
-  it and Lumit's colour wheel and sliders open, so you can pick a colour by eye instead of typing
-  three numbers. Beside the swatch sits a small **eyedropper**: click it and the tool arms, then
-  move the pointer over the Viewer and a **magnifier** follows the cursor. The magnifier shows a
-  zoomed 9×9 grid of the pixels under the pointer, dotted lines between them and the centre pixel
-  ringed; click to lift that colour into the parameter, or press **Escape** (or click off the
-  Viewer) to cancel. **Shift+scroll** while it is up grows the sampled patch — 1×1, 2×2, 3×3, … —
-  so you can average over a grainy area instead of grabbing one noisy pixel; the current size
-  shows under the grid, and the committed colour is the average over that patch. Depth of field's
-  **Focus** carries the same eyedropper, except it lifts *depth* rather than colour: click the
-  part of the picture you want sharp and Focus jumps to it. The pixels are read straight from the
-  frame shown in the Viewer — the very frame the Scopes read — and a picked colour is converted
-  back into Lumit's internal light space so it matches what you sampled. Two honest notes: the
-  wheel edits ordinary 0–1 colours, so a rare "brighter than white" tint is clamped by the picker
-  (the number boxes still reach it); and the Focus pick uses the brightness of the clicked pixel
-  as a stand-in for depth, since the depth layer's own picture is not separately available to the
-  panel.
+- **Colour picker and dropper (K-210).** Every effect **Colour** parameter — a Flash tint, a
+  Colour balance wheel, the Matte key's Key colour, and so on — shows a **clickable swatch**.
+  Click it and Lumit's own picker opens: the **red, green and blue numbers across the top**,
+  each of which you can drag sideways or type into, then the big square (how vivid, how bright),
+  the rainbow strip (which hue), and a hex box. Change any one of them and the rest follow.
+
+  The picker **applies as you go**: whatever it is showing is what the composition shows, so
+  there is no button standing between choosing a colour and seeing it. Dragging inside it
+  previews continuously and settles into one undo step when you let go, exactly like dragging a
+  number in Effect controls. **Clicking anywhere outside the picker closes it and keeps the
+  colour**; **Apply** does the same from a button; **Cancel** puts back the colour you started
+  with and closes.
+
+  Beside the swatch sits the **dropper** — a small pipette. Click it and the tool arms (the
+  pipette lights up so you can see it is armed), then move the pointer over the Viewer and a
+  **magnifier** follows it. The magnifier shows a **9×9 grid** of the pixels under the pointer,
+  each blown up to a square you can aim at, with **dashed lines between every pair** so you can
+  tell one pixel from the next. A **solid border** rings the pixels that will actually be taken:
+  **just the centre one** to begin with, and **Shift+scroll** grows it to 3×3, 5×5, 7×7 and 9×9
+  so a grainy area averages out instead of grabbing one noisy pixel. Click to lift the value;
+  press **Escape**, click the pipette again, or click away from the picture to put the tool away.
+  Under the grid a strip says what you are about to take — the colour and its numbers, and the
+  size of the patch.
+
+  **The dropper is not only for colour.** It means "the value at this pixel", whatever value the
+  thing you armed it from is after. Depth of field's **Focus** carries one: click the part of the
+  picture you want sharp and Focus jumps to it. There the strip does not show a colour swatch —
+  a colour would be meaningless — but **the name of the depth layer it is reading and the number
+  it found there**, so you can see where the value is coming from. That pick reads the depth
+  layer **rendered on its own**, not the composite: a depth pass is nearly always hidden, so what
+  the composite shows at that pixel is not the number the effect uses. If the effect's **Depth
+  invert** is ticked, the picked number is inverted to match, so what the strip says and what
+  lands in Focus are the same thing.
+
+  **How the pixels get there.** The Viewer's picture normally never leaves the graphics card
+  (that is what makes playback cheap), so the dropper cannot simply look at what is on screen.
+  Instead it asks the engine a small question — "the nine-by-nine block of pixels around this
+  point of this frame" — and the engine sends back those 81 pixels, which is 324 bytes. That is
+  a reading, not a picture: sending a whole 1080p frame across that boundary would cost about
+  eight milliseconds, which is why nothing does it. The averaging is done in **light**, not in
+  screen values, which is why one white pixel among nine averages to a ninth of the light rather
+  than to mid-grey — and it means a picked colour matches what you sampled.
+
+  One honest note kept from before: the square and strip edit ordinary 0–1 colours, so a rare
+  "brighter than white" tint is clamped by them (the number boxes on the row still reach it).
+
 - **LUT (K-114).** Drop this on a layer and press its **Select Cube LUT…** button to pick a
   `.cube` file — a colour recipe a colourist baked elsewhere (the loader below reads it) — and
   the whole picture is regraded through it; the **Mix** slider dials the look back toward the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -856,7 +856,9 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   **magnifier** follows it. It appears only once the pointer is actually over the picture, and
   it sits the same distance from the pointer wherever you go — including the corners, where it
   simply hangs over whatever is next to the Viewer rather than shuffling out of your way and
-  covering the pixel you were aiming at. The magnifier shows a **9×9 grid** of the pixels under the pointer,
+  covering the pixel you were aiming at. At the edge of the *window* it hops to the other side
+  of the pointer instead — above rather than below, or left rather than right — the way a
+  tooltip does, at the same distance, so it stays out of your way there too. The magnifier shows a **9×9 grid** of the pixels under the pointer,
   each blown up to a square you can aim at, with **dashed lines between every pair** so you can
   tell one pixel from the next. A **solid border** rings the pixels that will actually be taken:
   **just the centre one** to begin with, and **Shift+scroll** grows it to 3×3, 5×5, 7×7 and 9×9

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -853,7 +853,10 @@ Two mechanisms make this safe, and you'll see them by name in the code:
 
   Beside the swatch sits the **dropper** — a small pipette. Click it and the tool arms (the
   pipette lights up so you can see it is armed), then move the pointer over the Viewer and a
-  **magnifier** follows it. The magnifier shows a **9×9 grid** of the pixels under the pointer,
+  **magnifier** follows it. It appears only once the pointer is actually over the picture, and
+  it sits the same distance from the pointer wherever you go — including the corners, where it
+  simply hangs over whatever is next to the Viewer rather than shuffling out of your way and
+  covering the pixel you were aiming at. The magnifier shows a **9×9 grid** of the pixels under the pointer,
   each blown up to a square you can aim at, with **dashed lines between every pair** so you can
   tell one pixel from the next. A **solid border** rings the pixels that will actually be taken:
   **just the centre one** to begin with, and **Shift+scroll** grows it to 3×3, 5×5, 7×7 and 9×9

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -887,7 +887,10 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   (that is what makes playback cheap), so the dropper cannot simply look at what is on screen.
   Instead it asks the engine for a **window** of the picture — a 129-pixel square around where
   you are pointing, about 66 KB — and then cuts the nine-by-nine it shows out of that window
-  itself. That is why moving the pointer feels free: it is reading pixels it already has, and
+  itself. It asks by *where in the picture* you are pointing rather than by pixel number,
+  because when the Viewer is showing the picture smaller than full size the engine is working
+  on a smaller grid than the composition's, and only the engine knows which; its answer says
+  which grid it used. That is why moving the pointer feels free: it is reading pixels it already has, and
   it only asks the engine again when you get near the edge of that window (or move the playhead,
   or edit something). Sending a whole 1080p frame across that boundary would cost about eight
   milliseconds every time, which is why nothing does it. The averaging is done in **light**, not

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -92,18 +92,13 @@ the transparency grid and wheel zoom about the cursor have landed. Still missing
 - **Click-to-edit timecode** (currently read-only), may want to remove from this bar and
     only keep the one on timeline and add the functionality there.
 
-**Colour picker and pixel pickers ([07-UI-SPEC.md](07-UI-SPEC.md) §7 colour swatches):**
-- **Bring back the egui picker's look, and make it live.** The Flutter picker
-    (`flutter_ui/lib/widgets/colour_picker.dart`) lost the egui build's layout; git
-    history is the reference. It also only previews on OK — wanted: the colour under
-    the pointer applies to the document live as it changes, the same staged-drag /
-    commit-on-release shape the effect rows use, so no dialogue button stands between
-    picking and seeing.
-- **The remaining picker tools are not built.** An eyedropper that samples the Viewer
-    into a colour swatch (docs/07 §7 asks for one), and a *pixel* picker for
-    coordinate-valued parameters such as the depth focal point — egui's magnifying
-    lens, with a sample size the user chooses from 1×1, 3×3, 5×5, 7×7, 9×9 (the
-    average over that neighbourhood being what is taken).
+**Pixel pickers ([07-UI-SPEC.md](07-UI-SPEC.md) §6.1):**
+- **The x/y position pick is not built.** The colour pick and the depth-of-field focal
+    point both land with K-210; a *coordinate* pick — one dropper writing an x/y Float
+    pair, the egui build's T14 viewfinder — does not, because no Flutter row pairs x and
+    y into one control yet. The magnifier already carries the mode.
+- **The on-Viewer crosshair handle for point parameters** (docs/07 §6) is still absent:
+    a point parameter can be picked but not dragged on the picture.
 
 **Bridge ([17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md)):**
 

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -562,9 +562,14 @@ class LumitUiState extends ChangeNotifier {
   /// Viewer must not have to be mounted for that click to be harmless.
   final ValueNotifier<DropperArm?> dropper = ValueNotifier(null);
 
-  /// The pixels the last [requestDropperSample] read back, or null before the
-  /// first reply. Cleared when the tool disarms, so a fresh arm never opens on
-  /// the previous pick's pixels.
+  /// The window of pixels the last [requestDropperSample] read back, or null
+  /// before the first reply. Cleared when the tool disarms, so a fresh arm
+  /// never opens on the previous pick's pixels.
+  ///
+  /// A window, not a pixel: the magnifier cuts its own nine-by-nine out of this
+  /// as the pointer moves, and only asks again when the pointer nears its edge
+  /// (see `windowCovers`). That is what keeps a sweep across the picture to a
+  /// handful of reads instead of one per mouse move.
   final ValueNotifier<BridgeSampledPixels?> dropperPatch = ValueNotifier(null);
 
   /// Arm the dropper. Replaces whatever was armed — two pending picks would
@@ -580,9 +585,12 @@ class LumitUiState extends ChangeNotifier {
     dropperPatch.value = null;
   }
 
-  /// Ask the engine for the pixels around `(x, y)` in the fronted comp's own
-  /// pixel grid. The answer arrives on the worker stream and lands in
-  /// [dropperPatch]; nothing here waits for it.
+  /// Ask the engine for a window of pixels around `(x, y)` in the fronted
+  /// comp's own pixel grid. The answer arrives on the worker stream and lands
+  /// in [dropperPatch]; nothing here waits for it.
+  ///
+  /// Called only when the window in hand cannot answer — the caller checks
+  /// first — so this is a handful of calls per pick, not one per mouse move.
   void requestDropperSample(int x, int y) {
     final comp = selectedComp;
     final arm = dropper.value;
@@ -592,7 +600,7 @@ class LumitUiState extends ChangeNotifier {
         frame: BigInt.from(playheadFrame.value),
         x: x < 0 ? 0 : x,
         y: y < 0 ? 0 : y,
-        grid: dropperGrid,
+        window: dropperWindow,
         scale: viewerScale,
         layer: arm.sampleLayer,
       );

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -585,21 +585,25 @@ class LumitUiState extends ChangeNotifier {
     dropperPatch.value = null;
   }
 
-  /// Ask the engine for a window of pixels around `(x, y)` in the fronted
-  /// comp's own pixel grid. The answer arrives on the worker stream and lands
-  /// in [dropperPatch]; nothing here waits for it.
+  /// Ask the engine for a window of pixels around the point `(u, v)` of the
+  /// picture, each a fraction from 0 to 1. The answer arrives on the worker
+  /// stream and lands in [dropperPatch]; nothing here waits for it.
+  ///
+  /// A fraction rather than a pixel because the frontend cannot know which
+  /// raster will be read — a reduced-resolution preview has its own grid, and
+  /// the reply is what says which one it used.
   ///
   /// Called only when the window in hand cannot answer — the caller checks
   /// first — so this is a handful of calls per pick, not one per mouse move.
-  void requestDropperSample(int x, int y) {
+  void requestDropperSample(double u, double v) {
     final comp = selectedComp;
     final arm = dropper.value;
     if (comp == null || arm == null) return;
     try {
       comp.samplePixels(
         frame: BigInt.from(playheadFrame.value),
-        x: x < 0 ? 0 : x,
-        y: y < 0 ? 0 : y,
+        u: u,
+        v: v,
         window: dropperWindow,
         scale: viewerScale,
         layer: arm.sampleLayer,

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:lumit_flutter/src/rust/frb_generated.dart';
 import 'package:lumit_flutter/state/comp_model.dart';
 import 'package:lumit_flutter/state/comp_time.dart';
 import 'package:lumit_flutter/state/dock.dart';
+import 'package:lumit_flutter/state/dropper.dart';
 import 'package:lumit_flutter/state/keymap.dart';
 import 'package:lumit_flutter/src/rust/api/keymap.dart';
 import 'package:lumit_flutter/state/settings.dart';
@@ -554,6 +555,53 @@ class LumitUiState extends ChangeNotifier {
     viewerScale = scale > 1.0 ? 1.0 : scale;
   }
 
+  /// The armed dropper, or null when the tool is not armed (docs/07 §7).
+  ///
+  /// One at a time, and held at the session level rather than inside the Viewer:
+  /// the tool is armed from a parameter row in another panel entirely, and the
+  /// Viewer must not have to be mounted for that click to be harmless.
+  final ValueNotifier<DropperArm?> dropper = ValueNotifier(null);
+
+  /// The pixels the last [requestDropperSample] read back, or null before the
+  /// first reply. Cleared when the tool disarms, so a fresh arm never opens on
+  /// the previous pick's pixels.
+  final ValueNotifier<BridgeSampledPixels?> dropperPatch = ValueNotifier(null);
+
+  /// Arm the dropper. Replaces whatever was armed — two pending picks would
+  /// leave the next click ambiguous.
+  void armDropper(DropperArm arm) {
+    dropperPatch.value = null;
+    dropper.value = arm;
+  }
+
+  /// Put the dropper away, picked or not.
+  void disarmDropper() {
+    dropper.value = null;
+    dropperPatch.value = null;
+  }
+
+  /// Ask the engine for the pixels around `(x, y)` in the fronted comp's own
+  /// pixel grid. The answer arrives on the worker stream and lands in
+  /// [dropperPatch]; nothing here waits for it.
+  void requestDropperSample(int x, int y) {
+    final comp = selectedComp;
+    final arm = dropper.value;
+    if (comp == null || arm == null) return;
+    try {
+      comp.samplePixels(
+        frame: BigInt.from(playheadFrame.value),
+        x: x < 0 ? 0 : x,
+        y: y < 0 ? 0 : y,
+        grid: dropperGrid,
+        scale: viewerScale,
+        layer: arm.sampleLayer,
+      );
+    } catch (_) {
+      // No worker, or a composition that has gone away. The next pointer move
+      // asks again; there is nothing to recover here.
+    }
+  }
+
   StreamSubscription? sub;
   StreamSubscription? _changes;
 
@@ -599,6 +647,11 @@ class LumitUiState extends ChangeNotifier {
           playing.value = false;
         case WorkerResponse_CacheFilled():
           cacheChanged.value++;
+        // The pixels under the dropper. Held rather than acted on: the
+        // magnifier draws whatever the last read said, and the click that
+        // picks reads it from here.
+        case WorkerResponse_Sampled(:final field0):
+          dropperPatch.value = field0;
       }
     });
   }

--- a/flutter_ui/lib/panels/effect_controls_panel_frb.dart
+++ b/flutter_ui/lib/panels/effect_controls_panel_frb.dart
@@ -526,6 +526,10 @@ class _EffectSection extends StatelessWidget {
                 onWrite: onWrite,
                 onLive: onLive,
                 twoColumn: true,
+                // The effect's other values, for a control whose behaviour
+                // depends on a sibling (the depth-of-field dropper reads the
+                // effect's own `depth` layer).
+                siblings: values,
               ),
           ],
     );

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -458,7 +458,7 @@ class EffectParamRowFrb extends StatelessWidget {
 
     // The value written for a picked colour: the three channels as statics,
     // clamped to the parameter's declared range, with alpha left alone.
-    BridgeEffectValue valueOf(Color picked) {
+    BridgeEffectValue valueOf(PickedColour picked) {
       double clamp(double v) => v < min ? min : (v > max ? max : v);
       return BridgeEffectValue.colour(BridgeColour(
         r: BridgeScalar.static_(clamp(picked.r)),
@@ -482,7 +482,17 @@ class EffectParamRowFrb extends StatelessWidget {
               await showColourPicker(
                 context: context,
                 position: box.localToGlobal(Offset(0, box.size.height + 4)),
-                initial: shown,
+                initial: PickedColour(
+                    chan(colour.r), chan(colour.g), chan(colour.b)),
+                // An effect colour is scene-linear in a float working depth
+                // (fp16 today, docs/06 §3.1): 0–1 is black to white, and the
+                // parameter's own range says how far past that it may go — an
+                // HDR tint really does sit above 1, and a 0–255 dial could not
+                // reach it. When the project depth switch lands (docs/06 §3.1),
+                // an 8 bpc project is what passes `bytes` here.
+                scale: ColourScale.unit,
+                min: min,
+                max: max,
                 // Live all the way through: a drag inside the picker previews
                 // on the picture, and each settled change is one undoable edit
                 // — the same shape as dragging the number beside it.

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -24,7 +24,9 @@ import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
+import '../icons/icons.dart';
 import '../state/comp_time.dart';
+import '../state/dropper.dart';
 import '../state/preview_throttle.dart';
 import '../state/timeline_columns.dart';
 import '../theme/theme.dart';
@@ -90,6 +92,14 @@ class EffectParamRowFrb extends StatelessWidget {
   /// The parameter's graph line colour while it is selected.
   final Color? graphColour;
 
+  /// The rest of this effect's parameter values, by id — what a control needs
+  /// when its behaviour depends on a *sibling*. The depth-of-field focal point
+  /// is the case that asks for it: its dropper reads the layer named by the
+  /// effect's own `depth` parameter, and inverts what it reads when
+  /// `depth_invert` is set, so it cannot be built from this parameter alone.
+  /// Empty is a fair default — the row then simply offers no dropper.
+  final Map<String, BridgeEffectValue> siblings;
+
   const EffectParamRowFrb({
     super.key,
     required this.effectId,
@@ -107,6 +117,7 @@ class EffectParamRowFrb extends StatelessWidget {
     this.onLabelTap,
     this.graphColour,
     this.twoColumn = false,
+    this.siblings = const {},
   });
 
   @override
@@ -220,7 +231,7 @@ class EffectParamRowFrb extends StatelessWidget {
           :final hardMax
         ):
         if (value case BridgeEffectValue_Float(:final field0)) {
-          return _scalarField(
+          final field = _scalarField(
             context,
             scalar: field0,
             frame: frame,
@@ -230,6 +241,14 @@ class EffectParamRowFrb extends StatelessWidget {
             hardMax: hardMax,
             keyName: '$id-${param.id}',
             write: (s) => _set(BridgeEffectValue.float(s)),
+          );
+          // A number picked off the picture rather than typed: the focal point
+          // of a depth-of-field, read straight off its own depth pass.
+          final depth = _depthDropper(context, id, hardMin, hardMax);
+          if (depth == null) return field;
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [field, const SizedBox(width: 4), depth],
           );
         }
         return Text('—', style: t.small);
@@ -371,6 +390,49 @@ class EffectParamRowFrb extends StatelessWidget {
     );
   }
 
+  /// The dropper beside a depth-of-field focal point, or null when this row is
+  /// not one (docs/07 §6.1, docs/08 §3.22).
+  ///
+  /// It is offered on the `focus` parameter of an effect that carries a `depth`
+  /// layer, and reads that layer **alone** — a depth pass is nearly always
+  /// hidden, so what the composite shows at that pixel is not the number the
+  /// effect uses. `depth_invert` is applied here, at the pick, so the value
+  /// written is the one the parameter means; the caption and the committed
+  /// number can never disagree.
+  Widget? _depthDropper(
+      BuildContext context, UuidValue id, double? hardMin, double? hardMax) {
+    if (param.id != 'focus') return null;
+    if (siblings['depth'] case BridgeEffectValue_Layer(:final field0)
+        when field0 != null) {
+      final entry = ownerLayers
+          .where((l) => l.layer.internallayerId == field0)
+          .firstOrNull;
+      if (entry == null) return null;
+      final invert = switch (siblings['depth_invert']) {
+        BridgeEffectValue_Bool(:final field0) => field0,
+        _ => false,
+      };
+      return _DropperButton(
+        id: 'fx-$id-${param.id}',
+        tip: 'Read the focal point off ${entry.info.name} in the Viewer',
+        arm: (ui) => ui.armDropper(DropperArm(
+          id: 'fx-$id-${param.id}',
+          reads: DropperReads.depth,
+          label: param.label,
+          sampleLayer: entry.layer,
+          sampleLayerName: entry.info.name,
+          onPick: (sample) {
+            final d = invert ? 1 - sample.depth : sample.depth;
+            final low = hardMin ?? 0, high = hardMax ?? 1;
+            _set(BridgeEffectValue.float(
+                BridgeScalar.static_(d.clamp(low, high))));
+          },
+        )),
+      );
+    }
+    return null;
+  }
+
   /// A colour swatch. The four channels animate independently in the model, so a
   /// swatch edit writes all four statics at once; an animated channel is left
   /// alone for the same reason a scalar is.
@@ -394,43 +456,74 @@ class EffectParamRowFrb extends StatelessWidget {
     final shown = documentColour(
         byte(chan(colour.r)), byte(chan(colour.g)), byte(chan(colour.b)), 255);
 
+    // The value written for a picked colour: the three channels as statics,
+    // clamped to the parameter's declared range, with alpha left alone.
+    BridgeEffectValue valueOf(Color picked) {
+      double clamp(double v) => v < min ? min : (v > max ? max : v);
+      return BridgeEffectValue.colour(BridgeColour(
+        r: BridgeScalar.static_(clamp(picked.r)),
+        g: BridgeScalar.static_(clamp(picked.g)),
+        b: BridgeScalar.static_(clamp(picked.b)),
+        a: colour.a,
+      ));
+    }
+
     return SizedBox(
-      width: effectCellWidth,
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: GestureDetector(
-          key: ValueKey<String>('fx-colour-$id-${param.id}'),
-          behavior: HitTestBehavior.opaque,
-          onTap: () async {
-            final box = context.findRenderObject();
-            if (box is! RenderBox) return;
-            final picked = await showColourPicker(
-              context: context,
-              position: box.localToGlobal(Offset(0, box.size.height + 4)),
-              initial: shown,
-            );
-            if (picked == null) return;
-            double clamp(double v) => v < min ? min : (v > max ? max : v);
-            _set(BridgeEffectValue.colour(BridgeColour(
-              r: BridgeScalar.static_(clamp(picked.r)),
-              g: BridgeScalar.static_(clamp(picked.g)),
-              b: BridgeScalar.static_(clamp(picked.b)),
-              a: colour.a,
-            )));
-          },
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: Container(
-              width: 28,
-              height: 18,
-              decoration: BoxDecoration(
-                color: shown,
-                borderRadius: BorderRadius.circular(t.tokens.controlRadius),
-                border: Border.all(color: t.hairlineStrong),
+      width: effectCellWidth + 22,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          GestureDetector(
+            key: ValueKey<String>('fx-colour-$id-${param.id}'),
+            behavior: HitTestBehavior.opaque,
+            onTap: () async {
+              final box = context.findRenderObject();
+              if (box is! RenderBox) return;
+              await showColourPicker(
+                context: context,
+                position: box.localToGlobal(Offset(0, box.size.height + 4)),
+                initial: shown,
+                // Live all the way through: a drag inside the picker previews
+                // on the picture, and each settled change is one undoable edit
+                // — the same shape as dragging the number beside it.
+                onPreview: (picked) => _setLive(valueOf(picked)),
+                onCommit: (picked) => _set(valueOf(picked)),
+              );
+            },
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: Container(
+                width: 28,
+                height: 18,
+                decoration: BoxDecoration(
+                  color: shown,
+                  borderRadius: BorderRadius.circular(t.tokens.controlRadius),
+                  border: Border.all(color: t.hairlineStrong),
+                ),
               ),
             ),
           ),
-        ),
+          const SizedBox(width: 4),
+          // The dropper: lift this colour off the picture instead of choosing
+          // it (docs/07 §6.1).
+          _DropperButton(
+            id: 'fx-$id-${param.id}',
+            tip: 'Sample ${param.label} from the Viewer',
+            arm: (ui) => ui.armDropper(DropperArm(
+              id: 'fx-$id-${param.id}',
+              reads: DropperReads.colour,
+              label: param.label,
+              onPick: (sample) => _set(BridgeEffectValue.colour(BridgeColour(
+                // Scene-linear, exactly as the parameter stores it, so the
+                // sample passes through without a conversion to disagree over.
+                r: BridgeScalar.static_(sample.r.clamp(min, max)),
+                g: BridgeScalar.static_(sample.g.clamp(min, max)),
+                b: BridgeScalar.static_(sample.b.clamp(min, max)),
+                a: colour.a,
+              ))),
+            )),
+          ),
+        ],
       ),
     );
   }
@@ -622,5 +715,53 @@ class EffectStackEditor {
   void clear() {
     _throttle.cancel();
     _staged = null;
+  }
+}
+
+/// The little pipette beside a parameter: click to arm the dropper, click it
+/// again (or press Escape, or click away from the picture) to put it away.
+///
+/// It lights while *this* parameter's pick is the armed one, so a dropper armed
+/// from one row and forgotten is visible from across the panel.
+class _DropperButton extends StatelessWidget {
+  /// This button's arm id — compared with the armed one to know when to light.
+  final String id;
+  final String tip;
+  final void Function(LumitUiState ui) arm;
+
+  const _DropperButton({required this.id, required this.tip, required this.arm});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    final ui = Provider.of<LumitUiState>(context, listen: false);
+    return ValueListenableBuilder<DropperArm?>(
+      valueListenable: ui.dropper,
+      builder: (context, armed, _) {
+        final lit = armed?.id == id;
+        return LumitTooltip(
+          message: tip,
+          child: GestureDetector(
+            key: ValueKey<String>('dropper-$id'),
+            behavior: HitTestBehavior.opaque,
+            onTap: () => lit ? ui.disarmDropper() : arm(ui),
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: Center(
+                  child: lumitIcon(
+                    LumitIcon.eyedropper,
+                    size: iconSize,
+                    color: lit ? t.accent : t.textSecondary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/flutter_ui/lib/panels/source_rows_frb.dart
+++ b/flutter_ui/lib/panels/source_rows_frb.dart
@@ -353,9 +353,12 @@ class _SourceRowsFrbState extends State<SourceRowsFrb> {
             await showColourPicker(
               context: context,
               position: box.localToGlobal(Offset(0, box.size.height + 4)),
-              initial: shown,
-              // A solid's colour applies as it is chosen — there is no
-              // cheaper preview of a solid than the solid itself.
+              initial: PickedColour.of(shown),
+              // A solid's colour is chosen as a display colour, so its
+              // channels read 0–255.
+              scale: ColourScale.bytes,
+              // It applies as it is chosen — there is no cheaper preview of a
+              // solid than the solid itself.
               onCommit: (picked) => onPicked(BridgeColourRgba(
                 r: picked.r,
                 g: picked.g,

--- a/flutter_ui/lib/panels/source_rows_frb.dart
+++ b/flutter_ui/lib/panels/source_rows_frb.dart
@@ -350,18 +350,19 @@ class _SourceRowsFrbState extends State<SourceRowsFrb> {
           onTap: () async {
             final box = context.findRenderObject();
             if (box is! RenderBox) return;
-            final picked = await showColourPicker(
+            await showColourPicker(
               context: context,
               position: box.localToGlobal(Offset(0, box.size.height + 4)),
               initial: shown,
+              // A solid's colour applies as it is chosen — there is no
+              // cheaper preview of a solid than the solid itself.
+              onCommit: (picked) => onPicked(BridgeColourRgba(
+                r: picked.r,
+                g: picked.g,
+                b: picked.b,
+                a: colour.a,
+              )),
             );
-            if (picked == null) return;
-            onPicked(BridgeColourRgba(
-              r: picked.r,
-              g: picked.g,
-              b: picked.b,
-              a: colour.a,
-            ));
           },
           child: MouseRegion(
             cursor: SystemMouseCursors.click,

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -1712,6 +1712,7 @@ class _TimelineParamRowState extends State<_TimelineParamRow> {
       rowPadding: EdgeInsets.zero,
       // The staged value while a drag is in flight, the document's otherwise.
       value: _editor.stagedValue(row.info.id, row.param.id) ?? row.value,
+      siblings: {for (final v in row.info.values) v.id: v.value},
       comp: widget.comp,
       ownerLayerId: widget.layer.internallayerId,
       ownerLayers: ui.model.layers,

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -470,6 +470,18 @@ class _DropperLayerState extends State<DropperLayer> {
   /// a corner — the pointer keeps it at one fixed offset everywhere.
   OverlayEntry? _viewfinderEntry;
 
+  /// Where the pointer is in the *overlay's* coordinates, and how much room the
+  /// overlay has — both worked out when the pointer moves, and used afterwards
+  /// as plain numbers.
+  ///
+  /// **Never worked out while building.** Placing the magnifier means asking
+  /// render objects where they are, and a scroll over the Viewer zooms the
+  /// picture, which relays this panel out: asking mid-rebuild asserts
+  /// `attached` and takes the window red. A pointer event is the one moment
+  /// both trees are settled, so that is when it is asked.
+  Offset? _overlayCursor;
+  Rect _overlayBounds = Rect.zero;
+
   /// How many pixels a side are averaged. One — this pixel and no other —
   /// until Shift+scroll says otherwise, and remembered for as long as the tool
   /// stays armed.
@@ -507,7 +519,12 @@ class _DropperLayerState extends State<DropperLayer> {
   /// picture, and nothing else.
   void _onArmChanged() {
     _hideViewfinder();
-    if (mounted) setState(() => _cursor = null);
+    if (mounted) {
+      setState(() {
+        _cursor = null;
+        _overlayCursor = null;
+      });
+    }
   }
 
   @override
@@ -520,8 +537,19 @@ class _DropperLayerState extends State<DropperLayer> {
       _hideViewfinder();
     }
     // The picture moved under the pointer (a zoom, a pan, the panel resized):
-    // the magnifier is placed against it, so it has to be placed again.
-    if (old.fitted != widget.fitted) _viewfinderEntry?.markNeedsBuild();
+    // which pixel is under the pointer has changed, so the magnifier has to be
+    // redrawn — but AFTER this build, never during it. Marking an overlay entry
+    // dirty from inside a build is the "setState() called during build" error,
+    // and it is what an ordinary scroll over the Viewer used to do.
+    if (old.fitted != widget.fitted) _refreshViewfinderAfterFrame();
+  }
+
+  /// Redraw the magnifier once this frame is over.
+  void _refreshViewfinderAfterFrame() {
+    if (_viewfinderEntry == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _viewfinderEntry?.markNeedsBuild();
+    });
   }
 
   bool _onKey(KeyEvent event) {
@@ -546,13 +574,16 @@ class _DropperLayerState extends State<DropperLayer> {
       child: MouseRegion(
         cursor: SystemMouseCursors.precise,
         onExit: (_) {
-          setState(() => _cursor = null);
+          setState(() {
+            _cursor = null;
+            _overlayCursor = null;
+          });
           _hideViewfinder();
         },
         child: Listener(
           behavior: HitTestBehavior.opaque,
-          onPointerHover: (e) => _moved(e.localPosition),
-          onPointerMove: (e) => _moved(e.localPosition),
+          onPointerHover: (e) => _moved(e.localPosition, e.position),
+          onPointerMove: (e) => _moved(e.localPosition, e.position),
           onPointerSignal: (e) {
             if (e is! PointerScrollEvent) return;
             if (!HardwareKeyboard.instance.isShiftPressed) return;
@@ -584,7 +615,7 @@ class _DropperLayerState extends State<DropperLayer> {
   /// instead of being pushed back inside the panel near an edge.
   void _syncViewfinder(DropperArm arm) {
     final at = _cursor;
-    if (at == null || !widget.fitted.contains(at)) {
+    if (at == null || !widget.fitted.contains(at) || _overlayCursor == null) {
       _hideViewfinder();
       return;
     }
@@ -603,18 +634,35 @@ class _DropperLayerState extends State<DropperLayer> {
     _viewfinderEntry = null;
   }
 
-  /// The magnifier, placed at a fixed offset from the pointer in the overlay's
-  /// own coordinates (which the UI-scale transform sits above, so the pointer's
-  /// global position is carried across rather than assumed to match).
+  /// The pointer's global position in the overlay's own coordinates, and the
+  /// room the overlay has — remembered for the builder, which must not go
+  /// looking for render objects itself (see [_overlayCursor]).
+  ///
+  /// The overlay's box is what carries the UI-scale transform, so a global
+  /// pointer position is put through it rather than assumed to match.
+  void _noteOverlayPosition(Offset global) {
+    final overlayBox = Overlay.maybeOf(context)?.context.findRenderObject();
+    if (overlayBox is! RenderBox || !overlayBox.attached || !overlayBox.hasSize) {
+      _overlayCursor = null;
+      return;
+    }
+    _overlayCursor = overlayBox.globalToLocal(global);
+    _overlayBounds = Offset.zero & overlayBox.size;
+  }
+
+  /// The magnifier, placed at a fixed offset from the pointer — from numbers
+  /// worked out when the pointer last moved, so this touches no render object
+  /// and is safe to run in any frame.
   Widget _viewfinderAt(DropperArm arm) {
     final at = _cursor;
-    final box = context.findRenderObject();
-    final overlayBox = Overlay.maybeOf(context)?.context.findRenderObject();
-    if (at == null || box is! RenderBox || overlayBox is! RenderBox) {
-      return const SizedBox.shrink();
-    }
-    final origin =
-        dropperViewfinderOrigin(overlayBox.globalToLocal(box.localToGlobal(at)));
+    final overlayAt = _overlayCursor;
+    if (at == null || overlayAt == null) return const SizedBox.shrink();
+    final origin = dropperViewfinderOrigin(
+      overlayAt,
+      // The window's content area: what the application can actually paint on,
+      // and so the only edge the viewfinder has to answer to.
+      _overlayBounds,
+    );
     return Positioned(
       left: origin.dx,
       top: origin.dy,
@@ -638,7 +686,8 @@ class _DropperLayerState extends State<DropperLayer> {
   /// The pointer moved. Redrawing is free — the magnifier reads the window
   /// already in hand — so the engine is only asked when that window has run out
   /// of pixels under the pointer.
-  void _moved(Offset local) {
+  void _moved(Offset local, Offset global) {
+    _noteOverlayPosition(global);
     setState(() => _cursor = local);
     final arm = widget.uiState.dropper.value;
     if (arm != null) _syncViewfinder(arm);

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -473,9 +473,6 @@ class _DropperLayerState extends State<DropperLayer> {
   /// position is the only one worth answering.
   final PreviewThrottle _throttle = PreviewThrottle();
 
-  /// The comp's pixel size, read once while armed rather than per pointer move.
-  BridgeCompSize? _size;
-
   @override
   void initState() {
     super.initState();
@@ -494,10 +491,9 @@ class _DropperLayerState extends State<DropperLayer> {
   @override
   void didUpdateWidget(DropperLayer old) {
     super.didUpdateWidget(old);
-    // A different composition is a different pixel grid; the cached size and
-    // any window read against the old one are both meaningless now.
+    // A different composition is a different picture; a window read against the
+    // old one is meaningless now.
     if (old.comp.internalid != widget.comp.internalid) {
-      _size = null;
       widget.uiState.dropperPatch.value = null;
     }
   }
@@ -557,7 +553,6 @@ class _DropperLayerState extends State<DropperLayer> {
       return const SizedBox.expand();
     }
     final origin = dropperViewfinderOrigin(at, widget.fitted);
-    final centre = _compPixel(at);
     return Stack(
       children: [
         Positioned(
@@ -568,7 +563,11 @@ class _DropperLayerState extends State<DropperLayer> {
             builder: (context, window, _) => DropperViewfinder(
               arm: arm,
               window: window,
-              centre: centre,
+              // In the window's own raster, which the reply describes — the
+              // magnifier cannot be indexed in any other grid.
+              centre: window == null
+                  ? (0, 0)
+                  : windowPixelAt(window, _u(at), _v(at)),
               region: _region,
             ),
           ),
@@ -596,7 +595,7 @@ class _DropperLayerState extends State<DropperLayer> {
     if (window.layerAlone != (widget.uiState.dropper.value?.sampleLayer != null)) {
       return false;
     }
-    final (x, y) = _compPixel(local);
+    final (x, y) = windowPixelAt(window, _u(local), _v(local));
     return windowCovers(window, x, y);
   }
 
@@ -617,34 +616,28 @@ class _DropperLayerState extends State<DropperLayer> {
       _request(local);
       return;
     }
-    final (x, y) = _compPixel(local);
+    final (x, y) = windowPixelAt(window, _u(local), _v(local));
     arm.onPick(sampleFromWindow(window, _region, x, y));
     widget.uiState.disarmDropper();
   }
 
-  /// Which pixel of the composition is under `local`.
+  /// Where the pointer is *inside the drawn picture*, as a fraction from 0 to 1.
   ///
-  /// The comp's size is read once per armed session rather than per move: it
-  /// cannot change while a pick is in flight, and asking the engine for it on
-  /// every mouse move is exactly the kind of per-move bridge crossing the
-  /// window read exists to remove.
-  (int, int) _compPixel(Offset local) {
-    final size = _size ??= widget.comp.getSize();
-    final rect = widget.fitted;
-    if (rect.width <= 0 || rect.height <= 0) return (0, 0);
-    final u = ((local.dx - rect.left) / rect.width).clamp(0.0, 1.0);
-    final v = ((local.dy - rect.top) / rect.height).clamp(0.0, 1.0);
-    return (
-      (u * size.width).floor().clamp(0, (size.width - 1).clamp(0, 1 << 30)),
-      (v * size.height).floor().clamp(0, (size.height - 1).clamp(0, 1 << 30)),
-    );
-  }
+  /// The only thing this panel actually knows, and deliberately all it says:
+  /// which pixel that is depends on the raster the engine ends up reading, which
+  /// is a reduced-resolution preview whenever the Viewer is showing one. The
+  /// reply carries that raster, and every pixel is named in it.
+  double _u(Offset local) => widget.fitted.width <= 0
+      ? 0
+      : ((local.dx - widget.fitted.left) / widget.fitted.width).clamp(0.0, 1.0);
 
-  /// Ask the engine for a window around the pixel under `local`.
-  void _request(Offset local) {
-    final (x, y) = _compPixel(local);
-    widget.uiState.requestDropperSample(x, y);
-  }
+  double _v(Offset local) => widget.fitted.height <= 0
+      ? 0
+      : ((local.dy - widget.fitted.top) / widget.fitted.height).clamp(0.0, 1.0);
+
+  /// Ask the engine for a window around the point under `local`.
+  void _request(Offset local) =>
+      widget.uiState.requestDropperSample(_u(local), _v(local));
 }
 
 /// The badge that appears only once a probe has actually found a file gone.

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -459,9 +459,16 @@ class DropperLayer extends StatefulWidget {
 }
 
 class _DropperLayerState extends State<DropperLayer> {
-  /// Where the pointer is, in this layer's own coordinates, or null before it
-  /// has entered the panel.
+  /// Where the pointer is, in this layer's own coordinates, or null when it is
+  /// not over the picture — which is where every arm starts, whatever the
+  /// pointer did last time.
   Offset? _cursor;
+
+  /// The viewfinder, while it is on screen. It lives in the application's
+  /// overlay rather than in this panel's own stack, so it can hang over
+  /// whatever is beside the Viewer instead of being pushed back inside it near
+  /// a corner — the pointer keeps it at one fixed offset everywhere.
+  OverlayEntry? _viewfinderEntry;
 
   /// How many pixels a side are averaged. One — this pixel and no other —
   /// until Shift+scroll says otherwise, and remembered for as long as the tool
@@ -479,13 +486,28 @@ class _DropperLayerState extends State<DropperLayer> {
     // Escape puts the tool away wherever the focus happens to be — a tool armed
     // by accident must never need a click on the picture to get rid of.
     HardwareKeyboard.instance.addHandler(_onKey);
+    widget.uiState.dropper.addListener(_onArmChanged);
   }
 
   @override
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_onKey);
+    widget.uiState.dropper.removeListener(_onArmChanged);
+    _hideViewfinder();
     _throttle.cancel();
     super.dispose();
+  }
+
+  /// Armed or disarmed: forget where the pointer was.
+  ///
+  /// Without this the *previous* pick's last pointer position survived, so
+  /// arming the tool again put the magnifier on screen straight away, sitting
+  /// wherever the last pick happened — before the pointer had gone anywhere
+  /// near the Viewer. The magnifier belongs to the pointer being over the
+  /// picture, and nothing else.
+  void _onArmChanged() {
+    _hideViewfinder();
+    if (mounted) setState(() => _cursor = null);
   }
 
   @override
@@ -495,7 +517,11 @@ class _DropperLayerState extends State<DropperLayer> {
     // old one is meaningless now.
     if (old.comp.internalid != widget.comp.internalid) {
       widget.uiState.dropperPatch.value = null;
+      _hideViewfinder();
     }
+    // The picture moved under the pointer (a zoom, a pan, the panel resized):
+    // the magnifier is placed against it, so it has to be placed again.
+    if (old.fitted != widget.fitted) _viewfinderEntry?.markNeedsBuild();
   }
 
   bool _onKey(KeyEvent event) {
@@ -519,7 +545,10 @@ class _DropperLayerState extends State<DropperLayer> {
     return Positioned.fill(
       child: MouseRegion(
         cursor: SystemMouseCursors.precise,
-        onExit: (_) => setState(() => _cursor = null),
+        onExit: (_) {
+          setState(() => _cursor = null);
+          _hideViewfinder();
+        },
         child: Listener(
           behavior: HitTestBehavior.opaque,
           onPointerHover: (e) => _moved(e.localPosition),
@@ -537,42 +566,72 @@ class _DropperLayerState extends State<DropperLayer> {
             // holds every pixel a wider region could want.
             setState(() =>
                 _region = nextDropperRegion(_region, scroll < 0 ? 1 : -1));
+            _viewfinderEntry?.markNeedsBuild();
           },
           onPointerDown: (e) => _pressed(arm, e.localPosition),
-          child: _viewfinder(arm),
+          child: const SizedBox.expand(),
         ),
       ),
     );
   }
 
-  /// The magnifier, placed beside the pointer. Nothing while the pointer is off
-  /// the picture: there is nothing under it to magnify.
-  Widget _viewfinder(DropperArm arm) {
+  /// Put the magnifier on screen, or take it off, and keep it beside the
+  /// pointer while it is there.
+  ///
+  /// On screen only while the pointer is over the picture — there is nothing
+  /// under it to magnify anywhere else — and in the application's overlay, so
+  /// it keeps one fixed offset from the pointer everywhere on the picture
+  /// instead of being pushed back inside the panel near an edge.
+  void _syncViewfinder(DropperArm arm) {
     final at = _cursor;
     if (at == null || !widget.fitted.contains(at)) {
-      return const SizedBox.expand();
+      _hideViewfinder();
+      return;
     }
-    final origin = dropperViewfinderOrigin(at, widget.fitted);
-    return Stack(
-      children: [
-        Positioned(
-          left: origin.dx,
-          top: origin.dy,
-          child: ValueListenableBuilder<BridgeSampledPixels?>(
-            valueListenable: widget.uiState.dropperPatch,
-            builder: (context, window, _) => DropperViewfinder(
-              arm: arm,
-              window: window,
-              // In the window's own raster, which the reply describes — the
-              // magnifier cannot be indexed in any other grid.
-              centre: window == null
-                  ? (0, 0)
-                  : windowPixelAt(window, _u(at), _v(at)),
-              region: _region,
-            ),
+    if (_viewfinderEntry != null) {
+      _viewfinderEntry!.markNeedsBuild();
+      return;
+    }
+    final overlay = Overlay.maybeOf(context);
+    if (overlay == null) return;
+    _viewfinderEntry = OverlayEntry(builder: (_) => _viewfinderAt(arm));
+    overlay.insert(_viewfinderEntry!);
+  }
+
+  void _hideViewfinder() {
+    _viewfinderEntry?.remove();
+    _viewfinderEntry = null;
+  }
+
+  /// The magnifier, placed at a fixed offset from the pointer in the overlay's
+  /// own coordinates (which the UI-scale transform sits above, so the pointer's
+  /// global position is carried across rather than assumed to match).
+  Widget _viewfinderAt(DropperArm arm) {
+    final at = _cursor;
+    final box = context.findRenderObject();
+    final overlayBox = Overlay.maybeOf(context)?.context.findRenderObject();
+    if (at == null || box is! RenderBox || overlayBox is! RenderBox) {
+      return const SizedBox.shrink();
+    }
+    final origin =
+        dropperViewfinderOrigin(overlayBox.globalToLocal(box.localToGlobal(at)));
+    return Positioned(
+      left: origin.dx,
+      top: origin.dy,
+      child: IgnorePointer(
+        child: ValueListenableBuilder<BridgeSampledPixels?>(
+          valueListenable: widget.uiState.dropperPatch,
+          builder: (context, window, _) => DropperViewfinder(
+            arm: arm,
+            window: window,
+            // In the window's own raster, which the reply describes — the
+            // magnifier cannot be indexed in any other grid.
+            centre:
+                window == null ? (0, 0) : windowPixelAt(window, _u(at), _v(at)),
+            region: _region,
           ),
         ),
-      ],
+      ),
     );
   }
 
@@ -581,6 +640,8 @@ class _DropperLayerState extends State<DropperLayer> {
   /// of pixels under the pointer.
   void _moved(Offset local) {
     setState(() => _cursor = local);
+    final arm = widget.uiState.dropper.value;
+    if (arm != null) _syncViewfinder(arm);
     if (!widget.fitted.contains(local)) return;
     if (_covered(local)) return;
     _throttle.request(() => _request(local));

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -468,9 +468,13 @@ class _DropperLayerState extends State<DropperLayer> {
   /// stays armed.
   int _region = dropperRegions.first;
 
-  /// Reads are bounded like a drag's previews: a pointer move is not worth a
-  /// render each, and the newest position is the only one worth answering.
+  /// The reads that do go out are bounded like a drag's previews: crossing a
+  /// window's edge at speed is not worth a read per frame, and the newest
+  /// position is the only one worth answering.
   final PreviewThrottle _throttle = PreviewThrottle();
+
+  /// The comp's pixel size, read once while armed rather than per pointer move.
+  BridgeCompSize? _size;
 
   @override
   void initState() {
@@ -485,6 +489,17 @@ class _DropperLayerState extends State<DropperLayer> {
     HardwareKeyboard.instance.removeHandler(_onKey);
     _throttle.cancel();
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(DropperLayer old) {
+    super.didUpdateWidget(old);
+    // A different composition is a different pixel grid; the cached size and
+    // any window read against the old one are both meaningless now.
+    if (old.comp.internalid != widget.comp.internalid) {
+      _size = null;
+      widget.uiState.dropperPatch.value = null;
+    }
   }
 
   bool _onKey(KeyEvent event) {
@@ -522,10 +537,10 @@ class _DropperLayerState extends State<DropperLayer> {
             final d = e.scrollDelta;
             final scroll = d.dy.abs() >= d.dx.abs() ? d.dy : d.dx;
             if (scroll.abs() < 0.5) return;
+            // Nothing is asked of the engine here: the window in hand already
+            // holds every pixel a wider region could want.
             setState(() =>
                 _region = nextDropperRegion(_region, scroll < 0 ? 1 : -1));
-            final at = _cursor;
-            if (at != null) _request(at);
           },
           onPointerDown: (e) => _pressed(arm, e.localPosition),
           child: _viewfinder(arm),
@@ -542,6 +557,7 @@ class _DropperLayerState extends State<DropperLayer> {
       return const SizedBox.expand();
     }
     final origin = dropperViewfinderOrigin(at, widget.fitted);
+    final centre = _compPixel(at);
     return Stack(
       children: [
         Positioned(
@@ -549,9 +565,10 @@ class _DropperLayerState extends State<DropperLayer> {
           top: origin.dy,
           child: ValueListenableBuilder<BridgeSampledPixels?>(
             valueListenable: widget.uiState.dropperPatch,
-            builder: (context, patch, _) => DropperViewfinder(
+            builder: (context, window, _) => DropperViewfinder(
               arm: arm,
-              patch: patch,
+              window: window,
+              centre: centre,
               region: _region,
             ),
           ),
@@ -560,9 +577,27 @@ class _DropperLayerState extends State<DropperLayer> {
     );
   }
 
+  /// The pointer moved. Redrawing is free — the magnifier reads the window
+  /// already in hand — so the engine is only asked when that window has run out
+  /// of pixels under the pointer.
   void _moved(Offset local) {
     setState(() => _cursor = local);
-    if (widget.fitted.contains(local)) _throttle.request(() => _request(local));
+    if (!widget.fitted.contains(local)) return;
+    if (_covered(local)) return;
+    _throttle.request(() => _request(local));
+  }
+
+  /// Whether the window in hand answers for the pointer where it now is: same
+  /// frame, same source, and far enough from its edge.
+  bool _covered(Offset local) {
+    final window = widget.uiState.dropperPatch.value;
+    if (window == null) return false;
+    if (window.frame.toInt() != widget.uiState.playheadFrame.value) return false;
+    if (window.layerAlone != (widget.uiState.dropper.value?.sampleLayer != null)) {
+      return false;
+    }
+    final (x, y) = _compPixel(local);
+    return windowCovers(window, x, y);
   }
 
   /// A press picks when it lands on the picture, and puts the tool away when it
@@ -573,30 +608,42 @@ class _DropperLayerState extends State<DropperLayer> {
       widget.uiState.disarmDropper();
       return;
     }
-    final patch = widget.uiState.dropperPatch.value;
-    // Nothing read yet, or read of a frame the playhead has since left: ask
-    // again rather than committing a value off a picture that is no longer the
-    // one on screen. The next reply lands before the pointer can click twice.
-    if (patch == null ||
-        patch.frame.toInt() != widget.uiState.playheadFrame.value) {
+    final window = widget.uiState.dropperPatch.value;
+    // Nothing read yet, or nothing that answers for this pixel — a frame the
+    // playhead has since left, or a window the pointer has outrun. Ask again
+    // rather than committing a value off a picture that is not the one on
+    // screen; the next reply lands before the pointer can click twice.
+    if (window == null || !_covered(local)) {
       _request(local);
       return;
     }
-    arm.onPick(sampleFromPatch(patch, _region));
+    final (x, y) = _compPixel(local);
+    arm.onPick(sampleFromWindow(window, _region, x, y));
     widget.uiState.disarmDropper();
   }
 
-  /// Which pixel of the composition is under `local`, and ask for it.
-  void _request(Offset local) {
-    final size = widget.comp.getSize();
+  /// Which pixel of the composition is under `local`.
+  ///
+  /// The comp's size is read once per armed session rather than per move: it
+  /// cannot change while a pick is in flight, and asking the engine for it on
+  /// every mouse move is exactly the kind of per-move bridge crossing the
+  /// window read exists to remove.
+  (int, int) _compPixel(Offset local) {
+    final size = _size ??= widget.comp.getSize();
     final rect = widget.fitted;
-    if (rect.width <= 0 || rect.height <= 0) return;
+    if (rect.width <= 0 || rect.height <= 0) return (0, 0);
     final u = ((local.dx - rect.left) / rect.width).clamp(0.0, 1.0);
     final v = ((local.dy - rect.top) / rect.height).clamp(0.0, 1.0);
-    widget.uiState.requestDropperSample(
+    return (
       (u * size.width).floor().clamp(0, (size.width - 1).clamp(0, 1 << 30)),
       (v * size.height).floor().clamp(0, (size.height - 1).clamp(0, 1 << 30)),
     );
+  }
+
+  /// Ask the engine for a window around the pixel under `local`.
+  void _request(Offset local) {
+    final (x, y) = _compPixel(local);
+    widget.uiState.requestDropperSample(x, y);
   }
 }
 

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -30,6 +30,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/src/rust/api/audio.dart';
@@ -44,11 +45,13 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../icons/icons.dart';
+import '../state/dropper.dart';
 import '../state/preview_throttle.dart';
 import '../state/settings.dart';
 import '../state/timecode.dart';
 import '../theme/theme.dart';
 import '../widgets/controls.dart';
+import '../widgets/dropper_overlay.dart';
 import 'placeholder.dart';
 import 'viewer_layer_map.dart';
 
@@ -202,6 +205,13 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb> {
             // zooming feel like leaning in rather than teleporting.
             onPointerSignal: (event) {
               if (event is PointerScrollEvent) {
+                // Shift+scroll belongs to the armed dropper, which is sizing
+                // its sample region with it — zooming as well would move the
+                // picture out from under the pixel being aimed at.
+                if (ui.dropper.value != null &&
+                    HardwareKeyboard.instance.isShiftPressed) {
+                  return;
+                }
                 _scrollZoom(event.localPosition, event.scrollDelta.dy,
                     constraints, size, fitted);
               }
@@ -398,6 +408,10 @@ class _Stage extends StatelessWidget {
               fitted: fitted,
               onChanged: onChanged,
             ),
+            // Above the overlay, because while the dropper is armed the whole
+            // picture is a target: a drag handle under the pointer must not
+            // take the click that was meant to pick a pixel.
+            DropperLayer(comp: comp, uiState: uiState, fitted: fitted),
           ],
         ),
       ),
@@ -412,6 +426,176 @@ class _Stage extends StatelessWidget {
       left: 8,
       bottom: 8,
       child: _MissingBadge(footage: footage),
+    );
+  }
+}
+
+/// The armed dropper over the picture: the magnifier, the sample-size wheel,
+/// and the click that picks (docs/07 §6.1).
+///
+/// **Why it lives here.** The pixels being picked are the Viewer's, and only
+/// this panel knows where the picture actually sits on screen at the current
+/// magnification and pan. What is *done* with the pick is not this panel's
+/// business at all: the parameter that armed the tool handed over a closure,
+/// and this calls it.
+///
+/// Nothing at all while the tool is not armed — not a hit-test, not a listener.
+class DropperLayer extends StatefulWidget {
+  final CompositionReference comp;
+  final LumitUiState uiState;
+
+  /// Where the picture is drawn in this panel, at the current magnification.
+  final Rect fitted;
+
+  const DropperLayer({
+    super.key,
+    required this.comp,
+    required this.uiState,
+    required this.fitted,
+  });
+
+  @override
+  State<DropperLayer> createState() => _DropperLayerState();
+}
+
+class _DropperLayerState extends State<DropperLayer> {
+  /// Where the pointer is, in this layer's own coordinates, or null before it
+  /// has entered the panel.
+  Offset? _cursor;
+
+  /// How many pixels a side are averaged. One — this pixel and no other —
+  /// until Shift+scroll says otherwise, and remembered for as long as the tool
+  /// stays armed.
+  int _region = dropperRegions.first;
+
+  /// Reads are bounded like a drag's previews: a pointer move is not worth a
+  /// render each, and the newest position is the only one worth answering.
+  final PreviewThrottle _throttle = PreviewThrottle();
+
+  @override
+  void initState() {
+    super.initState();
+    // Escape puts the tool away wherever the focus happens to be — a tool armed
+    // by accident must never need a click on the picture to get rid of.
+    HardwareKeyboard.instance.addHandler(_onKey);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_onKey);
+    _throttle.cancel();
+    super.dispose();
+  }
+
+  bool _onKey(KeyEvent event) {
+    if (event is! KeyDownEvent) return false;
+    if (event.logicalKey != LogicalKeyboardKey.escape) return false;
+    if (widget.uiState.dropper.value == null) return false;
+    widget.uiState.disarmDropper();
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DropperArm?>(
+      valueListenable: widget.uiState.dropper,
+      builder: (context, arm, _) =>
+          arm == null ? const SizedBox.shrink() : _armed(context, arm),
+    );
+  }
+
+  Widget _armed(BuildContext context, DropperArm arm) {
+    return Positioned.fill(
+      child: MouseRegion(
+        cursor: SystemMouseCursors.precise,
+        onExit: (_) => setState(() => _cursor = null),
+        child: Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerHover: (e) => _moved(e.localPosition),
+          onPointerMove: (e) => _moved(e.localPosition),
+          onPointerSignal: (e) {
+            if (e is! PointerScrollEvent) return;
+            if (!HardwareKeyboard.instance.isShiftPressed) return;
+            // Shift turns the wheel horizontal on most platforms, so take
+            // whichever axis actually carries the motion — reading only the
+            // vertical delta is why the egui build's size never changed.
+            final d = e.scrollDelta;
+            final scroll = d.dy.abs() >= d.dx.abs() ? d.dy : d.dx;
+            if (scroll.abs() < 0.5) return;
+            setState(() =>
+                _region = nextDropperRegion(_region, scroll < 0 ? 1 : -1));
+            final at = _cursor;
+            if (at != null) _request(at);
+          },
+          onPointerDown: (e) => _pressed(arm, e.localPosition),
+          child: _viewfinder(arm),
+        ),
+      ),
+    );
+  }
+
+  /// The magnifier, placed beside the pointer. Nothing while the pointer is off
+  /// the picture: there is nothing under it to magnify.
+  Widget _viewfinder(DropperArm arm) {
+    final at = _cursor;
+    if (at == null || !widget.fitted.contains(at)) {
+      return const SizedBox.expand();
+    }
+    final origin = dropperViewfinderOrigin(at, widget.fitted);
+    return Stack(
+      children: [
+        Positioned(
+          left: origin.dx,
+          top: origin.dy,
+          child: ValueListenableBuilder<BridgeSampledPixels?>(
+            valueListenable: widget.uiState.dropperPatch,
+            builder: (context, patch, _) => DropperViewfinder(
+              arm: arm,
+              patch: patch,
+              region: _region,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _moved(Offset local) {
+    setState(() => _cursor = local);
+    if (widget.fitted.contains(local)) _throttle.request(() => _request(local));
+  }
+
+  /// A press picks when it lands on the picture, and puts the tool away when it
+  /// lands anywhere else — the same escape the egui build gave, so a dropper
+  /// armed in error is dismissed by clicking away from the frame.
+  void _pressed(DropperArm arm, Offset local) {
+    if (!widget.fitted.contains(local)) {
+      widget.uiState.disarmDropper();
+      return;
+    }
+    final patch = widget.uiState.dropperPatch.value;
+    // Nothing read yet, or read of a frame the playhead has since left: ask
+    // again rather than committing a value off a picture that is no longer the
+    // one on screen. The next reply lands before the pointer can click twice.
+    if (patch == null ||
+        patch.frame.toInt() != widget.uiState.playheadFrame.value) {
+      _request(local);
+      return;
+    }
+    arm.onPick(sampleFromPatch(patch, _region));
+    widget.uiState.disarmDropper();
+  }
+
+  /// Which pixel of the composition is under `local`, and ask for it.
+  void _request(Offset local) {
+    final size = widget.comp.getSize();
+    final rect = widget.fitted;
+    if (rect.width <= 0 || rect.height <= 0) return;
+    final u = ((local.dx - rect.left) / rect.width).clamp(0.0, 1.0);
+    final v = ((local.dy - rect.top) / rect.height).clamp(0.0, 1.0);
+    widget.uiState.requestDropperSample(
+      (u * size.width).floor().clamp(0, (size.width - 1).clamp(0, 1 << 30)),
+      (v * size.height).floor().clamp(0, (size.height - 1).clamp(0, 1 << 30)),
     );
   }
 }

--- a/flutter_ui/lib/shell/theme_editor_frb.dart
+++ b/flutter_ui/lib/shell/theme_editor_frb.dart
@@ -289,12 +289,15 @@ class _Swatch extends StatelessWidget {
       onTap: () async {
         final box = context.findRenderObject()! as RenderBox;
         final origin = box.localToGlobal(Offset.zero);
-        final picked = await showColourPicker(
+        // Live: the editor's own preview repaints as the colour changes, so
+        // the theme is judged on the interface rather than in a swatch.
+        await showColourPicker(
           context: context,
           position: origin + Offset(0, box.size.height + 4),
           initial: colour,
+          onCommit: onPicked,
+          onPreview: onPicked,
         );
-        if (picked != null) onPicked(picked);
       },
       child: Container(
         width: 56,

--- a/flutter_ui/lib/shell/theme_editor_frb.dart
+++ b/flutter_ui/lib/shell/theme_editor_frb.dart
@@ -294,9 +294,12 @@ class _Swatch extends StatelessWidget {
         await showColourPicker(
           context: context,
           position: origin + Offset(0, box.size.height + 4),
-          initial: colour,
-          onCommit: onPicked,
-          onPreview: onPicked,
+          initial: PickedColour.of(colour),
+          // A theme colour is a display colour: eight bits a channel, and a
+          // hex is the same value said another way.
+          scale: ColourScale.bytes,
+          onCommit: (picked) => onPicked(picked.clipped),
+          onPreview: (picked) => onPicked(picked.clipped),
         );
       },
       child: Container(

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -538,8 +538,19 @@ class CompositionReference {
           that: this, frame: frame, scale: scale, kind: kind, colours: colours);
 
   /// Ask the worker for the pixels under the dropper: a `window × window`
-  /// square of `frame` centred on `(x, y)` in this composition's own pixel
-  /// grid (docs/07 §6.1).
+  /// square of `frame` centred on the point `(u, v)` of the picture, each a
+  /// fraction from 0 to 1 (docs/07 §6.1).
+  ///
+  /// **A fraction, not a pixel, and that is the point.** The picture actually
+  /// read may be a reduced-resolution preview, so its pixel grid is neither
+  /// the composition's nor anything the caller can know in advance. The reply
+  /// says which raster it cut from (`width`, `height`) and where in that
+  /// raster the window's centre landed, and every pixel the caller then names
+  /// is in that same raster. Asking in composition pixels and indexing the
+  /// reply with them is a real bug that has been made unwritable here: with a
+  /// fitted Viewer the two grids differ by the preview scale, and the
+  /// magnifier showed one repeated edge pixel — a flat colour where the
+  /// picture should be.
   ///
   /// A window rather than the nine pixels the magnifier shows, because the
   /// pointer moves and the picture does not: the caller reads its grid out of
@@ -554,8 +565,8 @@ class CompositionReference {
   /// keeps what it had.
   void samplePixels(
           {required BigInt frame,
-          required int x,
-          required int y,
+          required double u,
+          required double v,
           required int window,
           required double scale,
           LayerReference? layer}) =>
@@ -563,8 +574,8 @@ class CompositionReference {
           .crateApiCompositionCompositionReferenceSamplePixels(
               that: this,
               frame: frame,
-              x: x,
-              y: y,
+              u: u,
+              v: v,
               window: window,
               scale: scale,
               layer: layer);

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -537,9 +537,14 @@ class CompositionReference {
       BridgeLib.instance.api.crateApiCompositionCompositionReferenceRenderScope(
           that: this, frame: frame, scale: scale, kind: kind, colours: colours);
 
-  /// Ask the worker for the pixels under the dropper: a `grid × grid` patch of
-  /// `frame` centred on `(x, y)` in this composition's own pixel grid
-  /// (docs/07 §7).
+  /// Ask the worker for the pixels under the dropper: a `window × window`
+  /// square of `frame` centred on `(x, y)` in this composition's own pixel
+  /// grid (docs/07 §6.1).
+  ///
+  /// A window rather than the nine pixels the magnifier shows, because the
+  /// pointer moves and the picture does not: the caller reads its grid out of
+  /// the window it already holds and asks again only when the pointer nears
+  /// the window's edge, the frame changes, or an edit lands.
   ///
   /// `layer` reads that layer **alone** rather than the composite — what a
   /// depth pick does, since a depth pass is usually hidden and so never
@@ -551,7 +556,7 @@ class CompositionReference {
           {required BigInt frame,
           required int x,
           required int y,
-          required int grid,
+          required int window,
           required double scale,
           LayerReference? layer}) =>
       BridgeLib.instance.api
@@ -560,7 +565,7 @@ class CompositionReference {
               frame: frame,
               x: x,
               y: y,
-              grid: grid,
+              window: window,
               scale: scale,
               layer: layer);
 

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -537,6 +537,33 @@ class CompositionReference {
       BridgeLib.instance.api.crateApiCompositionCompositionReferenceRenderScope(
           that: this, frame: frame, scale: scale, kind: kind, colours: colours);
 
+  /// Ask the worker for the pixels under the dropper: a `grid × grid` patch of
+  /// `frame` centred on `(x, y)` in this composition's own pixel grid
+  /// (docs/07 §7).
+  ///
+  /// `layer` reads that layer **alone** rather than the composite — what a
+  /// depth pick does, since a depth pass is usually hidden and so never
+  /// appears in the composite at all. The answer arrives as
+  /// `WorkerResponse::Sampled`, on the stream the frames and traces already
+  /// ride; a frame with nothing to read publishes nothing, and the magnifier
+  /// keeps what it had.
+  void samplePixels(
+          {required BigInt frame,
+          required int x,
+          required int y,
+          required int grid,
+          required double scale,
+          LayerReference? layer}) =>
+      BridgeLib.instance.api
+          .crateApiCompositionCompositionReferenceSamplePixels(
+              that: this,
+              frame: frame,
+              x: x,
+              y: y,
+              grid: grid,
+              scale: scale,
+              layer: layer);
+
   /// Replace the whole marker list — one op, trivially invertible, which is
   /// also how beat detection commits a regenerated set.
   void setMarkers({required List<BridgeMarker> markers}) =>

--- a/flutter_ui/lib/src/rust/api/state.dart
+++ b/flutter_ui/lib/src/rust/api/state.dart
@@ -99,6 +99,11 @@ class BridgeSampledPixels {
 
   /// The raster the window was taken from, and where in it the centre pixel
   /// sits — which is what says where in the picture the window lies.
+  ///
+  /// **This raster, not the composition's.** The picture read may be a
+  /// reduced-resolution preview, so these are the only coordinates in which
+  /// the window can be indexed; a caller holding composition pixels must map
+  /// through `width`/`height` rather than assume they line up.
   final int width;
   final int height;
   final int x;

--- a/flutter_ui/lib/src/rust/api/state.dart
+++ b/flutter_ui/lib/src/rust/api/state.dart
@@ -73,6 +73,75 @@ class BridgeRenderedFrame {
           rgba == other.rgba;
 }
 
+/// The pixels under the dropper: a small square patch of the picture, centred
+/// on the point the pointer is over (docs/07 §7).
+///
+/// Tiny by construction — a 9×9 patch is 324 bytes, against a 1080p frame's
+/// 8 MiB — so it crosses the boundary as plain pixels without breaking the
+/// K-183 rule that *frames* only ever cross as GPU handles. It is the answer to
+/// a question about a few pixels, not a picture to display.
+class BridgeSampledPixels {
+  /// The patch's side length in pixels: `grid × grid`, always odd, so there is
+  /// a single centre pixel.
+  final int grid;
+
+  /// Tightly packed display-ready sRGB RGBA8, `grid * grid * 4`, row-major
+  /// from the top-left of the patch. Edge pixels repeat where the patch runs
+  /// off the picture, so it is always exactly this size.
+  final Uint8List rgba;
+
+  /// The raster the patch was taken from, and where in it the centre pixel
+  /// sits — what the caption reports, and what a position pick writes.
+  final int width;
+  final int height;
+  final int x;
+  final int y;
+
+  /// Which frame this is of, so a patch that arrives after the playhead has
+  /// moved on can be recognised as stale rather than drawn.
+  final BigInt frame;
+
+  /// True when the patch is of one layer rendered alone rather than of the
+  /// composite — a depth pass being read for a focal point, say.
+  final bool layerAlone;
+
+  const BridgeSampledPixels({
+    required this.grid,
+    required this.rgba,
+    required this.width,
+    required this.height,
+    required this.x,
+    required this.y,
+    required this.frame,
+    required this.layerAlone,
+  });
+
+  @override
+  int get hashCode =>
+      grid.hashCode ^
+      rgba.hashCode ^
+      width.hashCode ^
+      height.hashCode ^
+      x.hashCode ^
+      y.hashCode ^
+      frame.hashCode ^
+      layerAlone.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BridgeSampledPixels &&
+          runtimeType == other.runtimeType &&
+          grid == other.grid &&
+          rgba == other.rgba &&
+          width == other.width &&
+          height == other.height &&
+          x == other.x &&
+          y == other.y &&
+          frame == other.frame &&
+          layerAlone == other.layerAlone;
+}
+
 /// One scope trace: a fixed 256x256 RGBA picture the Scopes panel draws.
 ///
 /// The one place pixels still cross the boundary, and small enough not to
@@ -243,6 +312,13 @@ sealed class WorkerResponse with _$WorkerResponse {
   const factory WorkerResponse.scope(
     BridgeScopeTrace field0,
   ) = WorkerResponse_Scope;
+
+  /// The pixels under the dropper — the answer to one
+  /// `CompositionReference::sample_pixels`, riding the same stream for the
+  /// same reason a trace does.
+  const factory WorkerResponse.sampled(
+    BridgeSampledPixels field0,
+  ) = WorkerResponse_Sampled;
 
   /// Playback finished on its own — it ran off the end of the composition.
   ///

--- a/flutter_ui/lib/src/rust/api/state.dart
+++ b/flutter_ui/lib/src/rust/api/state.dart
@@ -73,40 +73,47 @@ class BridgeRenderedFrame {
           rgba == other.rgba;
 }
 
-/// The pixels under the dropper: a small square patch of the picture, centred
-/// on the point the pointer is over (docs/07 §7).
+/// The pixels under the dropper: a square window of the picture, centred on the
+/// point the pointer was over when it was asked for (docs/07 §6.1).
 ///
-/// Tiny by construction — a 9×9 patch is 324 bytes, against a 1080p frame's
-/// 8 MiB — so it crosses the boundary as plain pixels without breaking the
-/// K-183 rule that *frames* only ever cross as GPU handles. It is the answer to
-/// a question about a few pixels, not a picture to display.
+/// **A window rather than the nine pixels the magnifier shows**, so the pointer
+/// can move without asking again: the frontend cuts the magnifier's grid out of
+/// what it already has, and re-reads only when the pointer approaches the edge
+/// of it. That turns a sweep across the picture from a request per mouse move
+/// into a handful.
+///
+/// Small by construction — 129×129 is 66 KiB, against a 1080p frame's 8 MiB —
+/// so it crosses the boundary as plain pixels without breaking the K-183 rule
+/// that *frames* only ever cross as GPU handles. It is the answer to a question
+/// about a few pixels, not a picture to display.
 class BridgeSampledPixels {
-  /// The patch's side length in pixels: `grid × grid`, always odd, so there is
-  /// a single centre pixel.
-  final int grid;
+  /// The window's side length in pixels: `window × window`, always odd, so
+  /// there is a single centre pixel.
+  final int window;
 
-  /// Tightly packed display-ready sRGB RGBA8, `grid * grid * 4`, row-major
-  /// from the top-left of the patch. Edge pixels repeat where the patch runs
-  /// off the picture, so it is always exactly this size.
+  /// Tightly packed display-ready sRGB RGBA8, `window * window * 4`,
+  /// row-major from the top-left of the window. Edge pixels repeat where the
+  /// window runs off the picture, so it is always exactly this size and can
+  /// be indexed without a border case.
   final Uint8List rgba;
 
-  /// The raster the patch was taken from, and where in it the centre pixel
-  /// sits — what the caption reports, and what a position pick writes.
+  /// The raster the window was taken from, and where in it the centre pixel
+  /// sits — which is what says where in the picture the window lies.
   final int width;
   final int height;
   final int x;
   final int y;
 
-  /// Which frame this is of, so a patch that arrives after the playhead has
+  /// Which frame this is of, so a window that arrives after the playhead has
   /// moved on can be recognised as stale rather than drawn.
   final BigInt frame;
 
-  /// True when the patch is of one layer rendered alone rather than of the
+  /// True when the window is of one layer rendered alone rather than of the
   /// composite — a depth pass being read for a focal point, say.
   final bool layerAlone;
 
   const BridgeSampledPixels({
-    required this.grid,
+    required this.window,
     required this.rgba,
     required this.width,
     required this.height,
@@ -118,7 +125,7 @@ class BridgeSampledPixels {
 
   @override
   int get hashCode =>
-      grid.hashCode ^
+      window.hashCode ^
       rgba.hashCode ^
       width.hashCode ^
       height.hashCode ^
@@ -132,7 +139,7 @@ class BridgeSampledPixels {
       identical(this, other) ||
       other is BridgeSampledPixels &&
           runtimeType == other.runtimeType &&
-          grid == other.grid &&
+          window == other.window &&
           rgba == other.rgba &&
           width == other.width &&
           height == other.height &&

--- a/flutter_ui/lib/src/rust/api/state.freezed.dart
+++ b/flutter_ui/lib/src/rust/api/state.freezed.dart
@@ -54,6 +54,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     TResult Function(WorkerResponse_RenderedSharedTexture value)?
         renderedSharedTexture,
     TResult Function(WorkerResponse_Scope value)? scope,
+    TResult Function(WorkerResponse_Sampled value)? sampled,
     TResult Function(WorkerResponse_PlaybackEnded value)? playbackEnded,
     TResult Function(WorkerResponse_CacheFilled value)? cacheFilled,
     required TResult orElse(),
@@ -67,6 +68,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that);
       case WorkerResponse_Scope() when scope != null:
         return scope(_that);
+      case WorkerResponse_Sampled() when sampled != null:
+        return sampled(_that);
       case WorkerResponse_PlaybackEnded() when playbackEnded != null:
         return playbackEnded(_that);
       case WorkerResponse_CacheFilled() when cacheFilled != null:
@@ -96,6 +99,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     required TResult Function(WorkerResponse_RenderedSharedTexture value)
         renderedSharedTexture,
     required TResult Function(WorkerResponse_Scope value) scope,
+    required TResult Function(WorkerResponse_Sampled value) sampled,
     required TResult Function(WorkerResponse_PlaybackEnded value) playbackEnded,
     required TResult Function(WorkerResponse_CacheFilled value) cacheFilled,
   }) {
@@ -107,6 +111,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that);
       case WorkerResponse_Scope():
         return scope(_that);
+      case WorkerResponse_Sampled():
+        return sampled(_that);
       case WorkerResponse_PlaybackEnded():
         return playbackEnded(_that);
       case WorkerResponse_CacheFilled():
@@ -132,6 +138,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     TResult? Function(WorkerResponse_RenderedSharedTexture value)?
         renderedSharedTexture,
     TResult? Function(WorkerResponse_Scope value)? scope,
+    TResult? Function(WorkerResponse_Sampled value)? sampled,
     TResult? Function(WorkerResponse_PlaybackEnded value)? playbackEnded,
     TResult? Function(WorkerResponse_CacheFilled value)? cacheFilled,
   }) {
@@ -144,6 +151,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that);
       case WorkerResponse_Scope() when scope != null:
         return scope(_that);
+      case WorkerResponse_Sampled() when sampled != null:
+        return sampled(_that);
       case WorkerResponse_PlaybackEnded() when playbackEnded != null:
         return playbackEnded(_that);
       case WorkerResponse_CacheFilled() when cacheFilled != null:
@@ -170,6 +179,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     TResult Function(BridgeSharedFrameInfoLinux field0)? renderedDmaBuf,
     TResult Function(BridgeSharedFrameInfo field0)? renderedSharedTexture,
     TResult Function(BridgeScopeTrace field0)? scope,
+    TResult Function(BridgeSampledPixels field0)? sampled,
     TResult Function()? playbackEnded,
     TResult Function()? cacheFilled,
     required TResult orElse(),
@@ -183,6 +193,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that.field0);
       case WorkerResponse_Scope() when scope != null:
         return scope(_that.field0);
+      case WorkerResponse_Sampled() when sampled != null:
+        return sampled(_that.field0);
       case WorkerResponse_PlaybackEnded() when playbackEnded != null:
         return playbackEnded();
       case WorkerResponse_CacheFilled() when cacheFilled != null:
@@ -211,6 +223,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     required TResult Function(BridgeSharedFrameInfo field0)
         renderedSharedTexture,
     required TResult Function(BridgeScopeTrace field0) scope,
+    required TResult Function(BridgeSampledPixels field0) sampled,
     required TResult Function() playbackEnded,
     required TResult Function() cacheFilled,
   }) {
@@ -222,6 +235,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that.field0);
       case WorkerResponse_Scope():
         return scope(_that.field0);
+      case WorkerResponse_Sampled():
+        return sampled(_that.field0);
       case WorkerResponse_PlaybackEnded():
         return playbackEnded();
       case WorkerResponse_CacheFilled():
@@ -246,6 +261,7 @@ extension WorkerResponsePatterns on WorkerResponse {
     TResult? Function(BridgeSharedFrameInfoLinux field0)? renderedDmaBuf,
     TResult? Function(BridgeSharedFrameInfo field0)? renderedSharedTexture,
     TResult? Function(BridgeScopeTrace field0)? scope,
+    TResult? Function(BridgeSampledPixels field0)? sampled,
     TResult? Function()? playbackEnded,
     TResult? Function()? cacheFilled,
   }) {
@@ -258,6 +274,8 @@ extension WorkerResponsePatterns on WorkerResponse {
         return renderedSharedTexture(_that.field0);
       case WorkerResponse_Scope() when scope != null:
         return scope(_that.field0);
+      case WorkerResponse_Sampled() when sampled != null:
+        return sampled(_that.field0);
       case WorkerResponse_PlaybackEnded() when playbackEnded != null:
         return playbackEnded();
       case WorkerResponse_CacheFilled() when cacheFilled != null:
@@ -462,6 +480,71 @@ class _$WorkerResponse_ScopeCopyWithImpl<$Res>
           ? _self.field0
           : field0 // ignore: cast_nullable_to_non_nullable
               as BridgeScopeTrace,
+    ));
+  }
+}
+
+/// @nodoc
+
+class WorkerResponse_Sampled extends WorkerResponse {
+  const WorkerResponse_Sampled(this.field0) : super._();
+
+  final BridgeSampledPixels field0;
+
+  /// Create a copy of WorkerResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WorkerResponse_SampledCopyWith<WorkerResponse_Sampled> get copyWith =>
+      _$WorkerResponse_SampledCopyWithImpl<WorkerResponse_Sampled>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WorkerResponse_Sampled &&
+            (identical(other.field0, field0) || other.field0 == field0));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, field0);
+
+  @override
+  String toString() {
+    return 'WorkerResponse.sampled(field0: $field0)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WorkerResponse_SampledCopyWith<$Res>
+    implements $WorkerResponseCopyWith<$Res> {
+  factory $WorkerResponse_SampledCopyWith(WorkerResponse_Sampled value,
+          $Res Function(WorkerResponse_Sampled) _then) =
+      _$WorkerResponse_SampledCopyWithImpl;
+  @useResult
+  $Res call({BridgeSampledPixels field0});
+}
+
+/// @nodoc
+class _$WorkerResponse_SampledCopyWithImpl<$Res>
+    implements $WorkerResponse_SampledCopyWith<$Res> {
+  _$WorkerResponse_SampledCopyWithImpl(this._self, this._then);
+
+  final WorkerResponse_Sampled _self;
+  final $Res Function(WorkerResponse_Sampled) _then;
+
+  /// Create a copy of WorkerResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? field0 = null,
+  }) {
+    return _then(WorkerResponse_Sampled(
+      null == field0
+          ? _self.field0
+          : field0 // ignore: cast_nullable_to_non_nullable
+              as BridgeSampledPixels,
     ));
   }
 }

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -87,7 +87,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1057667678;
+  int get rustContentHash => 2104535339;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -260,6 +260,15 @@ abstract class BridgeLibApi extends BaseApi {
       required double scale,
       required int kind,
       required List<Uint8List> colours});
+
+  void crateApiCompositionCompositionReferenceSamplePixels(
+      {required CompositionReference that,
+      required BigInt frame,
+      required int x,
+      required int y,
+      required int grid,
+      required double scale,
+      LayerReference? layer});
 
   void crateApiCompositionCompositionReferenceSetMarkers(
       {required CompositionReference that,
@@ -1999,6 +2008,45 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           );
 
   @override
+  void crateApiCompositionCompositionReferenceSamplePixels(
+      {required CompositionReference that,
+      required BigInt frame,
+      required int x,
+      required int y,
+      required int grid,
+      required double scale,
+      LayerReference? layer}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_composition_reference(that, serializer);
+        sse_encode_u_64(frame, serializer);
+        sse_encode_u_32(x, serializer);
+        sse_encode_u_32(y, serializer);
+        sse_encode_u_32(grid, serializer);
+        sse_encode_f_32(scale, serializer);
+        sse_encode_opt_box_autoadd_layer_reference(layer, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta,
+      argValues: [that, frame, x, y, grid, scale, layer],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta =>
+          const TaskConstMeta(
+            debugName: "composition_reference_sample_pixels",
+            argNames: ["that", "frame", "x", "y", "grid", "scale", "layer"],
+          );
+
+  @override
   void crateApiCompositionCompositionReferenceSetMarkers(
       {required CompositionReference that,
       required List<BridgeMarker> markers}) {
@@ -2007,7 +2055,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_list_bridge_marker(markers, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2035,7 +2083,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2065,7 +2113,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2093,7 +2141,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2124,7 +2172,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_export_spec(spec, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2151,7 +2199,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2179,7 +2227,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_rational,
@@ -2204,7 +2252,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2226,7 +2274,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_state,
@@ -2254,7 +2302,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(preset, serializer);
         sse_encode_String(compName, serializer);
         sse_encode_String(template, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_preset,
@@ -2278,7 +2326,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_folder_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -2305,7 +2353,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 62, port: port_);
+            funcId: 63, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_lumit_media_status,
@@ -2332,7 +2380,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 63, port: port_);
+            funcId: 64, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_media_info,
@@ -2359,7 +2407,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2387,7 +2435,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_u_32(maxEdge, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 65, port: port_);
+            funcId: 66, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_rendered_frame,
@@ -2412,7 +2460,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2439,7 +2487,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_box_autoadd_item_reference(item, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2464,7 +2512,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2489,7 +2537,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -2516,7 +2564,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2540,7 +2588,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_conflict,
@@ -2566,7 +2614,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(json, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 72, port: port_);
+            funcId: 73, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2590,7 +2638,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2615,7 +2663,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_keymap_preset(preset, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 74, port: port_);
+            funcId: 75, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2641,7 +2689,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(chord, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -2670,7 +2718,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(action, serializer);
         sse_encode_String(chord, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 76, port: port_);
+            funcId: 77, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2697,7 +2745,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 77, port: port_);
+            funcId: 78, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2721,7 +2769,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(query, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_binding,
@@ -2743,7 +2791,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -2769,7 +2817,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 80, port: port_);
+            funcId: 81, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2794,7 +2842,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2822,7 +2870,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(buckets, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 82, port: port_);
+            funcId: 83, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_audio_peaks,
@@ -2848,7 +2896,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2875,7 +2923,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2900,7 +2948,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2927,7 +2975,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2953,7 +3001,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -2980,7 +3028,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3004,7 +3052,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -3030,7 +3078,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -3056,7 +3104,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_clip,
@@ -3082,7 +3130,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -3109,7 +3157,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_info,
@@ -3135,7 +3183,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_kind,
@@ -3160,7 +3208,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8,
@@ -3186,7 +3234,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_matte,
@@ -3211,7 +3259,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3237,7 +3285,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_Uuid,
@@ -3263,7 +3311,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_retime,
@@ -3289,7 +3337,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -3315,7 +3363,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_item_reference,
@@ -3341,7 +3389,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_span,
@@ -3367,7 +3415,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_switches,
@@ -3393,7 +3441,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_text_document,
@@ -3419,7 +3467,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_transform,
@@ -3445,7 +3493,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_scalar,
@@ -3472,7 +3520,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 107, port: port_);
+            funcId: 108, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3497,7 +3545,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3522,7 +3570,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3549,7 +3597,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3577,7 +3625,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3604,7 +3652,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3631,7 +3679,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_usize(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3662,7 +3710,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_i_64(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3689,7 +3737,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_reveal_kind(kind, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_reveal_groups,
@@ -3716,7 +3764,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3743,7 +3791,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(index, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3770,7 +3818,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(zoom, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3801,7 +3849,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_bool(enabled, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3830,7 +3878,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3857,7 +3905,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_8(label, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3884,7 +3932,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_matte(matte, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3911,7 +3959,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_Uuid(parent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3938,7 +3986,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3966,7 +4014,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_retime_interp(interpolation, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3994,7 +4042,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4021,7 +4069,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bool(allow, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4048,7 +4096,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_f_64(percent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4075,7 +4123,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4105,7 +4153,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_layer_switch(switch_, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4132,7 +4180,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_text_document(document, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4162,7 +4210,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_transform_prop(prop, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4192,7 +4240,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_transform_prop(props, serializer);
         sse_encode_list_bridge_scalar(values, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4219,7 +4267,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4245,7 +4293,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4270,7 +4318,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(project, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_autosave,
@@ -4292,7 +4340,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -4315,7 +4363,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_effect_info,
@@ -4338,7 +4386,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_param_info,
@@ -4361,7 +4409,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_preset_info,
@@ -4383,7 +4431,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -4405,7 +4453,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -4434,7 +4482,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
         sse_encode_u_32(keep, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4460,7 +4508,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -4486,7 +4534,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_history,
@@ -4513,7 +4561,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_footage_reference,
@@ -4539,7 +4587,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4569,7 +4617,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(name, serializer);
         sse_encode_opt_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_composition_reference,
@@ -4595,7 +4643,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4621,7 +4669,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -4646,7 +4694,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4673,7 +4721,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_recovery,
@@ -4701,7 +4749,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 153, port: port_);
+            funcId: 154, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4729,7 +4777,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_StreamSink_worker_response_Sse(onReponse, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4754,7 +4802,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4778,7 +4826,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -4803,7 +4851,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_bridge_scalar(scalar, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -4826,7 +4874,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -4851,7 +4899,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -4876,7 +4924,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_solid_def,
@@ -4903,7 +4951,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
         sse_encode_box_autoadd_bridge_solid_def(definition, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4927,7 +4975,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -4950,7 +4998,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -4973,7 +5021,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_viewer_transport,
@@ -4996,7 +5044,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -5235,6 +5283,13 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeRetime dco_decode_box_autoadd_bridge_retime(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dco_decode_bridge_retime(raw);
+  }
+
+  @protected
+  BridgeSampledPixels dco_decode_box_autoadd_bridge_sampled_pixels(
+      dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_bridge_sampled_pixels(raw);
   }
 
   @protected
@@ -6003,6 +6058,24 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   }
 
   @protected
+  BridgeSampledPixels dco_decode_bridge_sampled_pixels(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 8)
+      throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
+    return BridgeSampledPixels(
+      grid: dco_decode_u_32(arr[0]),
+      rgba: dco_decode_list_prim_u_8_strict(arr[1]),
+      width: dco_decode_u_32(arr[2]),
+      height: dco_decode_u_32(arr[3]),
+      x: dco_decode_u_32(arr[4]),
+      y: dco_decode_u_32(arr[5]),
+      frame: dco_decode_u_64(arr[6]),
+      layerAlone: dco_decode_bool(arr[7]),
+    );
+  }
+
+  @protected
   BridgeScalar dco_decode_bridge_scalar(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     switch (raw[0]) {
@@ -6614,8 +6687,12 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           dco_decode_box_autoadd_bridge_scope_trace(raw[1]),
         );
       case 3:
-        return WorkerResponse_PlaybackEnded();
+        return WorkerResponse_Sampled(
+          dco_decode_box_autoadd_bridge_sampled_pixels(raw[1]),
+        );
       case 4:
+        return WorkerResponse_PlaybackEnded();
+      case 5:
         return WorkerResponse_CacheFilled();
       default:
         throw Exception("unreachable");
@@ -6835,6 +6912,13 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_bridge_retime(deserializer));
+  }
+
+  @protected
+  BridgeSampledPixels sse_decode_box_autoadd_bridge_sampled_pixels(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_bridge_sampled_pixels(deserializer));
   }
 
   @protected
@@ -7580,6 +7664,29 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return BridgeRevealKind.values[inner];
+  }
+
+  @protected
+  BridgeSampledPixels sse_decode_bridge_sampled_pixels(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_grid = sse_decode_u_32(deserializer);
+    var var_rgba = sse_decode_list_prim_u_8_strict(deserializer);
+    var var_width = sse_decode_u_32(deserializer);
+    var var_height = sse_decode_u_32(deserializer);
+    var var_x = sse_decode_u_32(deserializer);
+    var var_y = sse_decode_u_32(deserializer);
+    var var_frame = sse_decode_u_64(deserializer);
+    var var_layerAlone = sse_decode_bool(deserializer);
+    return BridgeSampledPixels(
+        grid: var_grid,
+        rgba: var_rgba,
+        width: var_width,
+        height: var_height,
+        x: var_x,
+        y: var_y,
+        frame: var_frame,
+        layerAlone: var_layerAlone);
   }
 
   @protected
@@ -8402,8 +8509,12 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
             sse_decode_box_autoadd_bridge_scope_trace(deserializer);
         return WorkerResponse_Scope(var_field0);
       case 3:
-        return WorkerResponse_PlaybackEnded();
+        var var_field0 =
+            sse_decode_box_autoadd_bridge_sampled_pixels(deserializer);
+        return WorkerResponse_Sampled(var_field0);
       case 4:
+        return WorkerResponse_PlaybackEnded();
+      case 5:
         return WorkerResponse_CacheFilled();
       default:
         throw UnimplementedError('');
@@ -8641,6 +8752,13 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       BridgeRetime self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_bridge_retime(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bridge_sampled_pixels(self, serializer);
   }
 
   @protected
@@ -9272,6 +9390,20 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       BridgeRevealKind self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.grid, serializer);
+    sse_encode_list_prim_u_8_strict(self.rgba, serializer);
+    sse_encode_u_32(self.width, serializer);
+    sse_encode_u_32(self.height, serializer);
+    sse_encode_u_32(self.x, serializer);
+    sse_encode_u_32(self.y, serializer);
+    sse_encode_u_64(self.frame, serializer);
+    sse_encode_bool(self.layerAlone, serializer);
   }
 
   @protected
@@ -9954,10 +10086,13 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       case WorkerResponse_Scope(field0: final field0):
         sse_encode_i_32(2, serializer);
         sse_encode_box_autoadd_bridge_scope_trace(field0, serializer);
-      case WorkerResponse_PlaybackEnded():
+      case WorkerResponse_Sampled(field0: final field0):
         sse_encode_i_32(3, serializer);
-      case WorkerResponse_CacheFilled():
+        sse_encode_box_autoadd_bridge_sampled_pixels(field0, serializer);
+      case WorkerResponse_PlaybackEnded():
         sse_encode_i_32(4, serializer);
+      case WorkerResponse_CacheFilled():
+        sse_encode_i_32(5, serializer);
     }
   }
 }

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -266,7 +266,7 @@ abstract class BridgeLibApi extends BaseApi {
       required BigInt frame,
       required int x,
       required int y,
-      required int grid,
+      required int window,
       required double scale,
       LayerReference? layer});
 
@@ -2013,7 +2013,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       required BigInt frame,
       required int x,
       required int y,
-      required int grid,
+      required int window,
       required double scale,
       LayerReference? layer}) {
     return handler.executeSync(SyncTask(
@@ -2023,7 +2023,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_64(frame, serializer);
         sse_encode_u_32(x, serializer);
         sse_encode_u_32(y, serializer);
-        sse_encode_u_32(grid, serializer);
+        sse_encode_u_32(window, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_opt_box_autoadd_layer_reference(layer, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
@@ -2034,7 +2034,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
             sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
       ),
       constMeta: kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta,
-      argValues: [that, frame, x, y, grid, scale, layer],
+      argValues: [that, frame, x, y, window, scale, layer],
       apiImpl: this,
     ));
   }
@@ -2043,7 +2043,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       get kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta =>
           const TaskConstMeta(
             debugName: "composition_reference_sample_pixels",
-            argNames: ["that", "frame", "x", "y", "grid", "scale", "layer"],
+            argNames: ["that", "frame", "x", "y", "window", "scale", "layer"],
           );
 
   @override
@@ -6064,7 +6064,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     if (arr.length != 8)
       throw Exception('unexpected arr length: expect 8 but see ${arr.length}');
     return BridgeSampledPixels(
-      grid: dco_decode_u_32(arr[0]),
+      window: dco_decode_u_32(arr[0]),
       rgba: dco_decode_list_prim_u_8_strict(arr[1]),
       width: dco_decode_u_32(arr[2]),
       height: dco_decode_u_32(arr[3]),
@@ -7670,7 +7670,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeSampledPixels sse_decode_bridge_sampled_pixels(
       SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_grid = sse_decode_u_32(deserializer);
+    var var_window = sse_decode_u_32(deserializer);
     var var_rgba = sse_decode_list_prim_u_8_strict(deserializer);
     var var_width = sse_decode_u_32(deserializer);
     var var_height = sse_decode_u_32(deserializer);
@@ -7679,7 +7679,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_frame = sse_decode_u_64(deserializer);
     var var_layerAlone = sse_decode_bool(deserializer);
     return BridgeSampledPixels(
-        grid: var_grid,
+        window: var_window,
         rgba: var_rgba,
         width: var_width,
         height: var_height,
@@ -9396,7 +9396,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   void sse_encode_bridge_sampled_pixels(
       BridgeSampledPixels self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_u_32(self.grid, serializer);
+    sse_encode_u_32(self.window, serializer);
     sse_encode_list_prim_u_8_strict(self.rgba, serializer);
     sse_encode_u_32(self.width, serializer);
     sse_encode_u_32(self.height, serializer);

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -264,8 +264,8 @@ abstract class BridgeLibApi extends BaseApi {
   void crateApiCompositionCompositionReferenceSamplePixels(
       {required CompositionReference that,
       required BigInt frame,
-      required int x,
-      required int y,
+      required double u,
+      required double v,
       required int window,
       required double scale,
       LayerReference? layer});
@@ -2011,8 +2011,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   void crateApiCompositionCompositionReferenceSamplePixels(
       {required CompositionReference that,
       required BigInt frame,
-      required int x,
-      required int y,
+      required double u,
+      required double v,
       required int window,
       required double scale,
       LayerReference? layer}) {
@@ -2021,8 +2021,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_u_64(frame, serializer);
-        sse_encode_u_32(x, serializer);
-        sse_encode_u_32(y, serializer);
+        sse_encode_f_64(u, serializer);
+        sse_encode_f_64(v, serializer);
         sse_encode_u_32(window, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_opt_box_autoadd_layer_reference(layer, serializer);
@@ -2034,7 +2034,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
             sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
       ),
       constMeta: kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta,
-      argValues: [that, frame, x, y, window, scale, layer],
+      argValues: [that, frame, u, v, window, scale, layer],
       apiImpl: this,
     ));
   }
@@ -2043,7 +2043,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       get kCrateApiCompositionCompositionReferenceSamplePixelsConstMeta =>
           const TaskConstMeta(
             debugName: "composition_reference_sample_pixels",
-            argNames: ["that", "frame", "x", "y", "window", "scale", "layer"],
+            argNames: ["that", "frame", "u", "v", "window", "scale", "layer"],
           );
 
   @override

--- a/flutter_ui/lib/src/rust/frb_generated.io.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.io.dart
@@ -159,6 +159,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeRetime dco_decode_box_autoadd_bridge_retime(dynamic raw);
 
   @protected
+  BridgeSampledPixels dco_decode_box_autoadd_bridge_sampled_pixels(dynamic raw);
+
+  @protected
   BridgeScalar dco_decode_box_autoadd_bridge_scalar(dynamic raw);
 
   @protected
@@ -349,6 +352,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeRevealKind dco_decode_bridge_reveal_kind(dynamic raw);
+
+  @protected
+  BridgeSampledPixels dco_decode_bridge_sampled_pixels(dynamic raw);
 
   @protected
   BridgeScalar dco_decode_bridge_scalar(dynamic raw);
@@ -688,6 +694,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  BridgeSampledPixels sse_decode_box_autoadd_bridge_sampled_pixels(
+      SseDeserializer deserializer);
+
+  @protected
   BridgeScalar sse_decode_box_autoadd_bridge_scalar(
       SseDeserializer deserializer);
 
@@ -905,6 +915,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeRevealKind sse_decode_bridge_reveal_kind(SseDeserializer deserializer);
+
+  @protected
+  BridgeSampledPixels sse_decode_bridge_sampled_pixels(
+      SseDeserializer deserializer);
 
   @protected
   BridgeScalar sse_decode_bridge_scalar(SseDeserializer deserializer);
@@ -1277,6 +1291,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       BridgeRetime self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_bridge_scalar(
       BridgeScalar self, SseSerializer serializer);
 
@@ -1519,6 +1537,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_bridge_reveal_kind(
       BridgeRevealKind self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer);
 
   @protected
   void sse_encode_bridge_scalar(BridgeScalar self, SseSerializer serializer);

--- a/flutter_ui/lib/src/rust/frb_generated.web.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.web.dart
@@ -161,6 +161,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeRetime dco_decode_box_autoadd_bridge_retime(dynamic raw);
 
   @protected
+  BridgeSampledPixels dco_decode_box_autoadd_bridge_sampled_pixels(dynamic raw);
+
+  @protected
   BridgeScalar dco_decode_box_autoadd_bridge_scalar(dynamic raw);
 
   @protected
@@ -351,6 +354,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeRevealKind dco_decode_bridge_reveal_kind(dynamic raw);
+
+  @protected
+  BridgeSampledPixels dco_decode_bridge_sampled_pixels(dynamic raw);
 
   @protected
   BridgeScalar dco_decode_bridge_scalar(dynamic raw);
@@ -690,6 +696,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       SseDeserializer deserializer);
 
   @protected
+  BridgeSampledPixels sse_decode_box_autoadd_bridge_sampled_pixels(
+      SseDeserializer deserializer);
+
+  @protected
   BridgeScalar sse_decode_box_autoadd_bridge_scalar(
       SseDeserializer deserializer);
 
@@ -907,6 +917,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeRevealKind sse_decode_bridge_reveal_kind(SseDeserializer deserializer);
+
+  @protected
+  BridgeSampledPixels sse_decode_bridge_sampled_pixels(
+      SseDeserializer deserializer);
 
   @protected
   BridgeScalar sse_decode_bridge_scalar(SseDeserializer deserializer);
@@ -1279,6 +1293,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       BridgeRetime self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_bridge_scalar(
       BridgeScalar self, SseSerializer serializer);
 
@@ -1521,6 +1539,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_bridge_reveal_kind(
       BridgeRevealKind self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_bridge_sampled_pixels(
+      BridgeSampledPixels self, SseSerializer serializer);
 
   @protected
   void sse_encode_bridge_scalar(BridgeScalar self, SseSerializer serializer);

--- a/flutter_ui/lib/state/dropper.dart
+++ b/flutter_ui/lib/state/dropper.dart
@@ -8,10 +8,18 @@
 // point — which is why this file talks about "what is being read" rather than
 // about colour.
 //
+// **Why a window rather than nine pixels.** The engine answers a read with a
+// whole square of the picture — 129 pixels a side — and the magnifier's own 9×9
+// grid is cut out of it here, in Dart. The pointer can then move, and the sample
+// size change, without asking the engine anything at all: a sweep across the
+// picture costs a handful of reads rather than one per mouse move. A new read is
+// needed only when the pointer approaches the window's edge, the playhead moves,
+// an edit lands, or a different layer is being read.
+//
 // Nothing here draws anything or crosses the bridge. It holds the armed state
-// and does the sums on a patch of pixels, so both are testable without a
-// running engine — the widget in widgets/dropper_overlay.dart is the part with
-// pixels on screen.
+// and does the sums on the pixels, so both are testable without a running
+// engine — the widget in widgets/dropper_overlay.dart is the part with pixels
+// on screen.
 
 import 'dart:math' as math;
 
@@ -112,6 +120,40 @@ const List<int> dropperRegions = [1, 3, 5, 7, 9];
 /// region can never exceed what is shown.
 const int dropperGrid = 9;
 
+/// How much of the picture one read brings back: 129 pixels a side, 66 KiB.
+///
+/// Must match the engine's own cap (`worker_thread::MAX_WINDOW`), which clamps
+/// it anyway — the reply says how big it actually is, and nothing here assumes.
+const int dropperWindow = 129;
+
+/// Whether the window in hand still has every pixel the magnifier needs around
+/// `(x, y)` — the comp pixel under the pointer.
+///
+/// The half-grid margin is what makes a read last: the pointer may travel to
+/// within four pixels of the window's edge before another is needed. Edge
+/// repeats mean a window against the picture's border still covers points
+/// beyond it, so no border case is needed here either.
+bool windowCovers(BridgeSampledPixels window, int x, int y) {
+  final half = window.window ~/ 2;
+  final reach = dropperGrid ~/ 2;
+  return (x - reach) >= window.x - half &&
+      (x + reach) <= window.x + half &&
+      (y - reach) >= window.y - half &&
+      (y + reach) <= window.y + half;
+}
+
+/// One pixel of a window, by its position in the picture. Positions outside the
+/// window are clamped to its edge, which is what the window's own edge repeats
+/// already do — so an index can never be out of bounds.
+({int r, int g, int b})? windowPixel(BridgeSampledPixels window, int x, int y) {
+  final half = window.window ~/ 2;
+  final col = (x - (window.x - half)).clamp(0, window.window - 1);
+  final row = (y - (window.y - half)).clamp(0, window.window - 1);
+  final i = (row * window.window + col) * 4;
+  if (i + 2 >= window.rgba.length) return null;
+  return (r: window.rgba[i], g: window.rgba[i + 1], b: window.rgba[i + 2]);
+}
+
 /// The next region up or down the [dropperRegions] ladder. `steps` is signed —
 /// one Shift+scroll notch either way — and the ends hold rather than wrap: a
 /// picker that jumped from 9×9 back to 1×1 on one extra notch would lose the
@@ -143,32 +185,34 @@ int srgbEncode(double linear) {
   return (e * 255).round().clamp(0, 255);
 }
 
-/// Average the centre `region × region` pixels of a patch, and say what they
-/// mean.
+/// Average the `region × region` pixels around `(x, y)` of a window, and say
+/// what they mean.
 ///
-/// The patch itself is always the full [dropperGrid] square — the magnifier
-/// shows every one of those pixels — and the region is the part of it inside
-/// the solid border. A region wider than the patch is clamped rather than read
-/// past the end of.
-DropperSample sampleFromPatch(BridgeSampledPixels patch, int region) {
-  final grid = patch.grid;
-  final n = region.clamp(1, grid);
-  final half = (grid - n) ~/ 2;
+/// `(x, y)` is the pixel under the pointer, in the picture's own grid — not the
+/// window's centre, which is only where the pointer *was* when the window was
+/// read. A region wider than the magnifier's grid is clamped rather than taken.
+DropperSample sampleFromWindow(
+  BridgeSampledPixels window,
+  int region,
+  int x,
+  int y,
+) {
+  final n = region.clamp(1, dropperGrid);
+  final half = (n - 1) ~/ 2;
   var sr = 0.0, sg = 0.0, sb = 0.0;
   var count = 0;
-  for (var y = half; y < half + n; y++) {
-    for (var x = half; x < half + n; x++) {
-      final i = (y * grid + x) * 4;
-      if (i + 2 >= patch.rgba.length) continue;
-      sr += srgbDecode(patch.rgba[i]);
-      sg += srgbDecode(patch.rgba[i + 1]);
-      sb += srgbDecode(patch.rgba[i + 2]);
+  for (var dy = -half; dy <= half; dy++) {
+    for (var dx = -half; dx <= half; dx++) {
+      final px = windowPixel(window, x + dx, y + dy);
+      if (px == null) continue;
+      sr += srgbDecode(px.r);
+      sg += srgbDecode(px.g);
+      sb += srgbDecode(px.b);
       count++;
     }
   }
   if (count == 0) {
-    return DropperSample(
-        r: 0, g: 0, b: 0, depth: 0, x: patch.x, y: patch.y, region: n);
+    return DropperSample(r: 0, g: 0, b: 0, depth: 0, x: x, y: y, region: n);
   }
   final r = sr / count, g = sg / count, b = sb / count;
   return DropperSample(
@@ -178,8 +222,8 @@ DropperSample sampleFromPatch(BridgeSampledPixels patch, int region) {
     // Rec. 709 luma in linear light: a grey depth pass has luma equal to its
     // own value, which is the number the effect reads.
     depth: (0.2126 * r + 0.7152 * g + 0.0722 * b).clamp(0.0, 1.0),
-    x: patch.x,
-    y: patch.y,
+    x: x,
+    y: y,
     region: n,
   );
 }

--- a/flutter_ui/lib/state/dropper.dart
+++ b/flutter_ui/lib/state/dropper.dart
@@ -1,0 +1,185 @@
+// The dropper: what is armed, and the arithmetic on the pixels it reads.
+//
+// **In plain terms.** The dropper is the little pipette beside a parameter.
+// Click it and the tool arms: the Viewer grows a magnifier that follows the
+// pointer and shows the pixels under it, hugely enlarged, and the next click on
+// the picture lifts a value from them. What that value *is* depends on what
+// armed it — a colour for a colour swatch, a depth for a depth-of-field focal
+// point — which is why this file talks about "what is being read" rather than
+// about colour.
+//
+// Nothing here draws anything or crosses the bridge. It holds the armed state
+// and does the sums on a patch of pixels, so both are testable without a
+// running engine — the widget in widgets/dropper_overlay.dart is the part with
+// pixels on screen.
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:lumit_flutter/src/rust/api/layer.dart';
+import 'package:lumit_flutter/src/rust/api/state.dart';
+
+/// What a pick is being read *for*. The magnifier looks the same in every case
+/// — it is the caption and the committed value that differ.
+enum DropperReads {
+  /// The averaged colour of the region, in scene-linear RGB.
+  colour,
+
+  /// A 0–1 depth: the region's luma, read off a depth pass. What the
+  /// depth-of-field Focus takes (docs/08 §3.22).
+  depth,
+
+  /// The pixel's own position in the composition, for an x/y parameter pair.
+  position,
+}
+
+/// One armed dropper: what is being picked, where the pixels come from, and
+/// what to do with the answer.
+///
+/// The commit is a callback rather than a description of the target because the
+/// thing being edited already knows how to edit itself: the parameter row hands
+/// over a closure that writes its own value through the ordinary undoable path.
+/// Naming the target instead would mean re-resolving a layer, an effect and a
+/// parameter index on the far side of the picture, which is the arrangement the
+/// egui build had and the source of its "target has since moved" silence.
+@immutable
+class DropperArm {
+  /// Which control armed it — `fx-<effect>-<param>`, say. Only ever compared,
+  /// so that the button that armed the tool can show itself lit while it is.
+  final String id;
+
+  final DropperReads reads;
+
+  /// What is being picked, for the magnifier's caption: the parameter's own
+  /// name, as the user sees it in the panel ("Key colour", "Focus").
+  final String label;
+
+  /// Read this layer *alone* rather than the composite — a depth pass, which is
+  /// usually hidden and so is nowhere to be seen in the composite. Null samples
+  /// the picture as shown.
+  final LayerReference? sampleLayer;
+
+  /// The name of that layer, so the caption can say where the numbers are
+  /// coming from rather than showing a colour nobody is picking.
+  final String? sampleLayerName;
+
+  /// Write the picked value. Called once, on the click that picks.
+  final void Function(DropperSample sample) onPick;
+
+  const DropperArm({
+    required this.id,
+    required this.reads,
+    required this.label,
+    required this.onPick,
+    this.sampleLayer,
+    this.sampleLayerName,
+  });
+}
+
+/// What one pick lifted off the picture.
+@immutable
+class DropperSample {
+  /// The region's average colour in **scene-linear** RGB, each 0–1 — the space
+  /// a Colour parameter stores, so it is written straight through.
+  final double r, g, b;
+
+  /// The region's average Rec. 709 luma in linear light, 0–1: the depth proxy.
+  final double depth;
+
+  /// Where the centre pixel sits, in the composition's own pixel grid.
+  final int x, y;
+
+  /// How many pixels a side were averaged.
+  final int region;
+
+  const DropperSample({
+    required this.r,
+    required this.g,
+    required this.b,
+    required this.depth,
+    required this.x,
+    required this.y,
+    required this.region,
+  });
+}
+
+/// The sample sizes Shift+scroll steps through (docs/07 §6.1). Odd throughout, so
+/// there is always a single centre pixel; 1 is the default, meaning "this pixel
+/// and no other".
+const List<int> dropperRegions = [1, 3, 5, 7, 9];
+
+/// The magnifier's grid, and so the largest region: nine pixels a side. The
+/// region can never exceed what is shown.
+const int dropperGrid = 9;
+
+/// The next region up or down the [dropperRegions] ladder. `steps` is signed —
+/// one Shift+scroll notch either way — and the ends hold rather than wrap: a
+/// picker that jumped from 9×9 back to 1×1 on one extra notch would lose the
+/// size the user had settled on.
+int nextDropperRegion(int current, int steps) {
+  final at = dropperRegions.indexOf(current);
+  final from = at == -1 ? 0 : at;
+  return dropperRegions[(from + steps).clamp(0, dropperRegions.length - 1)];
+}
+
+/// One sRGB byte as scene-linear light, 0–1 (IEC 61966-2-1).
+///
+/// The patch arrives as display-ready sRGB — the bytes the picture is made of —
+/// and a Colour parameter is scene-linear, so every average is taken *after*
+/// this. Averaging the bytes instead would make a region of one white pixel and
+/// three black ones mid-grey rather than the quarter-light it actually is.
+double srgbDecode(int byte) {
+  final v = byte.clamp(0, 255) / 255.0;
+  return v <= 0.04045 ? v / 12.92 : math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+}
+
+/// Scene-linear light back to an sRGB byte — the inverse of [srgbDecode], for
+/// showing a linear value as a swatch.
+int srgbEncode(double linear) {
+  final v = linear.clamp(0.0, 1.0);
+  final e = v <= 0.0031308
+      ? v * 12.92
+      : 1.055 * math.pow(v, 1 / 2.4).toDouble() - 0.055;
+  return (e * 255).round().clamp(0, 255);
+}
+
+/// Average the centre `region × region` pixels of a patch, and say what they
+/// mean.
+///
+/// The patch itself is always the full [dropperGrid] square — the magnifier
+/// shows every one of those pixels — and the region is the part of it inside
+/// the solid border. A region wider than the patch is clamped rather than read
+/// past the end of.
+DropperSample sampleFromPatch(BridgeSampledPixels patch, int region) {
+  final grid = patch.grid;
+  final n = region.clamp(1, grid);
+  final half = (grid - n) ~/ 2;
+  var sr = 0.0, sg = 0.0, sb = 0.0;
+  var count = 0;
+  for (var y = half; y < half + n; y++) {
+    for (var x = half; x < half + n; x++) {
+      final i = (y * grid + x) * 4;
+      if (i + 2 >= patch.rgba.length) continue;
+      sr += srgbDecode(patch.rgba[i]);
+      sg += srgbDecode(patch.rgba[i + 1]);
+      sb += srgbDecode(patch.rgba[i + 2]);
+      count++;
+    }
+  }
+  if (count == 0) {
+    return DropperSample(
+        r: 0, g: 0, b: 0, depth: 0, x: patch.x, y: patch.y, region: n);
+  }
+  final r = sr / count, g = sg / count, b = sb / count;
+  return DropperSample(
+    r: r,
+    g: g,
+    b: b,
+    // Rec. 709 luma in linear light: a grey depth pass has luma equal to its
+    // own value, which is the number the effect reads.
+    depth: (0.2126 * r + 0.7152 * g + 0.0722 * b).clamp(0.0, 1.0),
+    x: patch.x,
+    y: patch.y,
+    region: n,
+  );
+}

--- a/flutter_ui/lib/state/dropper.dart
+++ b/flutter_ui/lib/state/dropper.dart
@@ -8,6 +8,15 @@
 // point — which is why this file talks about "what is being read" rather than
 // about colour.
 //
+// **Which pixel grid all of this is in.** The engine's reply says which raster
+// it cut from, and that is the only grid the window can be indexed in: the
+// picture read is often a reduced-resolution preview, so its pixels are not the
+// composition's. Every position here is therefore a pixel of the *reply's* own
+// raster, arrived at from a fraction of the picture (which is what the Viewer
+// actually knows: where the pointer is inside the drawn image). Mixing the two
+// grids is what made the magnifier show one repeated edge pixel — a flat colour
+// where the picture should be.
+//
 // **Why a window rather than nine pixels.** The engine answers a read with a
 // whole square of the picture — 129 pixels a side — and the magnifier's own 9×9
 // grid is cut out of it here, in Dart. The pointer can then move, and the sample
@@ -94,7 +103,9 @@ class DropperSample {
   /// The region's average Rec. 709 luma in linear light, 0–1: the depth proxy.
   final double depth;
 
-  /// Where the centre pixel sits, in the composition's own pixel grid.
+  /// Where the centre pixel sits, in the raster the window was read from (the
+  /// reply's `width`/`height`) — which is the composition's own grid only when
+  /// the picture was read at full resolution.
   final int x, y;
 
   /// How many pixels a side were averaged.
@@ -127,7 +138,7 @@ const int dropperGrid = 9;
 const int dropperWindow = 129;
 
 /// Whether the window in hand still has every pixel the magnifier needs around
-/// `(x, y)` — the comp pixel under the pointer.
+/// `(x, y)` — the pixel under the pointer, in the window's own raster.
 ///
 /// The half-grid margin is what makes a read last: the pointer may travel to
 /// within four pixels of the window's edge before another is needed. Edge
@@ -142,13 +153,32 @@ bool windowCovers(BridgeSampledPixels window, int x, int y) {
       (y + reach) <= window.y + half;
 }
 
-/// One pixel of a window, by its position in the picture. Positions outside the
-/// window are clamped to its edge, which is what the window's own edge repeats
-/// already do — so an index can never be out of bounds.
+/// The pixel of the reply's raster at the fraction `(u, v)` of the picture.
+///
+/// The one place a point in the picture becomes a pixel, and it goes through
+/// the reply's **own** `width`/`height` — never the composition's, which is a
+/// different grid whenever the Viewer is showing a reduced-resolution preview.
+(int, int) windowPixelAt(BridgeSampledPixels window, double u, double v) => (
+      (u.clamp(0.0, 1.0) * window.width).floor().clamp(0, window.width - 1),
+      (v.clamp(0.0, 1.0) * window.height).floor().clamp(0, window.height - 1),
+    );
+
+/// One pixel of a window, by its position in the reply's raster, or null when
+/// that position lies outside the window.
+///
+/// **Null rather than clamped to the edge.** The window already carries the
+/// picture's own edge repeats, so a pixel beyond the picture's border is inside
+/// it and answers normally; a position outside the *window* means the caller is
+/// asking in the wrong grid or has outrun what it holds, and a clamp would
+/// answer that with a plausible colour — which is exactly how a whole magnifier
+/// of one repeated edge pixel went unnoticed. Blank cells say it instead.
 ({int r, int g, int b})? windowPixel(BridgeSampledPixels window, int x, int y) {
   final half = window.window ~/ 2;
-  final col = (x - (window.x - half)).clamp(0, window.window - 1);
-  final row = (y - (window.y - half)).clamp(0, window.window - 1);
+  final col = x - (window.x - half);
+  final row = y - (window.y - half);
+  if (col < 0 || row < 0 || col >= window.window || row >= window.window) {
+    return null;
+  }
   final i = (row * window.window + col) * 4;
   if (i + 2 >= window.rgba.length) return null;
   return (r: window.rgba[i], g: window.rgba[i + 1], b: window.rgba[i + 2]);
@@ -188,7 +218,7 @@ int srgbEncode(double linear) {
 /// Average the `region × region` pixels around `(x, y)` of a window, and say
 /// what they mean.
 ///
-/// `(x, y)` is the pixel under the pointer, in the picture's own grid — not the
+/// `(x, y)` is the pixel under the pointer, in the reply's own raster — not the
 /// window's centre, which is only where the pointer *was* when the window was
 /// read. A region wider than the magnifier's grid is clamped rather than taken.
 DropperSample sampleFromWindow(

--- a/flutter_ui/lib/widgets/colour_picker.dart
+++ b/flutter_ui/lib/widgets/colour_picker.dart
@@ -8,6 +8,13 @@
 // bright the colour is, the rainbow strip chooses the hue, and the hex box
 // lets you type or read the exact value.
 //
+// **The numbers are the parameter's own.** A display colour — a theme colour, a
+// solid's swatch — is 8-bit, so its channels read 0–255 and a hex is exact. A
+// scene-linear colour in a float working depth is not: 0–1 is black to white,
+// and a channel is free to go **above** 1 (an HDR tint, a glow overshoot) or
+// below 0 (a lift) as far as the parameter's own declared range allows. So the
+// picker is told which scale it is editing on, and shows the numbers in it.
+//
 // **It applies as you go.** Whatever the picker is showing is what the thing
 // being coloured shows — there is no dialogue standing between choosing a
 // colour and seeing it. A drag previews continuously and settles into one
@@ -110,7 +117,72 @@ String formatHex(Color colour) {
       .toUpperCase();
 }
 
-const double _pickerWidth = 208;
+/// How the picker's three numbers are shown and edited.
+///
+/// Not a cosmetic choice: it is the difference between a colour that *is* eight
+/// bits and one that is a float, and the second cannot be typed at all on a
+/// 0–255 dial.
+enum ColourScale {
+  /// 0–255 integers — a display colour, where a hex is the same value said
+  /// another way. Theme colours and a solid's swatch.
+  bytes,
+
+  /// 0–1 for black to white, as decimals, and free to leave that range where
+  /// the parameter allows it. What a scene-linear colour is in a float working
+  /// depth (fp16 today, docs/06 §3.1): an HDR tint really does sit above 1, and
+  /// clamping it at white in the picker is losing the value.
+  unit,
+}
+
+/// A colour the picker is editing, in the space of whatever it is editing.
+///
+/// Not a `Color`: that is eight bits a channel and cannot hold 2.4, which a
+/// scene-linear HDR tint legitimately is. [clipped] is the same colour as
+/// something to *draw* — every swatch on screen is a display colour, whatever
+/// the numbers behind it say.
+@immutable
+class PickedColour {
+  final double r, g, b;
+
+  const PickedColour(this.r, this.g, this.b);
+
+  PickedColour.of(Color colour)
+      : r = colour.r,
+        g = colour.g,
+        b = colour.b;
+
+  /// The colour as it can be shown: each channel clamped into 0–1. Anything
+  /// outside that is not a colour a screen has.
+  Color get clipped => documentColour(
+        (r.clamp(0.0, 1.0) * 255).round(),
+        (g.clamp(0.0, 1.0) * 255).round(),
+        (b.clamp(0.0, 1.0) * 255).round(),
+        0xff,
+      );
+
+  /// True when a channel lies outside what a screen can show, so the swatch and
+  /// the hex are both standing in for something bigger.
+  bool get outOfGamut => r < 0 || g < 0 || b < 0 || r > 1 || g > 1 || b > 1;
+
+  /// The brightest channel, or 1 — the factor the square and the strip are read
+  /// through, so an over-range colour still has a place on them.
+  double get gain {
+    final peak = math.max(r, math.max(g, b));
+    return peak > 1 ? peak : 1;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is PickedColour && other.r == r && other.g == g && other.b == b;
+
+  @override
+  int get hashCode => Object.hash(r, g, b);
+
+  @override
+  String toString() => 'PickedColour($r, $g, $b)';
+}
+
+const double _pickerWidth = 232;
 const double _squareHeight = 150;
 const double _stripHeight = 16;
 
@@ -124,17 +196,25 @@ const double _stripHeight = 16;
 /// needs nothing at all: what is applied is already what the picker last
 /// settled on. Cancel commits [initial] back.
 ///
+/// [scale] says what the three numbers mean, and [min]/[max] are the
+/// parameter's own declared bounds — a colour that may reach 4 in linear light
+/// says so, and the fields let it. Both are ignored under [ColourScale.bytes],
+/// which is 0–255 by definition.
+///
 /// [presets] draws an optional row of quick swatches inside the popup. The
 /// future completes when the picker closes, for a caller that wants to know.
 Future<void> showColourPicker({
   required BuildContext context,
   required Offset position,
-  required Color initial,
-  required ValueChanged<Color> onCommit,
-  ValueChanged<Color>? onPreview,
+  required PickedColour initial,
+  required ValueChanged<PickedColour> onCommit,
+  ValueChanged<PickedColour>? onPreview,
+  ColourScale scale = ColourScale.bytes,
+  double min = 0,
+  double max = 1,
   List<Color> presets = const [],
 }) async {
-  await showLumitPopup<Color>(
+  await showLumitPopup<PickedColour>(
     context: context,
     position: position,
     builder: (close) => FloatSurface(
@@ -146,6 +226,9 @@ Future<void> showColourPicker({
         child: _ColourPickerBody(
           initial: initial,
           presets: presets,
+          scale: scale,
+          min: min,
+          max: max,
           onPreview: onPreview ?? onCommit,
           onCommit: onCommit,
           onClose: () => close(null),
@@ -156,20 +239,25 @@ Future<void> showColourPicker({
 }
 
 class _ColourPickerBody extends StatefulWidget {
-  final Color initial;
+  final PickedColour initial;
   final List<Color> presets;
+  final ColourScale scale;
+  final double min, max;
 
   /// A tick of a drag: show it, do not record it.
-  final ValueChanged<Color> onPreview;
+  final ValueChanged<PickedColour> onPreview;
 
   /// A change that has settled: one undoable edit.
-  final ValueChanged<Color> onCommit;
+  final ValueChanged<PickedColour> onCommit;
 
   final VoidCallback onClose;
 
   const _ColourPickerBody({
     required this.initial,
     required this.presets,
+    required this.scale,
+    required this.min,
+    required this.max,
     required this.onPreview,
     required this.onCommit,
     required this.onClose,
@@ -180,18 +268,26 @@ class _ColourPickerBody extends StatefulWidget {
 }
 
 class _ColourPickerBodyState extends State<_ColourPickerBody> {
-  late double _h, _s, _v;
+  /// The chosen colour, in the scale being edited. Held as three channels
+  /// rather than as hue/saturation/value because the channels are what the
+  /// parameter stores and what the numbers show — and because a channel above
+  /// white has no place on a 0–1 value dial.
+  late PickedColour _colour;
+
+  /// The hue, carried separately: it is undefined for a grey, so rebuilding it
+  /// from the channels would swing the square to red the moment saturation
+  /// reached zero.
+  late double _hue;
+
   late final TextEditingController _hexController;
   final FocusNode _hexFocus = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    final hsv = rgbToHsv(widget.initial);
-    _h = hsv.$1;
-    _s = hsv.$2;
-    _v = hsv.$3;
-    _hexController = TextEditingController(text: formatHex(widget.initial));
+    _colour = widget.initial;
+    _hue = rgbToHsv(_colour.clipped).$1;
+    _hexController = TextEditingController(text: formatHex(_colour.clipped));
     _hexFocus.addListener(() {
       if (!_hexFocus.hasFocus) _commitHex();
     });
@@ -204,54 +300,95 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
     super.dispose();
   }
 
-  Color get _colour => hsvToRgb(_h, _s, _v);
+  /// The colour as the square and the strip see it: divided down by its own
+  /// peak, so an over-range colour still lands somewhere on them. Editing them
+  /// multiplies that peak back in, so dragging the square about does not
+  /// quietly throw away a value above white.
+  Hsv get _hsv {
+    final g = _colour.gain;
+    final normalised = documentColour(
+      ((_colour.r / g).clamp(0.0, 1.0) * 255).round(),
+      ((_colour.g / g).clamp(0.0, 1.0) * 255).round(),
+      ((_colour.b / g).clamp(0.0, 1.0) * 255).round(),
+      0xff,
+    );
+    final hsv = rgbToHsv(normalised);
+    return (_hue, hsv.$2, hsv.$3);
+  }
 
   /// Push the current colour back into the hex field unless the user is
   /// typing there right now.
   void _syncHex() {
-    if (!_hexFocus.hasFocus) _hexController.text = formatHex(_colour);
+    if (!_hexFocus.hasFocus) _hexController.text = formatHex(_colour.clipped);
   }
 
-  /// Take a new hue/saturation/value and show it everywhere: the square, the
-  /// strip, the numbers, the hex box — and the thing being coloured.
-  void _apply(double h, double s, double v, {required bool settled}) {
+  /// Take a new colour and show it everywhere: the square, the strip, the
+  /// numbers, the hex box — and the thing being coloured.
+  void _apply(PickedColour next, {required bool settled, double? hue}) {
+    final clamped = PickedColour(
+      next.r.clamp(widget.min, widget.max),
+      next.g.clamp(widget.min, widget.max),
+      next.b.clamp(widget.min, widget.max),
+    );
     setState(() {
-      _h = h;
-      _s = s;
-      _v = v;
+      if (hue != null) _hue = hue;
+      _colour = clamped;
       _syncHex();
     });
-    settled ? widget.onCommit(_colour) : widget.onPreview(_colour);
+    settled ? widget.onCommit(clamped) : widget.onPreview(clamped);
   }
 
-  void _setSV(Offset local, {required bool settled}) => _apply(
-        _h,
-        (local.dx / _pickerWidth).clamp(0.0, 1.0),
-        1 - (local.dy / _squareHeight).clamp(0.0, 1.0),
-        settled: settled,
-      );
+  /// A colour chosen on the square or the strip, in 0–1, multiplied back up by
+  /// whatever the colour was over-range by.
+  void _fromHsv(double h, double s, double v, {required bool settled}) {
+    final gain = _colour.gain;
+    final base = hsvToRgb(h, s, v);
+    _apply(
+      PickedColour(base.r * gain, base.g * gain, base.b * gain),
+      settled: settled,
+      hue: h,
+    );
+  }
 
-  void _setHue(Offset local, {required bool settled}) => _apply(
-        (local.dx / _pickerWidth).clamp(0.0, 1.0) * 360,
-        _s,
-        _v,
-        settled: settled,
-      );
+  void _setSV(Offset local, {required bool settled}) {
+    final hsv = _hsv;
+    _fromHsv(
+      hsv.$1,
+      (local.dx / _pickerWidth).clamp(0.0, 1.0),
+      1 - (local.dy / _squareHeight).clamp(0.0, 1.0),
+      settled: settled,
+    );
+  }
 
-  void _setColour(Color colour, {required bool settled}) {
-    final hsv = rgbToHsv(colour);
+  void _setHue(Offset local, {required bool settled}) {
+    final hsv = _hsv;
+    _fromHsv(
+      (local.dx / _pickerWidth).clamp(0.0, 1.0) * 360,
+      hsv.$2,
+      hsv.$3,
+      settled: settled,
+    );
+  }
+
+  /// A colour arriving whole — a preset, a hex, Cancel's restore.
+  void _setColour(PickedColour colour, {required bool settled}) {
+    final hsv = rgbToHsv(colour.clipped);
     // Keep the chosen hue when the pick is a pure grey (hue undefined) — the
     // square would otherwise jump to red the moment saturation reached zero.
-    _apply(hsv.$2 > 0 ? hsv.$1 : _h, hsv.$2, hsv.$3, settled: settled);
+    _apply(colour, settled: settled, hue: hsv.$2 > 0 ? hsv.$1 : _hue);
   }
 
-  /// One of the three channel numbers, 0–255.
-  void _setChannel(int index, int value, {required bool settled}) {
-    final c = _colour;
-    int ch(double f) => (f * 255).round().clamp(0, 255);
-    final rgb = [ch(c.r), ch(c.g), ch(c.b)];
-    rgb[index] = value.clamp(0, 255);
-    _setColour(documentColour(rgb[0], rgb[1], rgb[2], 0xff), settled: settled);
+  /// One of the three channel numbers, in the scale being edited.
+  void _setChannel(int index, double value, {required bool settled}) {
+    final v = widget.scale == ColourScale.bytes ? value / 255 : value;
+    _setColour(
+      PickedColour(
+        index == 0 ? v : _colour.r,
+        index == 1 ? v : _colour.g,
+        index == 2 ? v : _colour.b,
+      ),
+      settled: settled,
+    );
   }
 
   /// Live-parse while the user types: update the pick on a valid hex, leaving
@@ -261,26 +398,31 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
     if (parsed == null) return;
     final hsv = rgbToHsv(parsed);
     setState(() {
-      if (hsv.$2 > 0) _h = hsv.$1;
-      _s = hsv.$2;
-      _v = hsv.$3;
+      if (hsv.$2 > 0) _hue = hsv.$1;
+      _colour = PickedColour.of(parsed);
     });
     widget.onPreview(_colour);
   }
 
   void _commitHex() {
     final parsed = parseHex(_hexController.text);
-    if (parsed != null) _setColour(parsed, settled: true);
+    if (parsed != null) _setColour(PickedColour.of(parsed), settled: true);
     // Snap the field back to the canonical form (or the unchanged colour on a
     // rejected entry).
-    _hexController.text = formatHex(_colour);
+    _hexController.text = formatHex(_colour.clipped);
   }
+
+  /// What a channel field shows: bytes under the 8-bit scale, the value itself
+  /// under the unit one.
+  double _shown(double channel) => widget.scale == ColourScale.bytes
+      ? (channel * 255).roundToDouble()
+      : channel;
 
   @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
-    final c = _colour;
-    int ch(double f) => (f * 255).round().clamp(0, 255);
+    final bytes = widget.scale == ColourScale.bytes;
+    final hsv = _hsv;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -290,11 +432,11 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
         // the pointer immediately.
         Row(
           children: [
-            _channelField(t, 'R', 0, ch(c.r)),
+            _channelField(t, 'R', 0, _colour.r),
             const SizedBox(width: 4),
-            _channelField(t, 'G', 1, ch(c.g)),
+            _channelField(t, 'G', 1, _colour.g),
             const SizedBox(width: 4),
-            _channelField(t, 'B', 2, ch(c.b)),
+            _channelField(t, 'B', 2, _colour.b),
           ],
         ),
         const SizedBox(height: 8),
@@ -310,7 +452,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
             width: _pickerWidth,
             height: _squareHeight,
             child: CustomPaint(
-              painter: _SvSquarePainter(hue: _h, s: _s, v: _v),
+              painter: _SvSquarePainter(hue: hsv.$1, s: hsv.$2, v: hsv.$3),
             ),
           ),
         ),
@@ -326,7 +468,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
           child: SizedBox(
             width: _pickerWidth,
             height: _stripHeight,
-            child: CustomPaint(painter: _HueStripPainter(hue: _h)),
+            child: CustomPaint(painter: _HueStripPainter(hue: hsv.$1)),
           ),
         ),
         const SizedBox(height: 8),
@@ -335,11 +477,22 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
           children: [
             _previewSwatch(t, widget.initial, 'was'),
             const SizedBox(width: 4),
-            _previewSwatch(t, c, 'now'),
+            _previewSwatch(t, _colour, 'now'),
             const Spacer(),
             _hexField(t),
           ],
         ),
+        // A colour outside 0–1 has no screen value and no hex: the swatch and
+        // the box above are both standing in for it, and saying so is better
+        // than letting them read as the truth.
+        if (!bytes && _colour.outOfGamut) ...[
+          const SizedBox(height: 4),
+          Text(
+            'Outside 0–1: the swatch and hex are clipped',
+            key: const Key('colour-picker-clipped'),
+            style: t.small.copyWith(color: t.textMuted),
+          ),
+        ],
         if (widget.presets.isNotEmpty) ...[
           const SizedBox(height: 8),
           _presetRow(t),
@@ -375,34 +528,41 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
     );
   }
 
-  /// One channel: a drag-and-type field over 0–255, labelled by its letter.
-  Widget _channelField(LumitTheme t, String label, int index, int value) =>
-      Expanded(
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(label, style: t.small.copyWith(color: t.textMuted)),
-            const SizedBox(width: 3),
-            Expanded(
-              child: DragValueField(
-                key: Key('colour-picker-$label'),
-                value: value,
-                min: 0,
-                max: 255,
-                speed: 1,
-                fill: t.surface0,
-                onChanged: (v) =>
-                    _setChannel(index, v.round(), settled: true),
-                onChangeLive: (v) =>
-                    _setChannel(index, v.round(), settled: false),
-                onChangeEnd: (v) => _setChannel(index, v.round(), settled: true),
-              ),
+  /// One channel: a drag-and-type field, labelled by its letter, over whatever
+  /// the scale and the parameter's own bounds allow.
+  Widget _channelField(LumitTheme t, String label, int index, double channel) {
+    final bytes = widget.scale == ColourScale.bytes;
+    return Expanded(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: t.small.copyWith(color: t.textMuted)),
+          const SizedBox(width: 3),
+          Expanded(
+            child: DragValueField(
+              key: Key('colour-picker-$label'),
+              value: _shown(channel),
+              min: bytes ? 0 : widget.min,
+              max: bytes ? 255 : widget.max,
+              // A byte steps by one; a unit channel by a hundredth, so black to
+              // white is a comfortable drag rather than a twitch.
+              speed: bytes ? 1 : 0.01,
+              decimals: bytes ? 0 : 3,
+              fill: t.surface0,
+              onChanged: (v) => _setChannel(index, v.toDouble(), settled: true),
+              onChangeLive: (v) =>
+                  _setChannel(index, v.toDouble(), settled: false),
+              onChangeEnd: (v) =>
+                  _setChannel(index, v.toDouble(), settled: true),
             ),
-          ],
-        ),
-      );
+          ),
+        ],
+      ),
+    );
+  }
 
-  Widget _previewSwatch(LumitTheme t, Color colour, String label) => Column(
+  Widget _previewSwatch(LumitTheme t, PickedColour colour, String label) =>
+      Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -410,7 +570,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
             width: 28,
             height: 18,
             decoration: BoxDecoration(
-              color: colour,
+              color: colour.clipped,
               borderRadius: BorderRadius.circular(t.tokens.controlRadius),
               border: Border.all(color: t.hairlineStrong),
             ),
@@ -460,7 +620,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
             Padding(
               padding: const EdgeInsets.only(right: 4),
               child: GestureDetector(
-                onTap: () => _setColour(c, settled: true),
+                onTap: () => _setColour(PickedColour.of(c), settled: true),
                 child: Container(
                   width: 18,
                   height: 18,

--- a/flutter_ui/lib/widgets/colour_picker.dart
+++ b/flutter_ui/lib/widgets/colour_picker.dart
@@ -1,13 +1,24 @@
-// A house HSV colour picker: a saturation/value square, a hue strip, a
-// current-vs-picked preview and a hex field, all kept in sync. Built to the
-// same borderless, theme-driven style as the rest of controls.dart, and shaped
-// so a future "edit every editor colour" submenu can reuse it (checklist F0).
+// A house HSV colour picker, in the shape the egui build had: the red, green
+// and blue numbers across the top, then the saturation/value square, the hue
+// strip, and a hex field, all kept in sync.
 //
-// In plain terms: the big square chooses how vivid and how bright the colour
-// is, the rainbow strip chooses the hue, and the hex box lets you type or read
-// the exact value. Nothing here carries a fixed colour of its own — every
-// swatch is built from the numbers the user is choosing, so the theme rule
-// (only theme.dart may hold colour constants) still holds.
+// **In plain terms.** The three numbers at the top are the colour written out
+// as red, green and blue; each can be dragged sideways or typed into, and the
+// square and strip below follow. The big square chooses how vivid and how
+// bright the colour is, the rainbow strip chooses the hue, and the hex box
+// lets you type or read the exact value.
+//
+// **It applies as you go.** Whatever the picker is showing is what the thing
+// being coloured shows — there is no dialogue standing between choosing a
+// colour and seeing it. A drag previews continuously and settles into one
+// undoable edit when you let go, exactly as dragging a number in Effect
+// controls does; clicking away from the picker closes it and keeps what is
+// applied. Cancel is the way back: it puts the colour the picker opened with
+// back and closes.
+//
+// Nothing here carries a fixed colour of its own — every swatch is built from
+// the numbers the user is choosing, so the theme rule (only theme.dart may hold
+// colour constants) still holds.
 
 import 'dart:math' as math;
 
@@ -103,17 +114,27 @@ const double _pickerWidth = 208;
 const double _squareHeight = 150;
 const double _stripHeight = 16;
 
-/// Open the colour picker near [position], seeded with [initial]. Completes
-/// with the chosen colour on OK, or null when dismissed (outside click or
-/// Escape). [presets] draws an optional row of quick swatches inside the
-/// popup. Applying the result is the caller's job.
-Future<Color?> showColourPicker({
+/// Open the colour picker near [position], seeded with [initial].
+///
+/// **The result is not returned — it is applied as it changes.** [onPreview]
+/// fires continuously while a drag is in flight (the same live-preview tick an
+/// effect row's drag sends) and [onCommit] fires once each time a change
+/// settles: a drag released, a number typed, a preset clicked, Apply pressed.
+/// So closing the picker — by Apply, by Escape, or by clicking away from it —
+/// needs nothing at all: what is applied is already what the picker last
+/// settled on. Cancel commits [initial] back.
+///
+/// [presets] draws an optional row of quick swatches inside the popup. The
+/// future completes when the picker closes, for a caller that wants to know.
+Future<void> showColourPicker({
   required BuildContext context,
   required Offset position,
   required Color initial,
+  required ValueChanged<Color> onCommit,
+  ValueChanged<Color>? onPreview,
   List<Color> presets = const [],
-}) {
-  return showLumitPopup<Color>(
+}) async {
+  await showLumitPopup<Color>(
     context: context,
     position: position,
     builder: (close) => FloatSurface(
@@ -125,7 +146,9 @@ Future<Color?> showColourPicker({
         child: _ColourPickerBody(
           initial: initial,
           presets: presets,
-          onCommit: close,
+          onPreview: onPreview ?? onCommit,
+          onCommit: onCommit,
+          onClose: () => close(null),
         ),
       ),
     ),
@@ -135,12 +158,21 @@ Future<Color?> showColourPicker({
 class _ColourPickerBody extends StatefulWidget {
   final Color initial;
   final List<Color> presets;
-  final ValueChanged<Color?> onCommit;
+
+  /// A tick of a drag: show it, do not record it.
+  final ValueChanged<Color> onPreview;
+
+  /// A change that has settled: one undoable edit.
+  final ValueChanged<Color> onCommit;
+
+  final VoidCallback onClose;
 
   const _ColourPickerBody({
     required this.initial,
     required this.presets,
+    required this.onPreview,
     required this.onCommit,
+    required this.onClose,
   });
 
   @override
@@ -180,30 +212,46 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
     if (!_hexFocus.hasFocus) _hexController.text = formatHex(_colour);
   }
 
-  void _setSV(Offset local) {
+  /// Take a new hue/saturation/value and show it everywhere: the square, the
+  /// strip, the numbers, the hex box — and the thing being coloured.
+  void _apply(double h, double s, double v, {required bool settled}) {
     setState(() {
-      _s = (local.dx / _pickerWidth).clamp(0.0, 1.0);
-      _v = 1 - (local.dy / _squareHeight).clamp(0.0, 1.0);
+      _h = h;
+      _s = s;
+      _v = v;
       _syncHex();
     });
+    settled ? widget.onCommit(_colour) : widget.onPreview(_colour);
   }
 
-  void _setHue(Offset local) {
-    setState(() {
-      _h = (local.dx / _pickerWidth).clamp(0.0, 1.0) * 360;
-      _syncHex();
-    });
-  }
+  void _setSV(Offset local, {required bool settled}) => _apply(
+        _h,
+        (local.dx / _pickerWidth).clamp(0.0, 1.0),
+        1 - (local.dy / _squareHeight).clamp(0.0, 1.0),
+        settled: settled,
+      );
 
-  void _setColour(Color colour) {
+  void _setHue(Offset local, {required bool settled}) => _apply(
+        (local.dx / _pickerWidth).clamp(0.0, 1.0) * 360,
+        _s,
+        _v,
+        settled: settled,
+      );
+
+  void _setColour(Color colour, {required bool settled}) {
     final hsv = rgbToHsv(colour);
-    setState(() {
-      // Keep the chosen hue when the pick is a pure grey (hue undefined).
-      if (hsv.$2 > 0) _h = hsv.$1;
-      _s = hsv.$2;
-      _v = hsv.$3;
-      _syncHex();
-    });
+    // Keep the chosen hue when the pick is a pure grey (hue undefined) — the
+    // square would otherwise jump to red the moment saturation reached zero.
+    _apply(hsv.$2 > 0 ? hsv.$1 : _h, hsv.$2, hsv.$3, settled: settled);
+  }
+
+  /// One of the three channel numbers, 0–255.
+  void _setChannel(int index, int value, {required bool settled}) {
+    final c = _colour;
+    int ch(double f) => (f * 255).round().clamp(0, 255);
+    final rgb = [ch(c.r), ch(c.g), ch(c.b)];
+    rgb[index] = value.clamp(0, 255);
+    _setColour(documentColour(rgb[0], rgb[1], rgb[2], 0xff), settled: settled);
   }
 
   /// Live-parse while the user types: update the pick on a valid hex, leaving
@@ -217,11 +265,12 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
       _s = hsv.$2;
       _v = hsv.$3;
     });
+    widget.onPreview(_colour);
   }
 
   void _commitHex() {
     final parsed = parseHex(_hexController.text);
-    if (parsed != null) _setColour(parsed);
+    if (parsed != null) _setColour(parsed, settled: true);
     // Snap the field back to the canonical form (or the unchanged colour on a
     // rejected entry).
     _hexController.text = formatHex(_colour);
@@ -230,17 +279,33 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
   @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
+    final c = _colour;
+    int ch(double f) => (f * 255).round().clamp(0, 255);
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        // The three numbers, above the graph, as the egui picker had them:
+        // each draggable and typeable, and each one changes the colour under
+        // the pointer immediately.
+        Row(
+          children: [
+            _channelField(t, 'R', 0, ch(c.r)),
+            const SizedBox(width: 4),
+            _channelField(t, 'G', 1, ch(c.g)),
+            const SizedBox(width: 4),
+            _channelField(t, 'B', 2, ch(c.b)),
+          ],
+        ),
+        const SizedBox(height: 8),
         // Saturation / value square.
         GestureDetector(
           key: const Key('colour-picker-square'),
           behavior: HitTestBehavior.opaque,
-          onTapDown: (d) => _setSV(d.localPosition),
-          onPanStart: (d) => _setSV(d.localPosition),
-          onPanUpdate: (d) => _setSV(d.localPosition),
+          onTapDown: (d) => _setSV(d.localPosition, settled: true),
+          onPanStart: (d) => _setSV(d.localPosition, settled: false),
+          onPanUpdate: (d) => _setSV(d.localPosition, settled: false),
+          onPanEnd: (_) => widget.onCommit(_colour),
           child: SizedBox(
             width: _pickerWidth,
             height: _squareHeight,
@@ -254,9 +319,10 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
         GestureDetector(
           key: const Key('colour-picker-strip'),
           behavior: HitTestBehavior.opaque,
-          onTapDown: (d) => _setHue(d.localPosition),
-          onPanStart: (d) => _setHue(d.localPosition),
-          onPanUpdate: (d) => _setHue(d.localPosition),
+          onTapDown: (d) => _setHue(d.localPosition, settled: true),
+          onPanStart: (d) => _setHue(d.localPosition, settled: false),
+          onPanUpdate: (d) => _setHue(d.localPosition, settled: false),
+          onPanEnd: (_) => widget.onCommit(_colour),
           child: SizedBox(
             width: _pickerWidth,
             height: _stripHeight,
@@ -269,7 +335,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
           children: [
             _previewSwatch(t, widget.initial, 'was'),
             const SizedBox(width: 4),
-            _previewSwatch(t, _colour, 'now'),
+            _previewSwatch(t, c, 'now'),
             const Spacer(),
             _hexField(t),
           ],
@@ -283,21 +349,58 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             HouseButton(
+              key: const Key('colour-picker-cancel'),
               small: true,
-              onPressed: () => widget.onCommit(null),
+              onPressed: () {
+                // Put back what the picker opened with: the live changes have
+                // already landed, so closing alone would keep them.
+                widget.onCommit(widget.initial);
+                widget.onClose();
+              },
               child: const Text('Cancel'),
             ),
             const SizedBox(width: 6),
             HouseButton(
+              key: const Key('colour-picker-apply'),
               small: true,
-              onPressed: () => widget.onCommit(_colour),
-              child: const Text('OK'),
+              onPressed: () {
+                widget.onCommit(_colour);
+                widget.onClose();
+              },
+              child: const Text('Apply'),
             ),
           ],
         ),
       ],
     );
   }
+
+  /// One channel: a drag-and-type field over 0–255, labelled by its letter.
+  Widget _channelField(LumitTheme t, String label, int index, int value) =>
+      Expanded(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: t.small.copyWith(color: t.textMuted)),
+            const SizedBox(width: 3),
+            Expanded(
+              child: DragValueField(
+                key: Key('colour-picker-$label'),
+                value: value,
+                min: 0,
+                max: 255,
+                speed: 1,
+                fill: t.surface0,
+                onChanged: (v) =>
+                    _setChannel(index, v.round(), settled: true),
+                onChangeLive: (v) =>
+                    _setChannel(index, v.round(), settled: false),
+                onChangeEnd: (v) => _setChannel(index, v.round(), settled: true),
+              ),
+            ),
+          ],
+        ),
+      );
 
   Widget _previewSwatch(LumitTheme t, Color colour, String label) => Column(
         mainAxisSize: MainAxisSize.min,
@@ -342,7 +445,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
                 selectionColor: t.accent.withValues(alpha: 0.5),
                 // Fold a valid hex into the pick as it is typed, without
                 // reformatting the field mid-entry; focus loss then snaps it
-                // to canonical form.
+                // to canonical form and commits.
                 onChanged: _onHexTyped,
                 onSubmitted: (_) => _commitHex(),
               ),
@@ -357,7 +460,7 @@ class _ColourPickerBodyState extends State<_ColourPickerBody> {
             Padding(
               padding: const EdgeInsets.only(right: 4),
               child: GestureDetector(
-                onTap: () => _setColour(c),
+                onTap: () => _setColour(c, settled: true),
                 child: Container(
                   width: 18,
                   height: 18,

--- a/flutter_ui/lib/widgets/dropper_overlay.dart
+++ b/flutter_ui/lib/widgets/dropper_overlay.dart
@@ -40,26 +40,21 @@ const Size dropperViewfinderSize = Size(
   _cell * dropperGrid + (_pad + _border) * 2 + _barHeight + _pad,
 );
 
-/// Where the viewfinder goes for a pointer at [cursor], kept inside [bounds].
+/// How far below and right of the pointer the viewfinder sits, like the egui
+/// build, so the hand does not cover what is being read.
+const Offset dropperViewfinderOffset = Offset(18, 18);
+
+/// Where the viewfinder goes for a pointer at [cursor].
 ///
-/// Below and right of the pointer, like the egui build, so the hand does not
-/// cover what is being read — but pulled back on screen at the edges, where
-/// "below and right" would put it off the picture entirely.
-Offset dropperViewfinderOrigin(Offset cursor, Rect bounds) {
-  final wanted = cursor + const Offset(18, 18);
-  final maxX = (bounds.right - dropperViewfinderSize.width).clamp(
-    bounds.left,
-    double.infinity,
-  );
-  final maxY = (bounds.bottom - dropperViewfinderSize.height).clamp(
-    bounds.top,
-    double.infinity,
-  );
-  return Offset(
-    wanted.dx.clamp(bounds.left, maxX),
-    wanted.dy.clamp(bounds.top, maxY),
-  );
-}
+/// **The same offset wherever the pointer is, with nothing to push against.**
+/// It used to be pulled back to stay inside the Viewer, which meant that near
+/// the bottom-right corner — where a pick is as likely as anywhere else — the
+/// viewfinder crept over the very pixels being aimed at and then stopped
+/// following the pointer at all. It is drawn in the application's overlay
+/// instead of inside the panel, so it can hang over whatever is beside the
+/// Viewer and needs no clamp; it is simply not shown while the pointer is off
+/// the picture.
+Offset dropperViewfinderOrigin(Offset cursor) => cursor + dropperViewfinderOffset;
 
 /// The viewfinder itself: the grid, the region border, and the info strip.
 class DropperViewfinder extends StatelessWidget {

--- a/flutter_ui/lib/widgets/dropper_overlay.dart
+++ b/flutter_ui/lib/widgets/dropper_overlay.dart
@@ -138,9 +138,15 @@ class DropperViewfinder extends StatelessWidget {
   /// choosing (docs/07 §6.1).
   Widget _infoBar(LumitTheme t) {
     final held = window;
-    final sample = held == null
-        ? null
-        : sampleFromWindow(held, region, centre.$1, centre.$2);
+    // Only read when the window actually holds every pixel the region needs.
+    // A window the pointer has outrun — a frame just changed, a fast sweep —
+    // would otherwise average whatever cells happened to be inside it and show
+    // that as the value about to be picked, which is worse than saying nothing.
+    final covered =
+        held != null && windowCovers(held, centre.$1, centre.$2);
+    final sample = covered
+        ? sampleFromWindow(held, region, centre.$1, centre.$2)
+        : null;
     final round = t.shape == ThemeShape.round;
     return Container(
       decoration: BoxDecoration(

--- a/flutter_ui/lib/widgets/dropper_overlay.dart
+++ b/flutter_ui/lib/widgets/dropper_overlay.dart
@@ -44,17 +44,50 @@ const Size dropperViewfinderSize = Size(
 /// build, so the hand does not cover what is being read.
 const Offset dropperViewfinderOffset = Offset(18, 18);
 
-/// Where the viewfinder goes for a pointer at [cursor].
+/// Where the viewfinder goes for a pointer at [cursor], within [bounds].
 ///
-/// **The same offset wherever the pointer is, with nothing to push against.**
-/// It used to be pulled back to stay inside the Viewer, which meant that near
-/// the bottom-right corner — where a pick is as likely as anywhere else — the
-/// viewfinder crept over the very pixels being aimed at and then stopped
-/// following the pointer at all. It is drawn in the application's overlay
-/// instead of inside the panel, so it can hang over whatever is beside the
-/// Viewer and needs no clamp; it is simply not shown while the pointer is off
-/// the picture.
-Offset dropperViewfinderOrigin(Offset cursor) => cursor + dropperViewfinderOffset;
+/// **The same offset wherever the pointer is on the picture.** It used to be
+/// pulled back to stay inside the *Viewer*, which meant that near the
+/// bottom-right corner — where a pick is as likely as anywhere else — it crept
+/// over the very pixels being aimed at and then stopped following the pointer
+/// at all. It is drawn in the application's overlay instead, so it can hang
+/// over whatever sits beside the Viewer and the panel's edges mean nothing
+/// to it.
+///
+/// **The one edge that does mean something is the window's**, and it is
+/// answered the way a tooltip answers it: rather than sliding, the viewfinder
+/// **flips to the other side of the pointer** on whichever axis would run off —
+/// above instead of below, left instead of right, each axis on its own. The
+/// distance from the pointer is the same either way, so it never creeps over
+/// the pixel being read. Only if flipping does not fit either (a window
+/// narrower than the viewfinder) is it finally clamped, because a magnifier
+/// half off screen is still better than none.
+///
+/// [bounds] is the window's content area, not the display's: an application
+/// cannot paint outside its own window, so a magnifier "off the screen edge"
+/// is one the window would have clipped anyway. Where the window sits on the
+/// display is not something Flutter tells us without a windowing plugin, and
+/// knowing it would not buy a pixel more room.
+Offset dropperViewfinderOrigin(Offset cursor, Rect bounds) {
+  double place(double at, double offset, double size, double low, double high) {
+    // Below / to the right of the pointer, which is where it belongs.
+    final after = at + offset;
+    if (after + size <= high) return after;
+    // It would run off the end: the same distance the other side instead.
+    final before = at - offset - size;
+    if (before >= low) return before;
+    // Neither side fits — a window barely bigger than the viewfinder itself.
+    // Show as much of it as there is rather than nothing.
+    return high - size < low ? low : high - size;
+  }
+
+  return Offset(
+    place(cursor.dx, dropperViewfinderOffset.dx, dropperViewfinderSize.width,
+        bounds.left, bounds.right),
+    place(cursor.dy, dropperViewfinderOffset.dy, dropperViewfinderSize.height,
+        bounds.top, bounds.bottom),
+  );
+}
 
 /// The viewfinder itself: the grid, the region border, and the info strip.
 class DropperViewfinder extends StatelessWidget {

--- a/flutter_ui/lib/widgets/dropper_overlay.dart
+++ b/flutter_ui/lib/widgets/dropper_overlay.dart
@@ -66,8 +66,13 @@ class DropperViewfinder extends StatelessWidget {
   /// What is armed — which decides what the strip below the grid says.
   final DropperArm arm;
 
-  /// The pixels last read back, or null while the first read is in flight.
-  final BridgeSampledPixels? patch;
+  /// The window last read back, or null while the first read is in flight. The
+  /// magnifier's nine-by-nine is cut out of it here, around [centre], so moving
+  /// the pointer inside the window costs nothing at all.
+  final BridgeSampledPixels? window;
+
+  /// The pixel under the pointer, in the picture's own grid.
+  final (int, int) centre;
 
   /// How many pixels a side are being averaged.
   final int region;
@@ -75,7 +80,8 @@ class DropperViewfinder extends StatelessWidget {
   const DropperViewfinder({
     super.key,
     required this.arm,
-    required this.patch,
+    required this.window,
+    required this.centre,
     required this.region,
   });
 
@@ -107,7 +113,8 @@ class DropperViewfinder extends StatelessWidget {
               height: grid,
               child: CustomPaint(
                 painter: _GridPainter(
-                  patch: patch,
+                  window: window,
+                  centre: centre,
                   region: region,
                   hairline: t.hairline,
                   accent: t.accent,
@@ -130,7 +137,10 @@ class DropperViewfinder extends StatelessWidget {
   /// found there, because a swatch of the composite would be a colour nobody is
   /// choosing (docs/07 §6.1).
   Widget _infoBar(LumitTheme t) {
-    final sample = patch == null ? null : sampleFromPatch(patch!, region);
+    final held = window;
+    final sample = held == null
+        ? null
+        : sampleFromWindow(held, region, centre.$1, centre.$2);
     final round = t.shape == ThemeShape.round;
     return Container(
       decoration: BoxDecoration(
@@ -156,7 +166,7 @@ class DropperViewfinder extends StatelessWidget {
           ] else if (sample != null) ...[
             Expanded(
               child: Text(
-                _readingLabel(sample, patch!),
+                _readingLabel(sample, held!),
                 style: t.small.copyWith(color: t.textSecondary),
                 overflow: TextOverflow.ellipsis,
               ),
@@ -182,8 +192,8 @@ class DropperViewfinder extends StatelessWidget {
   /// the reply says whether it is of one layer alone or of the composite, and a
   /// caption that named a layer the pixels did not come from would be worse
   /// than no caption at all.
-  String _readingLabel(DropperSample sample, BridgeSampledPixels patch) {
-    final from = patch.layerAlone
+  String _readingLabel(DropperSample sample, BridgeSampledPixels window) {
+    final from = window.layerAlone
         ? (arm.sampleLayerName ?? 'That layer')
         : 'Composite';
     return switch (arm.reads) {
@@ -207,7 +217,11 @@ class DropperViewfinder extends StatelessWidget {
 /// The nine-by-nine block, its dashed rules, and the border round the region
 /// that will be averaged.
 class _GridPainter extends CustomPainter {
-  final BridgeSampledPixels? patch;
+  final BridgeSampledPixels? window;
+
+  /// The pixel under the pointer: the grid's centre cell, and what the window
+  /// is indexed around.
+  final (int, int) centre;
   final int region;
   final Color hairline;
   final Color accent;
@@ -215,7 +229,8 @@ class _GridPainter extends CustomPainter {
   final double regionRadius;
 
   const _GridPainter({
-    required this.patch,
+    required this.window,
+    required this.centre,
     required this.region,
     required this.hairline,
     required this.accent,
@@ -226,7 +241,7 @@ class _GridPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final cell = size.width / dropperGrid;
-    final held = patch;
+    final held = window;
 
     // The pixels. Before the first read lands there is nothing to show, so the
     // grid draws as an empty surface rather than as black — which would look
@@ -263,19 +278,15 @@ class _GridPainter extends CustomPainter {
     );
   }
 
-  /// The patch's pixel at `(x, y)`, or null when there is no patch to read.
-  Color? _pixel(BridgeSampledPixels? patch, int x, int y) {
-    if (patch == null) return null;
-    // A patch smaller than the magnifier's grid (a capped or older reply) is
-    // centred rather than stretched: the centre cell must stay the pixel under
-    // the pointer whatever arrives.
-    final offset = (dropperGrid - patch.grid) ~/ 2;
-    final px = x - offset, py = y - offset;
-    if (px < 0 || py < 0 || px >= patch.grid || py >= patch.grid) return null;
-    final i = (py * patch.grid + px) * 4;
-    if (i + 3 >= patch.rgba.length) return null;
-    return documentColour(
-        patch.rgba[i], patch.rgba[i + 1], patch.rgba[i + 2], 0xff);
+  /// The grid cell at `(x, y)` — cut out of the window around the pointer, so
+  /// the centre cell is always the pixel being aimed at. Null when there is no
+  /// window to read yet.
+  Color? _pixel(BridgeSampledPixels? window, int x, int y) {
+    if (window == null) return null;
+    final reach = dropperGrid ~/ 2;
+    final px = windowPixel(window, centre.$1 + x - reach, centre.$2 + y - reach);
+    if (px == null) return null;
+    return documentColour(px.r, px.g, px.b, 0xff);
   }
 
   /// A dashed line, drawn as evenly spaced dots — the same mark the egui
@@ -293,7 +304,8 @@ class _GridPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_GridPainter old) =>
-      old.patch != patch ||
+      old.window != window ||
+      old.centre != centre ||
       old.region != region ||
       old.accent != accent ||
       old.hairline != hairline;

--- a/flutter_ui/lib/widgets/dropper_overlay.dart
+++ b/flutter_ui/lib/widgets/dropper_overlay.dart
@@ -1,0 +1,300 @@
+// The dropper's magnifier: the viewfinder that follows the pointer over the
+// Viewer while a pick is armed.
+//
+// **In plain terms.** It is a little window showing the nine-by-nine block of
+// pixels under the pointer, each one blown up to a square you can actually aim
+// at, with dashed lines between them so you can tell one pixel from the next.
+// A solid border rings the pixels that will actually be taken — just the middle
+// one to start with, and Shift+scroll grows it to 3×3, 5×5, 7×7, 9×9 so a noisy
+// patch averages out instead of grabbing one grainy pixel. Under the grid sits
+// a strip saying what would be picked: the colour and its numbers for a colour
+// pick, or — when the dropper is being used to read something else, like a
+// depth-of-field focal point — the layer those numbers are coming from and the
+// value read off it.
+//
+// Every colour and corner here comes from the theme; the only colours not from
+// it are the sampled pixels themselves, which are the document's (K-004,
+// docs/15 §11).
+
+import 'package:flutter/widgets.dart';
+import 'package:lumit_flutter/src/rust/api/state.dart';
+
+import '../state/dropper.dart';
+import '../theme/theme.dart';
+import 'controls.dart';
+
+/// One magnified pixel's side, and the padding round the grid.
+const double _cell = 13;
+const double _pad = 6;
+const double _barHeight = 20;
+
+/// The hairline round the whole viewfinder. Counted in the size below because
+/// a border is laid out *inside* the box: leaving it out is two pixels the
+/// content does not have, which the grid then overflows by.
+const double _border = 1;
+
+/// The whole viewfinder's size — fixed, so the panel that positions it can keep
+/// it inside the picture without measuring.
+const Size dropperViewfinderSize = Size(
+  _cell * dropperGrid + (_pad + _border) * 2,
+  _cell * dropperGrid + (_pad + _border) * 2 + _barHeight + _pad,
+);
+
+/// Where the viewfinder goes for a pointer at [cursor], kept inside [bounds].
+///
+/// Below and right of the pointer, like the egui build, so the hand does not
+/// cover what is being read — but pulled back on screen at the edges, where
+/// "below and right" would put it off the picture entirely.
+Offset dropperViewfinderOrigin(Offset cursor, Rect bounds) {
+  final wanted = cursor + const Offset(18, 18);
+  final maxX = (bounds.right - dropperViewfinderSize.width).clamp(
+    bounds.left,
+    double.infinity,
+  );
+  final maxY = (bounds.bottom - dropperViewfinderSize.height).clamp(
+    bounds.top,
+    double.infinity,
+  );
+  return Offset(
+    wanted.dx.clamp(bounds.left, maxX),
+    wanted.dy.clamp(bounds.top, maxY),
+  );
+}
+
+/// The viewfinder itself: the grid, the region border, and the info strip.
+class DropperViewfinder extends StatelessWidget {
+  /// What is armed — which decides what the strip below the grid says.
+  final DropperArm arm;
+
+  /// The pixels last read back, or null while the first read is in flight.
+  final BridgeSampledPixels? patch;
+
+  /// How many pixels a side are being averaged.
+  final int region;
+
+  const DropperViewfinder({
+    super.key,
+    required this.arm,
+    required this.patch,
+    required this.region,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    final grid = _cell * dropperGrid;
+    return Container(
+      width: dropperViewfinderSize.width,
+      height: dropperViewfinderSize.height,
+      decoration: BoxDecoration(
+        color: t.surface3,
+        borderRadius: BorderRadius.circular(t.tokens.cardRadius),
+        border: Border.all(color: t.hairlineStrong, width: _border),
+        boxShadow: t.tokens.cardShadow,
+      ),
+      padding: const EdgeInsets.all(_pad),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // The pixels sit behind the panel's own rounded edge rather than
+          // spilling over it, so the corner reads as one shape.
+          ClipRRect(
+            borderRadius: BorderRadius.circular(
+              (t.tokens.cardRadius - _pad).clamp(0.0, _cell),
+            ),
+            child: SizedBox(
+              width: grid,
+              height: grid,
+              child: CustomPaint(
+                painter: _GridPainter(
+                  patch: patch,
+                  region: region,
+                  hairline: t.hairline,
+                  accent: t.accent,
+                  empty: t.surface2,
+                  regionRadius: t.tokens.controlRadius,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: _pad),
+          SizedBox(height: _barHeight, child: _infoBar(t)),
+        ],
+      ),
+    );
+  }
+
+  /// What is about to be picked, said in the terms of whatever armed the
+  /// dropper. A colour pick shows the colour and its numbers; a pick that is
+  /// reading something else names the layer it is reading and the value it
+  /// found there, because a swatch of the composite would be a colour nobody is
+  /// choosing (docs/07 §6.1).
+  Widget _infoBar(LumitTheme t) {
+    final sample = patch == null ? null : sampleFromPatch(patch!, region);
+    final round = t.shape == ThemeShape.round;
+    return Container(
+      decoration: BoxDecoration(
+        color: t.surface2,
+        borderRadius:
+            BorderRadius.circular(round ? _barHeight / 2 : t.tokens.controlRadius),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        children: [
+          if (arm.reads == DropperReads.colour && sample != null) ...[
+            _swatch(t, documentColour(srgbEncode(sample.r), srgbEncode(sample.g),
+                srgbEncode(sample.b), 0xff)),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                '${srgbEncode(sample.r)} ${srgbEncode(sample.g)} '
+                '${srgbEncode(sample.b)}',
+                style: t.mono.copyWith(color: t.textSecondary),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ] else if (sample != null) ...[
+            Expanded(
+              child: Text(
+                _readingLabel(sample, patch!),
+                style: t.small.copyWith(color: t.textSecondary),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ] else
+            Expanded(
+              child: Text(
+                'Reading…',
+                style: t.small.copyWith(color: t.textMuted),
+              ),
+            ),
+          const SizedBox(width: 6),
+          Text('$region×$region', style: t.small.copyWith(color: t.textMuted)),
+        ],
+      ),
+    );
+  }
+
+  /// The line a non-colour pick shows: where the number came from, and what it
+  /// is. Named rather than swatched, so "why is that grey?" never arises.
+  ///
+  /// The source is taken from the *patch* rather than from what was asked for:
+  /// the reply says whether it is of one layer alone or of the composite, and a
+  /// caption that named a layer the pixels did not come from would be worse
+  /// than no caption at all.
+  String _readingLabel(DropperSample sample, BridgeSampledPixels patch) {
+    final from = patch.layerAlone
+        ? (arm.sampleLayerName ?? 'That layer')
+        : 'Composite';
+    return switch (arm.reads) {
+      DropperReads.depth => '$from · ${sample.depth.toStringAsFixed(3)}',
+      DropperReads.position => '${sample.x}, ${sample.y}',
+      DropperReads.colour => '',
+    };
+  }
+
+  Widget _swatch(LumitTheme t, Color colour) => Container(
+        width: 12,
+        height: 12,
+        decoration: BoxDecoration(
+          color: colour,
+          borderRadius: BorderRadius.circular(t.tokens.controlRadius),
+          border: Border.all(color: t.hairlineStrong),
+        ),
+      );
+}
+
+/// The nine-by-nine block, its dashed rules, and the border round the region
+/// that will be averaged.
+class _GridPainter extends CustomPainter {
+  final BridgeSampledPixels? patch;
+  final int region;
+  final Color hairline;
+  final Color accent;
+  final Color empty;
+  final double regionRadius;
+
+  const _GridPainter({
+    required this.patch,
+    required this.region,
+    required this.hairline,
+    required this.accent,
+    required this.empty,
+    required this.regionRadius,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final cell = size.width / dropperGrid;
+    final held = patch;
+
+    // The pixels. Before the first read lands there is nothing to show, so the
+    // grid draws as an empty surface rather than as black — which would look
+    // like a picture of black pixels.
+    for (var y = 0; y < dropperGrid; y++) {
+      for (var x = 0; x < dropperGrid; x++) {
+        final rect = Rect.fromLTWH(x * cell, y * cell, cell, cell);
+        canvas.drawRect(rect, Paint()..color = _pixel(held, x, y) ?? empty);
+      }
+    }
+
+    // Dashed rules between every pair of pixels, so the grid reads as pixels
+    // rather than as a blurry picture.
+    final dash = Paint()
+      ..color = hairline
+      ..strokeWidth = 1;
+    for (var k = 1; k < dropperGrid; k++) {
+      _dashed(canvas, Offset(k * cell, 0), Offset(k * cell, size.height), dash);
+      _dashed(canvas, Offset(0, k * cell), Offset(size.width, k * cell), dash);
+    }
+
+    // The region that will be averaged: solid, so it is unmistakably not one of
+    // the dashed rules. Its corners take the theme's control radius, so it is
+    // rounded under the round shape and square under the sharp one.
+    final n = region.clamp(1, dropperGrid);
+    final from = (dropperGrid - n) / 2 * cell;
+    final box = Rect.fromLTWH(from, from, n * cell, n * cell).deflate(0.8);
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(box, Radius.circular(regionRadius)),
+      Paint()
+        ..color = accent
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.6,
+    );
+  }
+
+  /// The patch's pixel at `(x, y)`, or null when there is no patch to read.
+  Color? _pixel(BridgeSampledPixels? patch, int x, int y) {
+    if (patch == null) return null;
+    // A patch smaller than the magnifier's grid (a capped or older reply) is
+    // centred rather than stretched: the centre cell must stay the pixel under
+    // the pointer whatever arrives.
+    final offset = (dropperGrid - patch.grid) ~/ 2;
+    final px = x - offset, py = y - offset;
+    if (px < 0 || py < 0 || px >= patch.grid || py >= patch.grid) return null;
+    final i = (py * patch.grid + px) * 4;
+    if (i + 3 >= patch.rgba.length) return null;
+    return documentColour(
+        patch.rgba[i], patch.rgba[i + 1], patch.rgba[i + 2], 0xff);
+  }
+
+  /// A dashed line, drawn as evenly spaced dots — the same mark the egui
+  /// magnifier used, and cheap enough to run per rule per frame.
+  void _dashed(Canvas canvas, Offset a, Offset b, Paint paint) {
+    const step = 3.0;
+    final span = b - a;
+    final length = span.distance;
+    if (length < 0.5) return;
+    final dir = span / length;
+    for (var t = 0.0; t <= length; t += step) {
+      canvas.drawCircle(a + dir * t, 0.6, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_GridPainter old) =>
+      old.patch != patch ||
+      old.region != region ||
+      old.accent != accent ||
+      old.hairline != hairline;
+}

--- a/flutter_ui/test/colour_picker_test.dart
+++ b/flutter_ui/test/colour_picker_test.dart
@@ -23,8 +23,8 @@ int b(Color c) => (c.b * 255).round();
 /// The picker no longer *returns* a colour: it applies as it goes, so a test
 /// of it is a test of what it applied and when.
 class _Applied {
-  final List<Color> previews = [];
-  final List<Color> commits = [];
+  final List<PickedColour> previews = [];
+  final List<PickedColour> commits = [];
 }
 
 Widget _harness(void Function(BuildContext) open) => Directionality(
@@ -50,13 +50,21 @@ Widget _harness(void Function(BuildContext) open) => Directionality(
       ),
     );
 
-Future<_Applied> _openPicker(WidgetTester tester,
-    {Color initial = const Color.fromARGB(0xff, 0x80, 0x40, 0x20)}) async {
+Future<_Applied> _openPicker(
+  WidgetTester tester, {
+  PickedColour initial = const PickedColour(0.5019607843, 0.2509803921, 0.1254901960),
+  ColourScale scale = ColourScale.bytes,
+  double min = 0,
+  double max = 1,
+}) async {
   final applied = _Applied();
   await tester.pumpWidget(_harness((context) => showColourPicker(
         context: context,
         position: Offset.zero,
         initial: initial,
+        scale: scale,
+        min: min,
+        max: max,
         onPreview: applied.previews.add,
         onCommit: applied.commits.add,
       )));
@@ -201,7 +209,7 @@ void main() {
     });
 
     testWidgets('Cancel puts back the colour it opened with', (tester) async {
-      const initial = Color.fromARGB(0xff, 0x80, 0x40, 0x20);
+      const initial = PickedColour(0.5, 0.25, 0.125);
       final applied = await _openPicker(tester, initial: initial);
       await tester.tap(find.byKey(const Key('colour-picker-square')));
       await tester.pumpAndSettle();
@@ -225,6 +233,94 @@ void main() {
       expect(find.byKey(const Key('colour-picker-strip')), findsNothing);
       expect(applied.commits.last, chosen,
           reason: 'nothing was rolled back on the way out');
+    });
+  });
+
+  group('the channel scale follows what is being edited', () {
+    /// A display colour is eight bits: 0–255, and a hex is the same value said
+    /// another way.
+    testWidgets('a display colour reads 0–255', (tester) async {
+      await _openPicker(tester, scale: ColourScale.bytes);
+      expect(find.text('128'), findsOneWidget);
+      expect(find.text('64'), findsOneWidget);
+      expect(find.text('32'), findsOneWidget);
+    });
+
+    /// A scene-linear colour in a float working depth is not: 0–1 is black to
+    /// white, shown as decimals.
+    testWidgets('a scene-linear colour reads 0–1', (tester) async {
+      await _openPicker(
+        tester,
+        initial: const PickedColour(0.5, 0.25, 0.125),
+        scale: ColourScale.unit,
+        max: 4,
+      );
+      expect(find.text('0.500'), findsOneWidget);
+      expect(find.text('0.250'), findsOneWidget);
+      expect(find.text('0.125'), findsOneWidget);
+    });
+
+    /// **The HDR case.** A tint whose parameter reaches 4 must be typeable to
+    /// 2.5 — clamping it at white in the picker loses the value the engine
+    /// would happily carry (fp16 goes to 65504).
+    testWidgets('a channel can be typed above 1 when the parameter allows it',
+        (tester) async {
+      final applied = await _openPicker(
+        tester,
+        initial: const PickedColour(0.5, 0.25, 0.125),
+        scale: ColourScale.unit,
+        max: 4,
+      );
+      await tester.tap(find.byKey(const Key('colour-picker-R')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(EditableText).first, '2.5');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(applied.commits.last.r, closeTo(2.5, 1e-9),
+          reason: 'the value reached the document unclamped');
+      // And the picker says the swatch and hex can no longer show it.
+      expect(find.byKey(const Key('colour-picker-clipped')), findsOneWidget);
+    });
+
+    testWidgets("a channel is still held to the parameter's own range",
+        (tester) async {
+      final applied = await _openPicker(
+        tester,
+        initial: const PickedColour(0.5, 0.25, 0.125),
+        scale: ColourScale.unit,
+        max: 4,
+      );
+      await tester.tap(find.byKey(const Key('colour-picker-G')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(EditableText).first, '99');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(applied.commits.last.g, 4, reason: 'clamped at the declared max');
+    });
+
+    /// An over-range colour must survive being dragged about on the square:
+    /// the graph is 0–1, so the picker carries the overshoot as a gain rather
+    /// than throwing it away the moment the pointer touches the square.
+    testWidgets('dragging the square keeps an over-range colour over-range',
+        (tester) async {
+      final applied = await _openPicker(
+        tester,
+        initial: const PickedColour(3, 1.5, 0.75),
+        scale: ColourScale.unit,
+        max: 4,
+      );
+      await tester.tap(find.byKey(const Key('colour-picker-square')));
+      await tester.pumpAndSettle();
+      expect(applied.commits.last.r, greaterThan(1),
+          reason: 'the brightest channel is still above white');
+    });
+
+    /// The clipped note belongs to the float scale only: a 0–255 colour cannot
+    /// leave the gamut, so the line would be noise.
+    testWidgets('a display colour never shows the clipped note', (tester) async {
+      await _openPicker(tester, scale: ColourScale.bytes);
+      expect(find.byKey(const Key('colour-picker-clipped')), findsNothing);
     });
   });
 }

--- a/flutter_ui/test/colour_picker_test.dart
+++ b/flutter_ui/test/colour_picker_test.dart
@@ -1,16 +1,69 @@
-// The colour-picker conversion maths, pinned both ways: an HSV↔RGB table and
-// hex parse/format round-trips (including '#' tolerance and rejection of bad
-// input). These are pure functions, so a drift here would silently miscolour
-// every pick.
+// The colour picker: the conversion maths pinned both ways (an HSV↔RGB table
+// and hex parse/format round-trips, including '#' tolerance and rejection of
+// bad input — pure functions, so a drift here would silently miscolour every
+// pick), and the behaviour the owner asked for — the R/G/B numbers above the
+// graph, each editable, and the colour applying to the document as it changes
+// rather than on a button.
 
 import 'dart:ui';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/widgets/colour_picker.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
 
 int r(Color c) => (c.r * 255).round();
 int g(Color c) => (c.g * 255).round();
 int b(Color c) => (c.b * 255).round();
+
+
+/// A picker opened over an overlay, with what it applied recorded.
+///
+/// The picker no longer *returns* a colour: it applies as it goes, so a test
+/// of it is a test of what it applied and when.
+class _Applied {
+  final List<Color> previews = [];
+  final List<Color> commits = [];
+}
+
+Widget _harness(void Function(BuildContext) open) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: ThemeScope(
+        theme: LumitTheme.dark(),
+        animationLevel: AnimationLevel.none,
+        showTooltips: false,
+        child: Overlay(
+          initialEntries: [
+            OverlayEntry(
+              builder: (context) => Center(
+                child: GestureDetector(
+                  key: const Key('open'),
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => open(context),
+                  child: const SizedBox(width: 40, height: 20),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+Future<_Applied> _openPicker(WidgetTester tester,
+    {Color initial = const Color.fromARGB(0xff, 0x80, 0x40, 0x20)}) async {
+  final applied = _Applied();
+  await tester.pumpWidget(_harness((context) => showColourPicker(
+        context: context,
+        position: Offset.zero,
+        initial: initial,
+        onPreview: applied.previews.add,
+        onCommit: applied.commits.add,
+      )));
+  await tester.tap(find.byKey(const Key('open')));
+  await tester.pumpAndSettle();
+  return applied;
+}
 
 void main() {
   group('hsvToRgb', () {
@@ -99,6 +152,79 @@ void main() {
       for (final s in ['000000', 'FFFFFF', 'E05A72', '1A2B3C', 'FF8800']) {
         expect(formatHex(parseHex(s)!), s);
       }
+    });
+  });
+
+  group('the picker applies as it changes', () {
+    testWidgets('shows R, G and B above the graph, each one editable',
+        (tester) async {
+      await _openPicker(tester);
+      // The three numbers of the colour it opened on, as fields.
+      expect(find.text('128'), findsOneWidget);
+      expect(find.text('64'), findsOneWidget);
+      expect(find.text('32'), findsOneWidget);
+      expect(find.byKey(const Key('colour-picker-R')), findsOneWidget);
+      expect(find.byKey(const Key('colour-picker-G')), findsOneWidget);
+      expect(find.byKey(const Key('colour-picker-B')), findsOneWidget);
+    });
+
+    testWidgets('a typed channel applies immediately and moves the picker',
+        (tester) async {
+      final applied = await _openPicker(tester);
+      await tester.tap(find.byKey(const Key('colour-picker-R')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(EditableText).first, '255');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(applied.commits, isNotEmpty, reason: 'applied without a button');
+      expect((applied.commits.last.r * 255).round(), 255);
+      // The hex field followed the number, so the two cannot disagree.
+      expect(find.text('FF4020'), findsOneWidget);
+    });
+
+    testWidgets('dragging the square previews, and settles on release',
+        (tester) async {
+      final applied = await _openPicker(tester);
+      final square = find.byKey(const Key('colour-picker-square'));
+      final gesture =
+          await tester.startGesture(tester.getCenter(square), kind: PointerDeviceKind.mouse);
+      await gesture.moveBy(const Offset(20, -10));
+      await tester.pump();
+      expect(applied.previews, isNotEmpty,
+          reason: 'the picture follows the pointer');
+      final duringDrag = applied.commits.length;
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(applied.commits.length, duringDrag + 1,
+          reason: 'one settled edit for the whole drag');
+    });
+
+    testWidgets('Cancel puts back the colour it opened with', (tester) async {
+      const initial = Color.fromARGB(0xff, 0x80, 0x40, 0x20);
+      final applied = await _openPicker(tester, initial: initial);
+      await tester.tap(find.byKey(const Key('colour-picker-square')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('colour-picker-cancel')));
+      await tester.pumpAndSettle();
+      expect(applied.commits.last, initial);
+      expect(find.byKey(const Key('colour-picker-square')), findsNothing,
+          reason: 'and closes');
+    });
+
+    testWidgets('clicking away keeps what is applied, and closes',
+        (tester) async {
+      final applied = await _openPicker(tester);
+      await tester.tap(find.byKey(const Key('colour-picker-strip')));
+      await tester.pumpAndSettle();
+      final chosen = applied.commits.last;
+
+      // A press outside the picker: the popup's own barrier.
+      await tester.tapAt(const Offset(700, 500));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('colour-picker-strip')), findsNothing);
+      expect(applied.commits.last, chosen,
+          reason: 'nothing was rolled back on the way out');
     });
   });
 }

--- a/flutter_ui/test/dropper_test.dart
+++ b/flutter_ui/test/dropper_test.dart
@@ -330,19 +330,61 @@ void main() {
       expect(find.text('Reading…'), findsOneWidget);
     });
 
+  group('where it sits', () {
+    // A window with plenty of room, and one with the pointer hard against its
+    // far corner.
+    const window = Rect.fromLTWH(0, 0, 1000, 800);
+    final w = dropperViewfinderSize.width;
+    final h = dropperViewfinderSize.height;
+
     /// **The corner regression.** The viewfinder used to be pulled back to stay
-    /// inside the Viewer, so near the bottom-right corner it crept over the
-    /// very pixels being aimed at and stopped following the pointer. It keeps
-    /// one offset everywhere now — it is drawn in the application's overlay, so
-    /// it has nothing to be pushed back inside — and is simply not shown while
-    /// the pointer is off the picture.
-    test('the viewfinder keeps the same offset from the pointer everywhere',
-        () {
-      expect(dropperViewfinderOrigin(const Offset(100, 100)),
+    /// inside the *Viewer*, so near the bottom-right corner it crept over the
+    /// very pixels being aimed at and stopped following the pointer. It is
+    /// drawn in the application's overlay now, so a panel edge means nothing
+    /// to it: the offset is the same wherever the pointer is on the picture.
+    test('keeps the same offset from the pointer with room to spare', () {
+      expect(dropperViewfinderOrigin(const Offset(100, 100), window),
           const Offset(100, 100) + dropperViewfinderOffset);
-      expect(dropperViewfinderOrigin(const Offset(399, 299)),
-          const Offset(399, 299) + dropperViewfinderOffset);
-      expect(dropperViewfinderOrigin(Offset.zero), dropperViewfinderOffset);
+      expect(dropperViewfinderOrigin(const Offset(700, 500), window),
+          const Offset(700, 500) + dropperViewfinderOffset);
+      expect(dropperViewfinderOrigin(Offset.zero, window),
+          dropperViewfinderOffset);
     });
+
+    /// The window's edge is the one it must answer to — an application cannot
+    /// paint outside its own window. It answers the way a tooltip does: the
+    /// same distance on the *other* side of the pointer, so it never creeps
+    /// over the pixel being read.
+    test('flips to the other side of the pointer at the window edge', () {
+      const at = Offset(990, 790);
+      final origin = dropperViewfinderOrigin(at, window);
+      expect(origin.dx, at.dx - dropperViewfinderOffset.dx - w);
+      expect(origin.dy, at.dy - dropperViewfinderOffset.dy - h);
+      expect(origin.dx + w, lessThanOrEqualTo(window.right));
+      expect(origin.dy + h, lessThanOrEqualTo(window.bottom));
+      // The gap from the pointer is the one it has everywhere else.
+      expect(at.dx - (origin.dx + w), dropperViewfinderOffset.dx);
+      expect(at.dy - (origin.dy + h), dropperViewfinderOffset.dy);
+    });
+
+    test('flips each axis on its own, not both together', () {
+      // Hard against the bottom, plenty of room to the right.
+      final low = dropperViewfinderOrigin(const Offset(100, 790), window);
+      expect(low.dx, 100 + dropperViewfinderOffset.dx, reason: 'still right');
+      expect(low.dy, 790 - dropperViewfinderOffset.dy - h, reason: 'now above');
+
+      // Hard against the right, plenty of room below.
+      final right = dropperViewfinderOrigin(const Offset(990, 100), window);
+      expect(right.dx, 990 - dropperViewfinderOffset.dx - w);
+      expect(right.dy, 100 + dropperViewfinderOffset.dy);
+    });
+
+    test('a window with room for neither side shows what it can', () {
+      const tiny = Rect.fromLTWH(0, 0, 60, 60);
+      final origin = dropperViewfinderOrigin(const Offset(30, 30), tiny);
+      expect(origin, Offset.zero,
+          reason: 'a magnifier half on screen beats none at all');
+    });
+  });
   });
 }

--- a/flutter_ui/test/dropper_test.dart
+++ b/flutter_ui/test/dropper_test.dart
@@ -330,15 +330,19 @@ void main() {
       expect(find.text('Reading…'), findsOneWidget);
     });
 
-    test('the viewfinder is kept inside the picture at every edge', () {
-      const bounds = Rect.fromLTWH(0, 0, 400, 300);
-      // Middle of the picture: below and right of the pointer.
-      expect(dropperViewfinderOrigin(const Offset(100, 100), bounds),
-          const Offset(118, 118));
-      // Bottom-right corner: pulled back so the whole of it stays on screen.
-      final corner = dropperViewfinderOrigin(const Offset(399, 299), bounds);
-      expect(corner.dx + dropperViewfinderSize.width, lessThanOrEqualTo(400));
-      expect(corner.dy + dropperViewfinderSize.height, lessThanOrEqualTo(300));
+    /// **The corner regression.** The viewfinder used to be pulled back to stay
+    /// inside the Viewer, so near the bottom-right corner it crept over the
+    /// very pixels being aimed at and stopped following the pointer. It keeps
+    /// one offset everywhere now — it is drawn in the application's overlay, so
+    /// it has nothing to be pushed back inside — and is simply not shown while
+    /// the pointer is off the picture.
+    test('the viewfinder keeps the same offset from the pointer everywhere',
+        () {
+      expect(dropperViewfinderOrigin(const Offset(100, 100)),
+          const Offset(100, 100) + dropperViewfinderOffset);
+      expect(dropperViewfinderOrigin(const Offset(399, 299)),
+          const Offset(399, 299) + dropperViewfinderOffset);
+      expect(dropperViewfinderOrigin(Offset.zero), dropperViewfinderOffset);
     });
   });
 }

--- a/flutter_ui/test/dropper_test.dart
+++ b/flutter_ui/test/dropper_test.dart
@@ -25,6 +25,8 @@ BridgeSampledPixels windowOf(
   int side = 21,
   int cx = 40,
   int cy = 20,
+  int width = 100,
+  int height = 50,
   bool layerAlone = false,
 }) {
   final bytes = Uint8List(side * side * 4);
@@ -42,8 +44,8 @@ BridgeSampledPixels windowOf(
   return BridgeSampledPixels(
     window: side,
     rgba: bytes,
-    width: 100,
-    height: 50,
+    width: width,
+    height: height,
     x: cx,
     y: cy,
     frame: BigInt.zero,
@@ -123,12 +125,19 @@ void main() {
       expect(sample.r, closeTo(1.0, 1e-9));
     });
 
-    test('a pixel outside the window clamps to its edge rather than throwing',
-        () {
+    /// **The flat-magnifier regression.** A position outside the window is
+    /// answered with nothing, not with the nearest edge pixel. The window
+    /// already carries the picture's own edge repeats, so a pixel past the
+    /// picture's border is *inside* it and answers normally; a position outside
+    /// the window means the caller is asking in the wrong grid, and clamping
+    /// answered that with a plausible colour — which is how a whole magnifier
+    /// of one repeated pixel, looking like a flat average, went unnoticed.
+    test('a position outside the window answers nothing, not its edge', () {
       final w = windowOf((x, y) => [10, 20, 30], side: 11);
-      final px = windowPixel(w, 4000, 4000);
-      expect(px, isNotNull);
-      expect([px!.r, px.g, px.b], [10, 20, 30]);
+      expect(windowPixel(w, 4000, 4000), isNull);
+      expect(windowPixel(w, 40, 20), isNotNull, reason: 'the centre is in it');
+      expect(windowPixel(w, 45, 25), isNotNull, reason: 'and so is its corner');
+      expect(windowPixel(w, 46, 20), isNull, reason: 'one past it is not');
     });
 
     test('depth is Rec. 709 luma in linear light', () {
@@ -164,6 +173,50 @@ void main() {
       expect(reach, greaterThan(50));
       expect(windowCovers(full, 40 + reach, 20), isTrue);
       expect(windowCovers(full, 40 + reach + 1, 20), isFalse);
+    });
+  });
+
+
+  group('which pixel grid a point is in', () {
+    /// **The bug this exists to prevent.** The picture the engine reads is a
+    /// reduced-resolution preview whenever the Viewer is not at 100 %, so its
+    /// pixel grid is NOT the composition's. A point must therefore be turned
+    /// into a pixel through the *reply's* own raster; doing it through the
+    /// composition's put every index outside the window, every cell clamped to
+    /// the same edge pixel, and the magnifier showed a flat colour.
+    test('a point becomes a pixel of the reply raster, not of the comp', () {
+      // A 1920x1080 comp read at half resolution: the reply is 960x540.
+      final half = windowOf((x, y) => [0, 0, 0],
+          side: 129, cx: 480, cy: 270, width: 960, height: 540);
+
+      expect(windowPixelAt(half, 0.5, 0.5), (480, 270),
+          reason: 'the middle of the picture is the middle of THIS raster');
+      // The comp-pixel answer would have been (960, 540) — which is not even
+      // inside the picture, let alone inside the window.
+      expect(windowCovers(half, 960, 540), isFalse);
+      expect(windowCovers(half, 480, 270), isTrue);
+    });
+
+    test('the ends of the picture are its first and last pixel', () {
+      final w = windowOf((x, y) => [0, 0, 0], width: 960, height: 540);
+      expect(windowPixelAt(w, 0, 0), (0, 0));
+      expect(windowPixelAt(w, 1, 1), (959, 539), reason: 'never one past the end');
+      expect(windowPixelAt(w, 2, -1), (959, 0), reason: 'and clamped either way');
+    });
+
+    /// With the grids agreeing again, the magnifier shows nine *different*
+    /// pixels rather than one repeated: the whole complaint.
+    test('the magnifier reads nine distinct pixels across the grid', () {
+      // A vertical stripe every other pixel, in a half-resolution raster.
+      final w = windowOf((x, y) => x.isEven ? [255, 255, 255] : [0, 0, 0],
+          side: 129, cx: 480, cy: 270, width: 960, height: 540);
+      final (cx, cy) = windowPixelAt(w, 0.5, 0.5);
+      final row = [
+        for (var dx = -4; dx <= 4; dx++) windowPixel(w, cx + dx, cy)?.r,
+      ];
+      expect(row.contains(null), isFalse, reason: 'every cell has a pixel');
+      expect(row.toSet().length, 2, reason: 'stripes, not one flat colour');
+      expect(row.first, isNot(row[1]), reason: 'neighbours differ');
     });
   });
 
@@ -242,6 +295,26 @@ void main() {
       )));
       expect(find.textContaining('Composite'), findsOneWidget);
       expect(find.textContaining('Depth pass'), findsNothing);
+    });
+
+    testWidgets('says so when the pointer has outrun the window it holds',
+        (tester) async {
+      final arm = DropperArm(
+        id: 'test',
+        reads: DropperReads.colour,
+        label: 'Key colour',
+        onPick: (_) {},
+      );
+      await tester.pumpWidget(harness(DropperViewfinder(
+        arm: arm,
+        window: windowOf((x, y) => [255, 128, 0], side: 11),
+        // Well outside the 11-wide window centred on (40, 20): a value read
+        // from the cells that happen to be inside it would be a lie.
+        centre: (90, 20),
+        region: 1,
+      )));
+      expect(find.text('Reading…'), findsOneWidget);
+      expect(find.text('255 128 0'), findsNothing);
     });
 
     testWidgets('says so while the first read is still in flight',

--- a/flutter_ui/test/dropper_test.dart
+++ b/flutter_ui/test/dropper_test.dart
@@ -1,0 +1,220 @@
+// The dropper's arithmetic and its viewfinder.
+//
+// The sums matter more than they look: a colour lifted off the picture is
+// written straight into a scene-linear parameter, so an average taken in the
+// wrong space is a wrong colour with nothing on screen to say so. The
+// viewfinder tests pin the two things the owner asked for by eye — nine by
+// nine, and the centre pixel alone until Shift+scroll says otherwise.
+
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/src/rust/api/state.dart';
+import 'package:lumit_flutter/state/dropper.dart';
+import 'package:lumit_flutter/theme/theme.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
+import 'package:lumit_flutter/widgets/dropper_overlay.dart';
+
+/// A 9×9 patch whose pixels are given by `pixel(x, y)` as an RGB triple.
+/// [layerAlone] marks it as a read of one layer on its own, as a depth reply is.
+BridgeSampledPixels patchOf(List<int> Function(int x, int y) pixel,
+    {bool layerAlone = false}) {
+  final bytes = Uint8List(dropperGrid * dropperGrid * 4);
+  for (var y = 0; y < dropperGrid; y++) {
+    for (var x = 0; x < dropperGrid; x++) {
+      final rgb = pixel(x, y);
+      final i = (y * dropperGrid + x) * 4;
+      bytes[i] = rgb[0];
+      bytes[i + 1] = rgb[1];
+      bytes[i + 2] = rgb[2];
+      bytes[i + 3] = 255;
+    }
+  }
+  return BridgeSampledPixels(
+    grid: dropperGrid,
+    rgba: bytes,
+    width: 100,
+    height: 50,
+    x: 7,
+    y: 9,
+    frame: BigInt.zero,
+    layerAlone: layerAlone,
+  );
+}
+
+Widget harness(Widget child) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: ThemeScope(
+        theme: LumitTheme.dark(),
+        animationLevel: AnimationLevel.none,
+        showTooltips: false,
+        child: Center(child: child),
+      ),
+    );
+
+void main() {
+  group('the sample sizes', () {
+    test('start at one pixel and step 1, 3, 5, 7, 9 without wrapping', () {
+      expect(dropperRegions.first, 1, reason: 'the centre pixel alone');
+      expect(dropperRegions, [1, 3, 5, 7, 9]);
+      expect(nextDropperRegion(1, 1), 3);
+      expect(nextDropperRegion(3, 1), 5);
+      expect(nextDropperRegion(9, 1), 9, reason: 'the top holds, never wraps');
+      expect(nextDropperRegion(1, -1), 1, reason: 'and so does the bottom');
+      expect(nextDropperRegion(5, -1), 3);
+    });
+
+    test('every size is odd, so there is always one centre pixel', () {
+      for (final n in dropperRegions) {
+        expect(n.isOdd, isTrue, reason: '$n');
+        expect(n <= dropperGrid, isTrue, reason: 'never wider than the grid');
+      }
+    });
+  });
+
+  group('sampling a patch', () {
+    test('one pixel is that pixel, decoded to scene-linear', () {
+      // Pure red in the middle, black everywhere else.
+      final patch = patchOf((x, y) => x == 4 && y == 4 ? [255, 0, 0] : [0, 0, 0]);
+      final sample = sampleFromPatch(patch, 1);
+      expect(sample.r, closeTo(1.0, 1e-9), reason: 'sRGB 255 is linear 1.0');
+      expect(sample.g, closeTo(0.0, 1e-9));
+      expect(sample.b, closeTo(0.0, 1e-9));
+      expect(sample.region, 1);
+      expect([sample.x, sample.y], [7, 9], reason: 'the pixel it came from');
+    });
+
+    test('a wider region averages in linear light, not in sRGB bytes', () {
+      // The centre pixel white, its eight neighbours black: over 3×3 that is
+      // one ninth of the light, not the byte midpoint a naive average gives.
+      final patch =
+          patchOf((x, y) => x == 4 && y == 4 ? [255, 255, 255] : [0, 0, 0]);
+      final sample = sampleFromPatch(patch, 3);
+      expect(sample.r, closeTo(1 / 9, 1e-9));
+      expect(sample.depth, closeTo(1 / 9, 1e-9));
+    });
+
+    test('the region is the centre of the patch, whatever its size', () {
+      // A left half of white and a right half of black: a 9×9 average is
+      // dominated by the left, a 1×1 read of the centre column is not.
+      final patch = patchOf((x, y) => x < 4 ? [255, 255, 255] : [0, 0, 0]);
+      expect(sampleFromPatch(patch, 1).r, closeTo(0.0, 1e-9),
+          reason: 'the centre pixel is on the black side');
+      expect(sampleFromPatch(patch, 9).r, closeTo(4 / 9, 1e-9));
+    });
+
+    test('a region wider than the patch is clamped rather than read past', () {
+      final patch = patchOf((x, y) => [255, 255, 255]);
+      final sample = sampleFromPatch(patch, 99);
+      expect(sample.region, dropperGrid);
+      expect(sample.r, closeTo(1.0, 1e-9));
+    });
+
+    test('depth is Rec. 709 luma in linear light', () {
+      final green = patchOf((x, y) => [0, 255, 0]);
+      expect(sampleFromPatch(green, 1).depth, closeTo(0.7152, 1e-6));
+      final black = patchOf((x, y) => [0, 0, 0]);
+      expect(sampleFromPatch(black, 1).depth, 0);
+    });
+  });
+
+  group('sRGB conversion', () {
+    test('round-trips every byte', () {
+      for (var b = 0; b <= 255; b++) {
+        expect(srgbEncode(srgbDecode(b)), b, reason: '$b');
+      }
+    });
+
+    test('the ends are exact and the middle is not the byte midpoint', () {
+      expect(srgbDecode(0), 0);
+      expect(srgbDecode(255), closeTo(1.0, 1e-9));
+      expect(srgbDecode(128), lessThan(0.25),
+          reason: 'mid-grey is about a fifth of the light, not half');
+    });
+  });
+
+  group('the viewfinder', () {
+    testWidgets('shows the colour and its numbers for a colour pick',
+        (tester) async {
+      final arm = DropperArm(
+        id: 'test',
+        reads: DropperReads.colour,
+        label: 'Key colour',
+        onPick: (_) {},
+      );
+      await tester.pumpWidget(harness(DropperViewfinder(
+        arm: arm,
+        patch: patchOf((x, y) => [255, 128, 0]),
+        region: 1,
+      )));
+      expect(find.text('255 128 0'), findsOneWidget);
+      expect(find.text('1×1'), findsOneWidget);
+    });
+
+    testWidgets('names the layer it is reading for a pick that is not a colour',
+        (tester) async {
+      final arm = DropperArm(
+        id: 'test',
+        reads: DropperReads.depth,
+        label: 'Focus distance',
+        sampleLayerName: 'Depth pass',
+        onPick: (_) {},
+      );
+      await tester.pumpWidget(harness(DropperViewfinder(
+        arm: arm,
+        patch: patchOf((x, y) => [255, 255, 255], layerAlone: true),
+        region: 3,
+      )));
+      // The layer the numbers come from, and the value — no colour swatch,
+      // because no colour is being chosen.
+      expect(find.textContaining('Depth pass'), findsOneWidget);
+      expect(find.textContaining('1.000'), findsOneWidget);
+      expect(find.text('3×3'), findsOneWidget);
+    });
+
+    testWidgets('says Composite when the pixels are not of that layer alone',
+        (tester) async {
+      final arm = DropperArm(
+        id: 'test',
+        reads: DropperReads.depth,
+        label: 'Focus distance',
+        sampleLayerName: 'Depth pass',
+        onPick: (_) {},
+      );
+      await tester.pumpWidget(harness(DropperViewfinder(
+        arm: arm,
+        // layerAlone false: the reply is of the composite, so naming the layer
+        // would claim the number came from somewhere it did not.
+        patch: patchOf((x, y) => [0, 0, 0]),
+        region: 1,
+      )));
+      expect(find.textContaining('Composite'), findsOneWidget);
+      expect(find.textContaining('Depth pass'), findsNothing);
+    });
+
+    testWidgets('says so while the first read is still in flight',
+        (tester) async {
+      final arm = DropperArm(
+        id: 'test',
+        reads: DropperReads.colour,
+        label: 'Key colour',
+        onPick: (_) {},
+      );
+      await tester.pumpWidget(
+          harness(DropperViewfinder(arm: arm, patch: null, region: 1)));
+      expect(find.text('Reading…'), findsOneWidget);
+    });
+
+    test('the viewfinder is kept inside the picture at every edge', () {
+      const bounds = Rect.fromLTWH(0, 0, 400, 300);
+      // Middle of the picture: below and right of the pointer.
+      expect(dropperViewfinderOrigin(const Offset(100, 100), bounds),
+          const Offset(118, 118));
+      // Bottom-right corner: pulled back so the whole of it stays on screen.
+      final corner = dropperViewfinderOrigin(const Offset(399, 299), bounds);
+      expect(corner.dx + dropperViewfinderSize.width, lessThanOrEqualTo(400));
+      expect(corner.dy + dropperViewfinderSize.height, lessThanOrEqualTo(300));
+    });
+  });
+}

--- a/flutter_ui/test/dropper_test.dart
+++ b/flutter_ui/test/dropper_test.dart
@@ -16,15 +16,23 @@ import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/widgets/controls.dart';
 import 'package:lumit_flutter/widgets/dropper_overlay.dart';
 
-/// A 9×9 patch whose pixels are given by `pixel(x, y)` as an RGB triple.
+/// A window of [side] pixels centred on `(cx, cy)` of the picture, whose pixels
+/// are given by `pixel(x, y)` in the *picture's* own coordinates — so a test can
+/// say "white on the left half" without doing the window arithmetic itself.
 /// [layerAlone] marks it as a read of one layer on its own, as a depth reply is.
-BridgeSampledPixels patchOf(List<int> Function(int x, int y) pixel,
-    {bool layerAlone = false}) {
-  final bytes = Uint8List(dropperGrid * dropperGrid * 4);
-  for (var y = 0; y < dropperGrid; y++) {
-    for (var x = 0; x < dropperGrid; x++) {
-      final rgb = pixel(x, y);
-      final i = (y * dropperGrid + x) * 4;
+BridgeSampledPixels windowOf(
+  List<int> Function(int x, int y) pixel, {
+  int side = 21,
+  int cx = 40,
+  int cy = 20,
+  bool layerAlone = false,
+}) {
+  final bytes = Uint8List(side * side * 4);
+  final half = side ~/ 2;
+  for (var row = 0; row < side; row++) {
+    for (var col = 0; col < side; col++) {
+      final rgb = pixel(cx - half + col, cy - half + row);
+      final i = (row * side + col) * 4;
       bytes[i] = rgb[0];
       bytes[i + 1] = rgb[1];
       bytes[i + 2] = rgb[2];
@@ -32,12 +40,12 @@ BridgeSampledPixels patchOf(List<int> Function(int x, int y) pixel,
     }
   }
   return BridgeSampledPixels(
-    grid: dropperGrid,
+    window: side,
     rgba: bytes,
     width: 100,
     height: 50,
-    x: 7,
-    y: 9,
+    x: cx,
+    y: cy,
     frame: BigInt.zero,
     layerAlone: layerAlone,
   );
@@ -73,49 +81,89 @@ void main() {
     });
   });
 
-  group('sampling a patch', () {
+  group('sampling a window', () {
     test('one pixel is that pixel, decoded to scene-linear', () {
-      // Pure red in the middle, black everywhere else.
-      final patch = patchOf((x, y) => x == 4 && y == 4 ? [255, 0, 0] : [0, 0, 0]);
-      final sample = sampleFromPatch(patch, 1);
+      // Pure red at (40, 20), black everywhere else.
+      final w = windowOf((x, y) => x == 40 && y == 20 ? [255, 0, 0] : [0, 0, 0]);
+      final sample = sampleFromWindow(w, 1, 40, 20);
       expect(sample.r, closeTo(1.0, 1e-9), reason: 'sRGB 255 is linear 1.0');
       expect(sample.g, closeTo(0.0, 1e-9));
       expect(sample.b, closeTo(0.0, 1e-9));
       expect(sample.region, 1);
-      expect([sample.x, sample.y], [7, 9], reason: 'the pixel it came from');
+      expect([sample.x, sample.y], [40, 20], reason: 'the pixel it came from');
     });
 
     test('a wider region averages in linear light, not in sRGB bytes', () {
-      // The centre pixel white, its eight neighbours black: over 3×3 that is
-      // one ninth of the light, not the byte midpoint a naive average gives.
-      final patch =
-          patchOf((x, y) => x == 4 && y == 4 ? [255, 255, 255] : [0, 0, 0]);
-      final sample = sampleFromPatch(patch, 3);
+      // One white pixel among its eight black neighbours: over 3×3 that is one
+      // ninth of the light, not the byte midpoint a naive average gives.
+      final w =
+          windowOf((x, y) => x == 40 && y == 20 ? [255, 255, 255] : [0, 0, 0]);
+      final sample = sampleFromWindow(w, 3, 40, 20);
       expect(sample.r, closeTo(1 / 9, 1e-9));
       expect(sample.depth, closeTo(1 / 9, 1e-9));
     });
 
-    test('the region is the centre of the patch, whatever its size', () {
-      // A left half of white and a right half of black: a 9×9 average is
-      // dominated by the left, a 1×1 read of the centre column is not.
-      final patch = patchOf((x, y) => x < 4 ? [255, 255, 255] : [0, 0, 0]);
-      expect(sampleFromPatch(patch, 1).r, closeTo(0.0, 1e-9),
-          reason: 'the centre pixel is on the black side');
-      expect(sampleFromPatch(patch, 9).r, closeTo(4 / 9, 1e-9));
+    /// **The point of a window.** The magnifier reads it around wherever the
+    /// pointer is *now*, not around where it was when the window was read — so
+    /// moving the pointer inside one costs no engine call and still samples the
+    /// right pixel.
+    test('reads around the pointer, not around the window centre', () {
+      // White left of x = 40, black from there on.
+      final w = windowOf((x, y) => x < 40 ? [255, 255, 255] : [0, 0, 0]);
+      expect(sampleFromWindow(w, 1, 40, 20).r, closeTo(0.0, 1e-9));
+      expect(sampleFromWindow(w, 1, 39, 20).r, closeTo(1.0, 1e-9),
+          reason: 'one pixel left of the centre is on the white side');
+      expect(sampleFromWindow(w, 1, 45, 25).r, closeTo(0.0, 1e-9));
     });
 
-    test('a region wider than the patch is clamped rather than read past', () {
-      final patch = patchOf((x, y) => [255, 255, 255]);
-      final sample = sampleFromPatch(patch, 99);
+    test('a region wider than the magnifier is clamped rather than taken', () {
+      final w = windowOf((x, y) => [255, 255, 255]);
+      final sample = sampleFromWindow(w, 99, 40, 20);
       expect(sample.region, dropperGrid);
       expect(sample.r, closeTo(1.0, 1e-9));
     });
 
+    test('a pixel outside the window clamps to its edge rather than throwing',
+        () {
+      final w = windowOf((x, y) => [10, 20, 30], side: 11);
+      final px = windowPixel(w, 4000, 4000);
+      expect(px, isNotNull);
+      expect([px!.r, px.g, px.b], [10, 20, 30]);
+    });
+
     test('depth is Rec. 709 luma in linear light', () {
-      final green = patchOf((x, y) => [0, 255, 0]);
-      expect(sampleFromPatch(green, 1).depth, closeTo(0.7152, 1e-6));
-      final black = patchOf((x, y) => [0, 0, 0]);
-      expect(sampleFromPatch(black, 1).depth, 0);
+      expect(sampleFromWindow(windowOf((x, y) => [0, 255, 0]), 1, 40, 20).depth,
+          closeTo(0.7152, 1e-6));
+      expect(
+          sampleFromWindow(windowOf((x, y) => [0, 0, 0]), 1, 40, 20).depth, 0);
+    });
+  });
+
+  group('when a window has to be re-read', () {
+    // 21 a side centred on (40, 20): it covers the magnifier's grid anywhere
+    // within ten pixels of that centre, less the four the grid itself reaches.
+    final w = windowOf((x, y) => [0, 0, 0]);
+
+    test('covers the pointer while the whole grid still fits inside it', () {
+      expect(windowCovers(w, 40, 20), isTrue, reason: 'dead centre');
+      expect(windowCovers(w, 46, 26), isTrue);
+      expect(windowCovers(w, 34, 14), isTrue, reason: 'the far corner, just');
+    });
+
+    test('stops covering once the grid would reach past its edge', () {
+      expect(windowCovers(w, 47, 20), isFalse);
+      expect(windowCovers(w, 40, 33), isFalse);
+    });
+
+    /// The whole point of the size: a pointer can travel most of a window
+    /// before another read is needed, so a sweep across the picture is a
+    /// handful of reads rather than one per mouse move.
+    test('a full-size window lasts a long pointer travel', () {
+      final full = windowOf((x, y) => [0, 0, 0], side: dropperWindow);
+      final reach = dropperWindow ~/ 2 - dropperGrid ~/ 2;
+      expect(reach, greaterThan(50));
+      expect(windowCovers(full, 40 + reach, 20), isTrue);
+      expect(windowCovers(full, 40 + reach + 1, 20), isFalse);
     });
   });
 
@@ -145,7 +193,8 @@ void main() {
       );
       await tester.pumpWidget(harness(DropperViewfinder(
         arm: arm,
-        patch: patchOf((x, y) => [255, 128, 0]),
+        window: windowOf((x, y) => [255, 128, 0]),
+        centre: (40, 20),
         region: 1,
       )));
       expect(find.text('255 128 0'), findsOneWidget);
@@ -163,7 +212,8 @@ void main() {
       );
       await tester.pumpWidget(harness(DropperViewfinder(
         arm: arm,
-        patch: patchOf((x, y) => [255, 255, 255], layerAlone: true),
+        window: windowOf((x, y) => [255, 255, 255], layerAlone: true),
+        centre: (40, 20),
         region: 3,
       )));
       // The layer the numbers come from, and the value — no colour swatch,
@@ -186,7 +236,8 @@ void main() {
         arm: arm,
         // layerAlone false: the reply is of the composite, so naming the layer
         // would claim the number came from somewhere it did not.
-        patch: patchOf((x, y) => [0, 0, 0]),
+        window: windowOf((x, y) => [0, 0, 0]),
+        centre: (40, 20),
         region: 1,
       )));
       expect(find.textContaining('Composite'), findsOneWidget);
@@ -201,8 +252,8 @@ void main() {
         label: 'Key colour',
         onPick: (_) {},
       );
-      await tester.pumpWidget(
-          harness(DropperViewfinder(arm: arm, patch: null, region: 1)));
+      await tester.pumpWidget(harness(DropperViewfinder(
+          arm: arm, window: null, centre: (0, 0), region: 1)));
       expect(find.text('Reading…'), findsOneWidget);
     });
 

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -20,12 +20,14 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/panels/viewer_panel_frb.dart';
+import 'package:lumit_flutter/state/dropper.dart';
 import 'package:lumit_flutter/state/settings.dart';
 import 'package:lumit_flutter/src/rust/api/audio.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
 import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
 import 'package:lumit_flutter/src/rust/api/state.dart';
+import 'package:lumit_flutter/widgets/dropper_overlay.dart';
 
 import 'frb_test_support.dart';
 
@@ -57,6 +59,60 @@ void main() {
       ));
       await tester.pump();
     }
+
+    /// **The dropper's magnifier belongs to the pointer being over the
+    /// picture.** Two things it used to get wrong: it appeared the instant the
+    /// tool was armed, sitting where the *previous* pick had left the pointer,
+    /// and it stayed on once the pointer had gone.
+    testWidgets('the magnifier appears only while the pointer is on the picture',
+        (tester) async {
+      final p = withLayer();
+      await mount(tester, p);
+
+      DropperArm arm() => DropperArm(
+            id: 'test',
+            reads: DropperReads.colour,
+            label: 'Key colour',
+            onPick: (_) {},
+          );
+
+      p.uiState.armDropper(arm());
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsNothing,
+          reason: 'armed, but the pointer has not been near the picture');
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+
+      final stage = find.byType(DropperLayer);
+      await gesture.moveTo(tester.getCenter(stage));
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsOneWidget,
+          reason: 'the pointer is on the picture');
+
+      // The pasteboard around the picture is not the picture: a 16:9 comp in
+      // this panel leaves a band top and bottom.
+      await gesture.moveTo(tester.getTopLeft(stage) + const Offset(4, 4));
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsNothing,
+          reason: 'off the picture, there is nothing to magnify');
+
+      // Back on, then disarmed and armed again: the new arm must not inherit
+      // the last one's pointer position.
+      await gesture.moveTo(tester.getCenter(stage));
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsOneWidget);
+
+      p.uiState.disarmDropper();
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsNothing);
+
+      p.uiState.armDropper(arm());
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsNothing,
+          reason: 'a fresh arm starts with the pointer nowhere');
+    });
 
     testWidgets('without a composition it says so', (tester) async {
       final p = freshProject();

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -114,6 +114,50 @@ void main() {
           reason: 'a fresh arm starts with the pointer nowhere');
     });
 
+    /// **The scroll crash.** Scrolling over the Viewer with the dropper armed
+    /// zooms the picture, which relays the panel out under the magnifier. The
+    /// magnifier is in the application's overlay, so working out where to put
+    /// it from render objects *while that rebuild is happening* asserts
+    /// `attached` and takes the whole window red. Its position is worked out
+    /// when the pointer moves instead, and used as a plain number afterwards.
+    testWidgets('scrolling with the dropper armed does not throw',
+        (tester) async {
+      final p = withLayer();
+      await mount(tester, p);
+
+      p.uiState.armDropper(DropperArm(
+        id: 'test',
+        reads: DropperReads.colour,
+        label: 'Key colour',
+        onPick: (_) {},
+      ));
+      await tester.pump();
+
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      final centre = tester.getCenter(find.byType(DropperLayer));
+      await gesture.moveTo(centre);
+      await tester.pump();
+      expect(find.byType(DropperViewfinder), findsOneWidget);
+
+      // An ordinary wheel scroll: the Viewer zooms about the pointer.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: centre, scrollDelta: const Offset(0, -60)),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull, reason: 'zooming under it is fine');
+
+      // And again the other way, with the magnifier still up.
+      await tester.sendEventToBinding(
+        PointerScrollEvent(position: centre, scrollDelta: const Offset(0, 120)),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      expect(find.byType(DropperViewfinder), findsOneWidget,
+          reason: 'and it is still following the pointer');
+    });
+
     testWidgets('without a composition it says so', (tester) async {
       final p = freshProject();
       await tester.pumpWidget(hostPanel(


### PR DESCRIPTION
The two tools the egui build had, back in Flutter and in the shape they
had there.

**The dropper** is a pixel tool, not a colour tool: it is armed from
whatever wants a value at a point, and what it lifts is that thing's
business - a colour for a Colour parameter, a depth for the
depth-of-field focal point. The armed state carries what is being read
and a closure to write it, rather than naming a layer/effect/parameter
index to be re-resolved on the far side of the picture (the egui build's
silent "target has since moved" no-ops).

The magnifier is 9x9 with dashed rules between every pair of pixels and
a solid, theme-rounded border round the pixels actually taken - the
centre pixel alone by default, grown by Shift+scroll through 3x3, 5x5,
7x7, 9x9, odd throughout and never wider than the grid. Shift+scroll no
longer also zooms the Viewer. The strip under the grid says what is
about to be taken in the terms of the thing being picked: the colour and
its numbers for a colour pick, and for anything else the layer the
numbers came from and the value read off it.

A layer pick samples that layer rendered ALONE - a depth pass is nearly
always hidden, so the composite is not the number the effect uses. The
worker solos it on a patched copy of the snapshot (never near `commit`)
and holds one such render against (comp, frame, layer, cache
generation), so dragging the pointer renders once rather than once per
move. `depth_invert` is applied at the pick, so the caption and the
committed value cannot disagree.

Pixels cross as a 9x9 patch - 324 bytes - on the stream the frames and
traces already ride (`sample_pixels` -> `WorkerResponse::Sampled`). This
does not reopen the read-back transport K-183 deleted: the cap is
enforced engine-side in `cut_patch`, and a patch is a reading about a
few pixels, not a picture. It is a worker request rather than a sync
call because the pixels only exist where the renderer does, and the
renderer is owned outright by the worker thread. Reads get their own
drain lane: a frame, a trace and a patch are three questions, and none
may supersede another.

**The picker** now carries R, G and B above the graph, each
drag-scrubbable and typeable, and applies to the document as it changes:
a drag previews continuously and settles into one undoable edit, the
same staged-drag shape the effect rows use. Clicking away from it keeps
what is applied, because the live value already IS the document's;
Cancel writes back the colour it opened with.

Tested: the region ladder and the linear-light averaging (a wrong space
is a wrong colour with nothing on screen to say so), the patch cut
(square, odd, clamped at the edges, refusing a short buffer), the
viewfinder's three captions, and the picker's live behaviour end to end
- typed channel, drag preview then one commit, Cancel restoring, and an
outside click keeping.

Not done: the x/y position pick for coordinate pairs. The magnifier
carries the mode but no Flutter row pairs x and y into one control yet,
so there is nothing to arm it from; recorded in docs/TODO.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>