### PR TITLE
Layer ends are handles, the source is the limit, and keyframes tell the truth about where they are

### DIFF
--- a/crates/lumit-bridge/src/api/assets.rs
+++ b/crates/lumit-bridge/src/api/assets.rs
@@ -87,20 +87,23 @@ impl LayerReference {
     /// model where the z=0 plane maps 1:1. `None` on any other kind.
     #[frb(sync)]
     pub fn get_camera_zoom(&self) -> Result<Option<BridgeScalar>, BridgeError> {
-        let lumit_core::model::LayerKind::Camera { zoom } = self.item()?.kind else {
+        let layer = self.item()?;
+        let lumit_core::model::LayerKind::Camera { zoom } = layer.kind else {
             return Ok(None);
         };
-        Ok(Some(BridgeScalar::read(&zoom)))
+        // Keys on the composition's clock, like every other channel (K-212).
+        Ok(Some(BridgeScalar::read_at(&zoom, layer.start_offset.0)))
     }
 
     /// Set a camera's zoom. Animatable, so it takes a whole `BridgeScalar` like
     /// every other curve-capable value.
     #[frb(sync)]
     pub fn set_camera_zoom(&self, zoom: BridgeScalar) -> Result<(), BridgeError> {
-        let lumit_core::model::LayerKind::Camera { .. } = self.item()?.kind else {
+        let layer = self.item()?;
+        let lumit_core::model::LayerKind::Camera { .. } = layer.kind else {
             return Err(BridgeError::NotCamera);
         };
-        let animation = zoom.animation()?;
+        let animation = zoom.animation_at(layer.start_offset.0)?;
         self.commit(lumit_core::Op::SetCameraZoom {
             comp: self.comp_id,
             layer: self.layer_id,

--- a/crates/lumit-bridge/src/api/effect.rs
+++ b/crates/lumit-bridge/src/api/effect.rs
@@ -373,12 +373,18 @@ pub struct BridgeKeyframe {
 }
 
 impl BridgeKeyframe {
+    /// One key, its time carried into **comp** time by `offset` — the layer's
+    /// `start_offset`, where its own zero sits on the composition's clock
+    /// (K-212). The engine keys every property in layer-local seconds so a
+    /// layer's animation travels with it; the interface draws and edits in comp
+    /// frames. This is the one place the two are reconciled.
     #[frb(ignore)]
-    fn read(key: &Keyframe) -> BridgeKeyframe {
+    fn read_at(key: &Keyframe, offset: Rational) -> BridgeKeyframe {
+        let time = key.time.checked_add(offset).unwrap_or(key.time);
         BridgeKeyframe {
             time: BridgeRational {
-                num: key.time.num(),
-                den: key.time.den(),
+                num: time.num(),
+                den: time.den(),
             },
             value: key.value,
             interp_in: BridgeSideInterp::read(key.interp_in),
@@ -386,10 +392,13 @@ impl BridgeKeyframe {
         }
     }
 
+    /// The way back: a comp-time key returned to the layer's own clock.
     #[frb(ignore)]
-    fn write(&self) -> Result<Keyframe, BridgeError> {
+    fn write_at(&self, offset: Rational) -> Result<Keyframe, BridgeError> {
         Ok(Keyframe {
             time: Rational::new(self.time.num, self.time.den)
+                .map_err(|_| BridgeError::InvalidKeyframes)?
+                .checked_sub(offset)
                 .map_err(|_| BridgeError::InvalidKeyframes)?,
             value: self.value,
             interp_in: self.interp_in.write(),
@@ -416,8 +425,12 @@ pub enum BridgeScalar {
 }
 
 impl BridgeScalar {
+    /// This channel with its keys on the composition's clock — see
+    /// [`BridgeKeyframe::read_at`] for why the seam converts (K-212). Pass the
+    /// layer's `start_offset`; the offset is never guessed, so a caller that
+    /// has no layer cannot forget one.
     #[frb(ignore)]
-    pub(crate) fn read(property: &Property) -> BridgeScalar {
+    pub(crate) fn read_at(property: &Property, offset: Rational) -> BridgeScalar {
         match &property.animation {
             Animation::Static(value) => BridgeScalar::Static(*value),
             // A keyframed property with no keys is not a curve anything can
@@ -428,9 +441,11 @@ impl BridgeScalar {
             Animation::Keyframed(keys) if keys.is_empty() => {
                 BridgeScalar::Static(property.value_at(0.0))
             }
-            Animation::Keyframed(keys) => {
-                BridgeScalar::Keyframed(keys.iter().map(BridgeKeyframe::read).collect())
-            }
+            Animation::Keyframed(keys) => BridgeScalar::Keyframed(
+                keys.iter()
+                    .map(|k| BridgeKeyframe::read_at(k, offset))
+                    .collect(),
+            ),
         }
     }
 
@@ -441,7 +456,7 @@ impl BridgeScalar {
     /// validate every channel *before* writing any of them, or a bad third
     /// channel would leave the parameter half-updated.
     #[frb(ignore)]
-    pub(crate) fn animation(&self) -> Result<Animation, BridgeError> {
+    pub(crate) fn animation_at(&self, offset: Rational) -> Result<Animation, BridgeError> {
         match self {
             BridgeScalar::Static(value) => Ok(Animation::Static(*value)),
             BridgeScalar::Keyframed(keys) => {
@@ -450,7 +465,7 @@ impl BridgeScalar {
                 }
                 let mut out: Vec<Keyframe> = Vec::with_capacity(keys.len());
                 for key in keys {
-                    let key = key.write()?;
+                    let key = key.write_at(offset)?;
                     // Ascending, unique times: `anim::evaluate` walks the list
                     // assuming it is sorted, so an unsorted one does not error,
                     // it silently evaluates wrongly.
@@ -519,26 +534,30 @@ pub enum BridgeEffectValue {
 }
 
 impl BridgeEffectValue {
+    /// `offset` is the owning layer's `start_offset`, carrying every key onto
+    /// the composition's clock (K-212).
     #[frb(ignore)]
-    fn read(value: &EffectValue) -> BridgeEffectValue {
+    fn read_at(value: &EffectValue, offset: Rational) -> BridgeEffectValue {
         match value {
-            EffectValue::Float(property) => BridgeEffectValue::Float(BridgeScalar::read(property)),
+            EffectValue::Float(property) => {
+                BridgeEffectValue::Float(BridgeScalar::read_at(property, offset))
+            }
             EffectValue::Point(x, y) => BridgeEffectValue::Point(BridgePoint {
-                x: BridgeScalar::read(x),
-                y: BridgeScalar::read(y),
+                x: BridgeScalar::read_at(x, offset),
+                y: BridgeScalar::read_at(y, offset),
             }),
             EffectValue::Colour(channels) => BridgeEffectValue::Colour(BridgeColour {
-                r: BridgeScalar::read(&channels[0]),
-                g: BridgeScalar::read(&channels[1]),
-                b: BridgeScalar::read(&channels[2]),
-                a: BridgeScalar::read(&channels[3]),
+                r: BridgeScalar::read_at(&channels[0], offset),
+                g: BridgeScalar::read_at(&channels[1], offset),
+                b: BridgeScalar::read_at(&channels[2], offset),
+                a: BridgeScalar::read_at(&channels[3], offset),
             }),
             EffectValue::Bool(value) => BridgeEffectValue::Bool(*value),
             EffectValue::Choice(index) => BridgeEffectValue::Choice(*index),
             EffectValue::Seed(seed) => BridgeEffectValue::Seed(*seed),
             EffectValue::File(file) => BridgeEffectValue::File(BridgeFileParam {
                 paths: file.paths.clone(),
-                index: BridgeScalar::read(&file.index),
+                index: BridgeScalar::read_at(&file.index, offset),
             }),
             EffectValue::Layer(layer) => BridgeEffectValue::Layer(*layer),
         }
@@ -552,24 +571,24 @@ impl BridgeEffectValue {
     /// effect's own resolver cannot read, and it would be undoable but not
     /// obviously wrong on screen.
     #[frb(ignore)]
-    fn write(self, target: &mut EffectValue) -> Result<(), BridgeError> {
+    fn write_at(self, target: &mut EffectValue, offset: Rational) -> Result<(), BridgeError> {
         match (self, target) {
             (BridgeEffectValue::Float(scalar), EffectValue::Float(property)) => {
-                property.animation = scalar.animation()?;
+                property.animation = scalar.animation_at(offset)?;
                 Ok(())
             }
             (BridgeEffectValue::Point(point), EffectValue::Point(x, y)) => {
-                let (ax, ay) = (point.x.animation()?, point.y.animation()?);
+                let (ax, ay) = (point.x.animation_at(offset)?, point.y.animation_at(offset)?);
                 x.animation = ax;
                 y.animation = ay;
                 Ok(())
             }
             (BridgeEffectValue::Colour(colour), EffectValue::Colour(channels)) => {
                 let animations = [
-                    colour.r.animation()?,
-                    colour.g.animation()?,
-                    colour.b.animation()?,
-                    colour.a.animation()?,
+                    colour.r.animation_at(offset)?,
+                    colour.g.animation_at(offset)?,
+                    colour.b.animation_at(offset)?,
+                    colour.a.animation_at(offset)?,
                 ];
                 for (property, animation) in channels.iter_mut().zip(animations) {
                     property.animation = animation;
@@ -589,7 +608,7 @@ impl BridgeEffectValue {
                 Ok(())
             }
             (BridgeEffectValue::File(file), EffectValue::File(target)) => {
-                let animation = file.index.animation()?;
+                let animation = file.index.animation_at(offset)?;
                 *target = FileParam {
                     paths: file.paths,
                     index: Property {
@@ -622,6 +641,11 @@ impl BridgeEffectValue {
 #[frb(opaque)]
 pub struct BridgeEffectInstance {
     effect: EffectInstance,
+    /// Where the owning layer's own zero sits on the composition's clock, so a
+    /// handle read out of a layer still knows how to speak comp time about its
+    /// keyframes (K-212). Carried rather than looked up: the handle is a
+    /// snapshot, and the layer it came from is the only place this is known.
+    offset: Rational,
 }
 
 /// One parameter's current value, as [`BridgeEffectInstance::get_info`]
@@ -650,7 +674,10 @@ pub struct BridgeEffectInstanceInfo {
 /// Build one instance's [`BridgeEffectInstanceInfo`] — the shared body of
 /// [`BridgeEffectInstance::get_info`] and the comp read model (K-184).
 #[frb(ignore)]
-pub(crate) fn read_instance_info(effect: &EffectInstance) -> BridgeEffectInstanceInfo {
+pub(crate) fn read_instance_info(
+    effect: &EffectInstance,
+    offset: Rational,
+) -> BridgeEffectInstanceInfo {
     BridgeEffectInstanceInfo {
         id: effect.id,
         name: effect.effect.match_name.clone(),
@@ -660,21 +687,27 @@ pub(crate) fn read_instance_info(effect: &EffectInstance) -> BridgeEffectInstanc
             .iter()
             .map(|p| BridgeParamValue {
                 id: p.id.to_string(),
-                value: BridgeEffectValue::read(&p.value),
+                value: BridgeEffectValue::read_at(&p.value, offset),
             })
             .collect(),
     }
 }
 
 impl BridgeEffectInstance {
-    pub fn new(effect: EffectInstance) -> BridgeEffectInstance {
-        BridgeEffectInstance { effect }
+    /// Rust-side only (`frb(ignore)`): a handle is made *from a layer*, which is
+    /// where the keyframe offset comes from (K-212). It was exposed to Dart and
+    /// never called from there — an instance can only be got from the layer
+    /// that owns it — and a Dart constructor with no layer would have no
+    /// honest offset to take.
+    #[frb(ignore)]
+    pub fn new(effect: EffectInstance, offset: Rational) -> BridgeEffectInstance {
+        BridgeEffectInstance { effect, offset }
     }
 
     /// One read for everything a card draws — see [`BridgeEffectInstanceInfo`].
     #[frb(sync)]
     pub fn get_info(&self) -> BridgeEffectInstanceInfo {
-        read_instance_info(&self.effect)
+        read_instance_info(&self.effect, self.offset)
     }
 
     /// This instance's own id — what the stack ops on
@@ -721,7 +754,10 @@ impl BridgeEffectInstance {
     /// no "cannot represent this one" answer any more.
     #[frb(sync)]
     pub fn get_value(&self, id: String) -> Result<BridgeEffectValue, BridgeError> {
-        Ok(BridgeEffectValue::read(&self.param(&id)?.value))
+        Ok(BridgeEffectValue::read_at(
+            &self.param(&id)?.value,
+            self.offset,
+        ))
     }
 
     /// Overwrite a parameter on this staged copy. Nothing is committed — see the
@@ -731,6 +767,7 @@ impl BridgeEffectInstance {
     /// control can never quietly change what a parameter *is*.
     #[frb(sync)]
     pub fn set_value(&mut self, id: String, value: BridgeEffectValue) -> Result<(), BridgeError> {
+        let offset = self.offset;
         let param = self
             .effect
             .params
@@ -738,7 +775,7 @@ impl BridgeEffectInstance {
             .find(|p| p.id == id)
             .ok_or(BridgeError::InvalidParam)?;
 
-        value.write(&mut param.value)
+        value.write_at(&mut param.value, offset)
     }
 
     #[frb(ignore)]

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -202,11 +202,11 @@ pub(crate) fn read_layer_info(
                 .find(|l| l.id == p)
                 .map(|l| l.name.clone())
         }),
-        transform: BridgeTransform::read(&layer.transform),
+        transform: BridgeTransform::read_at(&layer.transform, layer.start_offset.0),
         effects: layer
             .effects
             .iter()
-            .map(crate::api::effect::read_instance_info)
+            .map(|e| crate::api::effect::read_instance_info(e, layer.start_offset.0))
             .collect(),
         label: layer.label,
         matte: layer.matte.as_ref().map(|m| BridgeMatte {
@@ -214,7 +214,10 @@ pub(crate) fn read_layer_info(
             luma: matches!(m.channel, lumit_core::model::MatteChannel::Luma),
             inverted: m.inverted,
         }),
-        retime: layer.retime.as_ref().map(BridgeScalar::read),
+        retime: layer
+            .retime
+            .as_ref()
+            .map(|r| BridgeScalar::read_at(r, layer.start_offset.0)),
     }
 }
 
@@ -323,40 +326,47 @@ impl BridgeTransformProp {
 
 impl BridgeTransform {
     #[frb(ignore)]
-    pub(crate) fn read(group: &lumit_core::model::TransformGroup) -> BridgeTransform {
+    /// `offset` is the layer's `start_offset`: keys cross on the composition's
+    /// clock, not the layer's own (K-212).
+    #[allow(clippy::similar_names)]
+    pub(crate) fn read_at(
+        group: &lumit_core::model::TransformGroup,
+        offset: Rational,
+    ) -> BridgeTransform {
         BridgeTransform {
-            anchor_x: BridgeScalar::read(&group.anchor_x),
-            anchor_y: BridgeScalar::read(&group.anchor_y),
-            position_x: BridgeScalar::read(&group.position_x),
-            position_y: BridgeScalar::read(&group.position_y),
-            position_z: BridgeScalar::read(&group.position_z),
-            scale_x: BridgeScalar::read(&group.scale_x),
-            scale_y: BridgeScalar::read(&group.scale_y),
-            rotation: BridgeScalar::read(&group.rotation),
-            rotation_x: BridgeScalar::read(&group.rotation_x),
-            rotation_y: BridgeScalar::read(&group.rotation_y),
-            opacity: BridgeScalar::read(&group.opacity),
+            anchor_x: BridgeScalar::read_at(&group.anchor_x, offset),
+            anchor_y: BridgeScalar::read_at(&group.anchor_y, offset),
+            position_x: BridgeScalar::read_at(&group.position_x, offset),
+            position_y: BridgeScalar::read_at(&group.position_y, offset),
+            position_z: BridgeScalar::read_at(&group.position_z, offset),
+            scale_x: BridgeScalar::read_at(&group.scale_x, offset),
+            scale_y: BridgeScalar::read_at(&group.scale_y, offset),
+            rotation: BridgeScalar::read_at(&group.rotation, offset),
+            rotation_x: BridgeScalar::read_at(&group.rotation_x, offset),
+            rotation_y: BridgeScalar::read_at(&group.rotation_y, offset),
+            opacity: BridgeScalar::read_at(&group.opacity, offset),
         }
     }
 
     /// Write this whole group onto `target`, for the drag preview — which needs
     /// a document to render, not an op to commit.
     #[frb(ignore)]
-    pub(crate) fn write(
+    pub(crate) fn write_at(
         &self,
         target: &mut lumit_core::model::TransformGroup,
+        offset: Rational,
     ) -> Result<(), BridgeError> {
-        target.anchor_x.animation = self.anchor_x.animation()?;
-        target.anchor_y.animation = self.anchor_y.animation()?;
-        target.position_x.animation = self.position_x.animation()?;
-        target.position_y.animation = self.position_y.animation()?;
-        target.position_z.animation = self.position_z.animation()?;
-        target.scale_x.animation = self.scale_x.animation()?;
-        target.scale_y.animation = self.scale_y.animation()?;
-        target.rotation.animation = self.rotation.animation()?;
-        target.rotation_x.animation = self.rotation_x.animation()?;
-        target.rotation_y.animation = self.rotation_y.animation()?;
-        target.opacity.animation = self.opacity.animation()?;
+        target.anchor_x.animation = self.anchor_x.animation_at(offset)?;
+        target.anchor_y.animation = self.anchor_y.animation_at(offset)?;
+        target.position_x.animation = self.position_x.animation_at(offset)?;
+        target.position_y.animation = self.position_y.animation_at(offset)?;
+        target.position_z.animation = self.position_z.animation_at(offset)?;
+        target.scale_x.animation = self.scale_x.animation_at(offset)?;
+        target.scale_y.animation = self.scale_y.animation_at(offset)?;
+        target.rotation.animation = self.rotation.animation_at(offset)?;
+        target.rotation_x.animation = self.rotation_x.animation_at(offset)?;
+        target.rotation_y.animation = self.rotation_y.animation_at(offset)?;
+        target.opacity.animation = self.opacity.animation_at(offset)?;
         Ok(())
     }
 }
@@ -991,7 +1001,11 @@ impl LayerReference {
     /// This layer's whole transform.
     #[frb(sync)]
     pub fn get_transform(&self) -> Result<BridgeTransform, BridgeError> {
-        Ok(BridgeTransform::read(&self.item()?.transform))
+        let layer = self.item()?;
+        Ok(BridgeTransform::read_at(
+            &layer.transform,
+            layer.start_offset.0,
+        ))
     }
 
     /// Whether this layer's source actually carries sound.
@@ -1139,7 +1153,11 @@ impl LayerReference {
     /// hides the row.
     #[frb(sync)]
     pub fn get_retime_property(&self) -> Result<Option<BridgeScalar>, BridgeError> {
-        Ok(self.item()?.retime.as_ref().map(BridgeScalar::read))
+        let layer = self.item()?;
+        Ok(layer
+            .retime
+            .as_ref()
+            .map(|r| BridgeScalar::read_at(r, layer.start_offset.0)))
     }
 
     /// Turn Retime on or off (Ctrl+Alt+T), returning whether it is now on.
@@ -1159,13 +1177,16 @@ impl LayerReference {
     pub fn toggle_retime_property(&self) -> Result<bool, BridgeError> {
         let layer = self.item()?;
         let on = layer.retime.is_none();
+        // The layer's own span in ITS time, which is where the two keys belong
+        // (K-212): its comp in and out less where its zero sits. A layer that
+        // has been moved or trimmed does not start at its own zero, and keys at
+        // zero would sit at the start of the composition on screen and leave
+        // the tail past `duration` frozen on one frame.
         let retime = on.then(|| {
-            let duration = layer
-                .out_point
-                .0
-                .checked_sub(layer.in_point.0)
-                .unwrap_or(layer.out_point.0);
-            Layer::identity_retime(duration)
+            let local = |t: lumit_core::time::CompTime| {
+                t.0.checked_sub(layer.start_offset.0).unwrap_or(t.0)
+            };
+            Layer::identity_retime(local(layer.in_point), local(layer.out_point))
         });
         let removal = lumit_core::Op::SetRetimeProperty {
             comp: self.comp_id,
@@ -1272,8 +1293,9 @@ impl LayerReference {
     /// only exists once it is.
     #[frb(sync)]
     pub fn set_retime_property(&self, value: BridgeScalar) -> Result<(), BridgeError> {
-        let animation = value.animation()?;
-        let mut retime = self.item()?.retime.clone().ok_or(BridgeError::NotRetimed)?;
+        let layer = self.item()?;
+        let animation = value.animation_at(layer.start_offset.0)?;
+        let mut retime = layer.retime.clone().ok_or(BridgeError::NotRetimed)?;
         retime.animation = animation;
         self.commit(lumit_core::Op::SetRetimeProperty {
             comp: self.comp_id,
@@ -1285,15 +1307,18 @@ impl LayerReference {
     /// This layer's Volume, in dB (docs/09 §6): 0 is unity.
     #[frb(sync)]
     pub fn get_volume_db(&self) -> Result<BridgeScalar, BridgeError> {
-        Ok(BridgeScalar::read(&self.item()?.volume_db))
+        let layer = self.item()?;
+        Ok(BridgeScalar::read_at(
+            &layer.volume_db,
+            layer.start_offset.0,
+        ))
     }
 
     /// Set the Volume, as one undoable step — the same coarse-grained shape as
     /// a transform property, and for the same invertibility reason.
     #[frb(sync)]
     pub fn set_volume_db(&self, value: BridgeScalar) -> Result<(), BridgeError> {
-        let animation = value.animation()?;
-        self.item()?;
+        let animation = value.animation_at(self.item()?.start_offset.0)?;
 
         let proj = self.project()?;
         let proj = proj.write().map_err(|_| BridgeError::WriteFailed)?;
@@ -1331,7 +1356,7 @@ impl LayerReference {
         if props.is_empty() {
             return Ok(());
         }
-        self.item()?;
+        let offset = self.item()?.start_offset.0;
 
         let mut ops = Vec::with_capacity(props.len());
         for (prop, value) in props.into_iter().zip(values) {
@@ -1339,7 +1364,7 @@ impl LayerReference {
                 comp: self.comp_id,
                 layer: self.layer_id,
                 prop: prop.core(),
-                animation: value.animation()?,
+                animation: value.animation_at(offset)?,
             });
         }
         // One op stays one op; a batch of one would undo the same but reads
@@ -1365,10 +1390,10 @@ impl LayerReference {
         prop: BridgeTransformProp,
         value: BridgeScalar,
     ) -> Result<(), BridgeError> {
-        let animation = value.animation()?;
         // Confirm the layer is there before committing, so a stale reference is
-        // a calm error rather than a failed op.
-        self.item()?;
+        // a calm error rather than a failed op — and its offset is what carries
+        // the keys back onto its own clock (K-212).
+        let animation = value.animation_at(self.item()?.start_offset.0)?;
 
         let proj = self.project()?;
         let proj = proj.write().map_err(|_| BridgeError::WriteFailed)?;
@@ -1390,7 +1415,7 @@ impl LayerReference {
         Ok(layer
             .effects
             .iter()
-            .map(|f| BridgeEffectInstance::new(f.clone()))
+            .map(|f| BridgeEffectInstance::new(f.clone(), layer.start_offset.0))
             .collect())
     }
 

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use flutter_rust_bridge::frb;
 use lumit_core::model::{EffectInstance, Layer};
+use lumit_core::time::{CompTime, Duration, Rational, SourceTime};
 
 use uuid::Uuid;
 
@@ -1148,6 +1149,12 @@ impl LayerReference {
     /// to key, exactly as AE's Time Remap does. Off removes the property
     /// rather than flattening it: "not retimed" and "retimed to exactly 1×" are
     /// different states in the file, and only the first skips the map.
+    ///
+    /// Off also re-hangs the layer on its source (K-211). A retimed layer can be
+    /// any length, so when the map goes away the layer has to be given one
+    /// again: it keeps its in point and the frame showing there, then plays at
+    /// source rate until the source runs out or its own out point arrives,
+    /// whichever comes first. It never grows. One undo step covers both.
     #[frb(sync)]
     pub fn toggle_retime_property(&self) -> Result<bool, BridgeError> {
         let layer = self.item()?;
@@ -1160,12 +1167,103 @@ impl LayerReference {
                 .unwrap_or(layer.out_point.0);
             Layer::identity_retime(duration)
         });
-        self.commit(lumit_core::Op::SetRetimeProperty {
+        let removal = lumit_core::Op::SetRetimeProperty {
             comp: self.comp_id,
             layer: self.layer_id,
             retime,
+        };
+        // Switching it off re-hangs the layer on its source (K-211); switching
+        // it on changes nothing but the map.
+        self.commit(if on {
+            removal
+        } else {
+            self.unretime_op(&layer, removal)
         })?;
         Ok(on)
+    }
+
+    /// One op that switches a Retime off: `removal` — whichever of the two
+    /// retime routes is being cleared — with the layer's span re-anchored on
+    /// the frame that was showing, as a single undo step (K-211).
+    ///
+    /// Plain `removal` when the new span cannot be worked out (unreadable
+    /// source time, or arithmetic that would overflow): switching Retime off
+    /// must always work, even when nothing can be said about the source.
+    #[frb(ignore)]
+    pub(crate) fn unretime_op(&self, layer: &Layer, removal: lumit_core::Op) -> lumit_core::Op {
+        let Some((in_point, out_point, start_offset)) = self.reanchored_span(layer) else {
+            return removal;
+        };
+        lumit_core::Op::Batch {
+            ops: vec![
+                removal,
+                lumit_core::Op::SetLayerSpan {
+                    comp: self.comp_id,
+                    layer: self.layer_id,
+                    in_point,
+                    out_point,
+                    start_offset,
+                },
+            ],
+        }
+    }
+
+    /// Where this layer's span lands once its Retime goes away: anchored on the
+    /// source moment showing at its in point, running at source rate until the
+    /// source or its own out point ends it (`lumit_core::ops::unretimed_span`).
+    ///
+    /// The anchor is snapped to the **comp's** frame grid rather than kept at
+    /// full precision, because the start offset it produces is what every later
+    /// trim measures from: an offset sitting between two frames puts the
+    /// layer's own zero between two frames for good, and the timeline edits in
+    /// whole frames.
+    #[frb(ignore)]
+    fn reanchored_span(&self, layer: &Layer) -> Option<(CompTime, CompTime, CompTime)> {
+        let rate = self.composition().ok()?.frame_rate;
+        // The source moment showing at the in point, read through the map that
+        // is about to be removed.
+        let local = layer.in_point.0.checked_sub(layer.start_offset.0).ok()?;
+        let seconds = layer.source_time_at(local.to_f64());
+        let approximate = CompTime(Rational::from_f64_on_grid(seconds, Rational::FLICK_DEN).ok()?);
+        let anchor = SourceTime(rate.time_of_frame(rate.frame_at(approximate)).ok()?.0);
+        lumit_core::ops::unretimed_span(
+            layer.in_point,
+            layer.out_point,
+            anchor,
+            self.source_length(layer),
+        )
+    }
+
+    /// How long this layer's source runs, when it has one that can be measured:
+    /// a nested comp's duration, or a footage file's probed length. `None` for
+    /// every generated kind, for media that will not read, and in builds
+    /// without the `media` feature — "no length" is never a guessed length.
+    #[frb(ignore)]
+    fn source_length(&self, layer: &Layer) -> Option<Duration> {
+        let proj = self.project().ok()?;
+        let proj = proj.read().ok()?;
+        let doc = proj.store.snapshot();
+        match layer.kind {
+            lumit_core::model::LayerKind::Precomp { comp } => match doc.item(comp) {
+                Some(lumit_core::model::ProjectItem::Composition(inner)) => Some(inner.duration),
+                _ => None,
+            },
+            #[cfg(feature = "media")]
+            lumit_core::model::LayerKind::Footage { item, .. } => {
+                let Some(lumit_core::model::ProjectItem::Footage(footage)) = doc.item(item) else {
+                    return None;
+                };
+                let path = crate::api::footage::FootageReference::resolve_path(&proj, footage)?;
+                let info = lumit_media::probe::probe(&path).ok()?;
+                // The one sanctioned route back from the container's floating
+                // point duration is an explicit grid (docs/impl/rational-time.md
+                // §4) — the same millisecond grid `media_info` reports on.
+                Some(Duration(
+                    Rational::from_f64_on_grid(info.duration_seconds, 1000).ok()?,
+                ))
+            }
+            _ => None,
+        }
     }
 
     /// Replace the Retime property's whole animation, as one undoable step —

--- a/crates/lumit-bridge/src/api/retime.rs
+++ b/crates/lumit-bridge/src/api/retime.rs
@@ -72,6 +72,11 @@ impl LayerReference {
     /// edit. Off removes the map entirely rather than setting 100%, because
     /// "not retimed" and "retimed to exactly 1×" are different states in the
     /// file and only the first skips the resampler.
+    ///
+    /// Off also re-hangs the layer on its source, exactly as the Retime property
+    /// does (K-211): it keeps its in point and the frame showing there, then
+    /// plays at source rate until the source runs out or its own out point
+    /// arrives, whichever comes first. It never grows. One undo step covers both.
     #[frb(sync)]
     pub fn set_retime_enabled(&self, on: bool) -> Result<(), BridgeError> {
         let layer = self.item()?;
@@ -87,10 +92,18 @@ impl LayerReference {
                 .unwrap_or(layer.out_point.0);
             Retime::identity(duration, Rational::ZERO)
         });
-        self.commit(lumit_core::Op::SetLayerRetime {
+        let removal = lumit_core::Op::SetLayerRetime {
             comp: self.comp_id,
             layer: self.layer_id,
             retime,
+        };
+        // Off re-hangs the layer on its source, exactly as the Retime property
+        // does (K-211): both routes make the same promise, so they let go of it
+        // the same way.
+        self.commit(if on {
+            removal
+        } else {
+            self.unretime_op(&layer, removal)
         })
     }
 

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -1288,7 +1288,7 @@ fn setting_one_property_leaves_the_others_alone_and_undoes_alone() {
         opacity: BridgeScalar::Static(7.0),
         ..after
     }
-    .write(&mut group)
+    .write_at(&mut group, lumit_core::time::Rational::ZERO)
     .expect("preview write");
     assert_eq!(
         group.opacity.animation,
@@ -3259,4 +3259,103 @@ fn switching_retime_off_re_hangs_the_layer_on_its_source() {
         60,
         "one second in, one second out"
     );
+}
+
+/// Keyframes belong to the layer, and the seam says so in the interface's units
+/// (K-212).
+///
+/// The engine keys every property in the layer's **own** time, which is what
+/// makes a layer's animation travel with it when it is moved. The Timeline
+/// draws and edits in **comp** frames. The bridge is where the two meet: what
+/// crosses is comp time, converted by the layer's `start_offset` in both
+/// directions. Read raw, a moved layer's keys drew at the start of the comp.
+#[test]
+fn keyframes_cross_on_the_comp_clock_and_travel_with_the_layer() {
+    use crate::api::effect::{BridgeKeyframe, BridgeRational, BridgeScalar, BridgeSideInterp};
+    use crate::api::layer::{BridgeSpan, BridgeTransformProp};
+
+    let rational = |num: i64, den: i64| BridgeRational { num, den };
+    let key = |seconds: i64, value: f64| BridgeKeyframe {
+        time: rational(seconds, 1),
+        value,
+        interp_in: BridgeSideInterp::Linear,
+        interp_out: BridgeSideInterp::Linear,
+    };
+
+    let project = LumitBridgeState::new_project(None).expect("a new project");
+    let comp = project.new_composition("Scene".into(), None).expect("comp");
+    let layer = comp.add_solid_layer().expect("solid");
+
+    // A key at comp second 2, written the way a panel writes one.
+    layer
+        .set_transform(
+            BridgeTransformProp::PositionX,
+            BridgeScalar::Keyframed(vec![key(2, 100.0)]),
+        )
+        .expect("keyed");
+    assert_eq!(
+        layer.get_transform().expect("transform").position_x,
+        BridgeScalar::Keyframed(vec![key(2, 100.0)]),
+        "it reads back at the comp time it was written at"
+    );
+
+    // Move the whole layer three seconds later — in, out and the offset all
+    // shift, which is what a bar drag commits.
+    layer
+        .set_span(BridgeSpan {
+            in_point: rational(3, 1),
+            out_point: rational(8, 1),
+            start_offset: rational(3, 1),
+        })
+        .expect("moved");
+    assert_eq!(
+        layer.get_transform().expect("transform").position_x,
+        BridgeScalar::Keyframed(vec![key(5, 100.0)]),
+        "the key travelled with the layer, and says so in comp time"
+    );
+}
+
+/// Switching Retime on keys the layer where it *is* (K-212): one key on its in
+/// point, one on its out point, both in comp time — not at the start of the
+/// composition, and not stopping short of a trimmed layer's tail.
+#[test]
+fn enabling_retime_keys_the_layer_where_it_sits() {
+    use crate::api::effect::{BridgeRational, BridgeScalar};
+    use crate::api::layer::BridgeSpan;
+
+    let rational = |num: i64, den: i64| BridgeRational { num, den };
+    let project = LumitBridgeState::new_project(None).expect("a new project");
+    let comp = project.new_composition("Scene".into(), None).expect("comp");
+    let inner = project.new_composition("Inner".into(), None).expect("comp");
+    let layer = comp.add_precomp_layer(&inner).expect("nested");
+
+    // Moved to comp second 3 and trimmed a second off its head: its own zero
+    // sits at comp second 2, so local time at the in point is one second.
+    layer
+        .set_span(BridgeSpan {
+            in_point: rational(3, 1),
+            out_point: rational(8, 1),
+            start_offset: rational(2, 1),
+        })
+        .expect("placed");
+
+    assert!(layer.toggle_retime_property().expect("on"));
+    let Some(BridgeScalar::Keyframed(keys)) = layer.get_retime_property().expect("retime") else {
+        panic!("switching Retime on installs a keyed map");
+    };
+    assert_eq!(keys.len(), 2, "one key on each end, and no others");
+    assert_eq!(
+        comp.frame_at_time(keys[0].time).expect("frame"),
+        comp.frame_at_time(rational(3, 1)).expect("frame"),
+        "the first key is on the layer's in point"
+    );
+    assert_eq!(
+        comp.frame_at_time(keys[1].time).expect("frame"),
+        comp.frame_at_time(rational(8, 1)).expect("frame"),
+        "and the second on its out point"
+    );
+    // The values are the source times those moments show — the identity map,
+    // so each is the layer's own local time and nothing moves on screen.
+    assert!((keys[0].value - 1.0).abs() < 1e-9);
+    assert!((keys[1].value - 6.0).abs() < 1e-9);
 }

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -3165,3 +3165,98 @@ fn system_memory_bytes_reports_non_zero_on_supported_platforms() {
         );
     }
 }
+
+/// Switching Retime off re-hangs the layer on its source (K-211): it keeps its
+/// in point, shows the same frame there, and runs at source rate until the
+/// source runs out — never longer than it already was.
+#[test]
+fn switching_retime_off_re_hangs_the_layer_on_its_source() {
+    use crate::api::composition::BridgeCompSettings;
+    use crate::api::effect::BridgeRational;
+    use crate::api::layer::BridgeSpan;
+
+    let rational = |num: i64, den: i64| BridgeRational { num, den };
+    let project = LumitBridgeState::new_project(None).expect("a new project");
+    // A five-second source at 60 fps: 300 frames of material, and no file to
+    // probe — a nested comp's length is its own.
+    let inner = project
+        .new_composition(
+            "Inner".into(),
+            Some(BridgeCompSettings {
+                name: "Inner".into(),
+                width: 320,
+                height: 240,
+                fps_num: 60,
+                fps_den: 1,
+                duration: rational(5, 1),
+            }),
+        )
+        .expect("comp");
+    let outer = project.new_composition("Outer".into(), None).expect("comp");
+    let layer = outer.add_precomp_layer(&inner).expect("nested");
+
+    // Retimed, a layer is any length it likes: stretched to twenty seconds.
+    layer.toggle_retime_property().expect("on");
+    layer
+        .set_span(BridgeSpan {
+            in_point: rational(0, 1),
+            out_point: rational(20, 1),
+            start_offset: rational(0, 1),
+        })
+        .expect("stretched");
+
+    layer.toggle_retime_property().expect("off");
+    let span = layer.get_span().expect("span");
+    assert_eq!(
+        outer.frame_at_time(span.out_point).expect("frame"),
+        300,
+        "showing the source's first frame, it runs the source's whole length"
+    );
+    assert_eq!(
+        outer.frame_at_time(span.start_offset).expect("frame"),
+        0,
+        "and its own zero stays where that frame is"
+    );
+    assert_eq!(outer.frame_at_time(span.in_point).expect("frame"), 0);
+
+    // Anchored two seconds into the source instead: only the three seconds
+    // that are left of the source remain.
+    layer.toggle_retime_property().expect("on");
+    layer
+        .set_span(BridgeSpan {
+            in_point: rational(0, 1),
+            out_point: rational(20, 1),
+            start_offset: rational(-2, 1),
+        })
+        .expect("stretched");
+    layer.toggle_retime_property().expect("off");
+    let span = layer.get_span().expect("span");
+    assert_eq!(
+        outer.frame_at_time(span.out_point).expect("frame"),
+        180,
+        "three seconds of source were left to play"
+    );
+    assert_eq!(
+        outer.frame_at_time(span.start_offset).expect("frame"),
+        -120,
+        "the anchor frame still shows at the in point"
+    );
+
+    // And it never grows: a layer shorter than what is left keeps its length.
+    layer.toggle_retime_property().expect("on");
+    layer
+        .set_span(BridgeSpan {
+            in_point: rational(0, 1),
+            out_point: rational(1, 1),
+            start_offset: rational(0, 1),
+        })
+        .expect("trimmed");
+    layer.toggle_retime_property().expect("off");
+    assert_eq!(
+        outer
+            .frame_at_time(layer.get_span().expect("span").out_point)
+            .expect("frame"),
+        60,
+        "one second in, one second out"
+    );
+}

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -1156,7 +1156,10 @@ fn render_comp_with_preview(
         comp.layers[index].effects = effects;
     }
     if let Some(transform) = &req.transform {
-        transform.write(&mut comp.layers[index].transform)?;
+        // The preview's keys arrive on the composition's clock like every other
+        // read (K-212); the layer's own offset carries them back.
+        let offset = comp.layers[index].start_offset.0;
+        transform.write_at(&mut comp.layers[index].transform, offset)?;
     }
 
     // A drag is not playback: full resolution (EveryFrame skips the adaptive

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1057667678;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -2112594183;
 
 // Section: executor
 
@@ -334,41 +334,6 @@ fn wire__crate__api__effect__BridgeEffectInstance_name_impl(
                 )?;
                 Ok(output_ok)
             })())
-        },
-    )
-}
-fn wire__crate__api__effect__BridgeEffectInstance_new_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "BridgeEffectInstance_new",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_effect = <EffectInstance>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, ()>((move || {
-                    let output_ok = Result::<_, ()>::Ok(
-                        crate::api::effect::BridgeEffectInstance::new(api_effect),
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
         },
     )
 }
@@ -5518,9 +5483,6 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BridgeError>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
-    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>
-);
-flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<LumitBridgeState>
 );
 
@@ -5554,16 +5516,6 @@ impl SseDecode for BridgeError {
     }
 }
 
-impl SseDecode for EffectInstance {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <RustOpaqueMoi<
-            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>,
-        >>::sse_decode(deserializer);
-        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
-    }
-}
-
 impl SseDecode for LumitBridgeState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5586,16 +5538,6 @@ impl SseDecode
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BridgeError>>
-{
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <usize>::sse_decode(deserializer);
-        return decode_rust_opaque_moi(inner);
-    }
-}
-
-impl SseDecode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7457,56 +7399,50 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        7 => wire__crate__api__effect__BridgeEffectInstance_new_impl(
+        33 => wire__crate__api__composition__composition_reference_detect_beats_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__composition__composition_reference_detect_beats_impl(
+        61 => wire__crate__api__footage__footage_reference_get_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__footage__footage_reference_get_status_impl(
+        62 => wire__crate__api__footage__footage_reference_media_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__footage__footage_reference_media_info_impl(
+        64 => wire__crate__api__footage__footage_reference_thumbnail_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__footage__footage_reference_thumbnail_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        72 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
-        74 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
-        76 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
-        77 => {
+        71 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
+        76 => {
             wire__crate__api__keymap__keymap_reset_binding_impl(port, ptr, rust_vec_len, data_len)
         }
-        80 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
+        79 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        107 => wire__crate__api__layer__layer_reference_has_audio_impl(
+        106 => wire__crate__api__layer__layer_reference_has_audio_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        153 => wire__crate__api__project__project_reference_save_impl(
+        152 => wire__crate__api__project__project_reference_save_impl(
             port,
             ptr,
             rust_vec_len,
@@ -7530,152 +7466,152 @@ fn pde_ffi_dispatcher_sync_impl(
 4 => wire__crate__api__effect__BridgeEffectInstance_get_value_impl(ptr, rust_vec_len, data_len),
 5 => wire__crate__api__effect__BridgeEffectInstance_id_impl(ptr, rust_vec_len, data_len),
 6 => wire__crate__api__effect__BridgeEffectInstance_name_impl(ptr, rust_vec_len, data_len),
-8 => wire__crate__api__effect__BridgeEffectInstance_serialize_impl(ptr, rust_vec_len, data_len),
-9 => wire__crate__api__effect__BridgeEffectInstance_set_value_impl(ptr, rust_vec_len, data_len),
-10 => wire__crate__api__state__LumitBridgeState_get_current_project_impl(ptr, rust_vec_len, data_len),
-11 => wire__crate__api__state__LumitBridgeState_new_project_impl(ptr, rust_vec_len, data_len),
-12 => wire__crate__api__state__LumitBridgeState_open_project_impl(ptr, rust_vec_len, data_len),
-13 => wire__crate__api__audio__audio_clock_impl(ptr, rust_vec_len, data_len),
-14 => wire__crate__api__audio__audio_pause_impl(ptr, rust_vec_len, data_len),
-15 => wire__crate__api__audio__audio_seek_impl(ptr, rust_vec_len, data_len),
-16 => wire__crate__api__audio__audio_stop_impl(ptr, rust_vec_len, data_len),
-17 => wire__crate__api__shell__boot_log_impl(ptr, rust_vec_len, data_len),
-18 => wire__crate__api__composition__bridge_comp_settings_defaults_impl(ptr, rust_vec_len, data_len),
-19 => wire__crate__api__cache__cache_stats_impl(ptr, rust_vec_len, data_len),
-20 => wire__crate__api__cache__clear_cache_impl(ptr, rust_vec_len, data_len),
-21 => wire__crate__api__cache__clear_vram_cache_impl(ptr, rust_vec_len, data_len),
-22 => wire__crate__api__composition__composition_reference_add_adjustment_layer_impl(ptr, rust_vec_len, data_len),
-23 => wire__crate__api__composition__composition_reference_add_camera_layer_impl(ptr, rust_vec_len, data_len),
-24 => wire__crate__api__composition__composition_reference_add_footage_layer_impl(ptr, rust_vec_len, data_len),
-25 => wire__crate__api__composition__composition_reference_add_null_layer_impl(ptr, rust_vec_len, data_len),
-26 => wire__crate__api__composition__composition_reference_add_precomp_layer_impl(ptr, rust_vec_len, data_len),
-27 => wire__crate__api__composition__composition_reference_add_sequence_layer_impl(ptr, rust_vec_len, data_len),
-28 => wire__crate__api__composition__composition_reference_add_solid_layer_impl(ptr, rust_vec_len, data_len),
-29 => wire__crate__api__composition__composition_reference_add_text_layer_impl(ptr, rust_vec_len, data_len),
-30 => wire__crate__api__composition__composition_reference_audio_play_impl(ptr, rust_vec_len, data_len),
-31 => wire__crate__api__composition__composition_reference_audio_prepare_impl(ptr, rust_vec_len, data_len),
-32 => wire__crate__api__composition__composition_reference_cached_frames_impl(ptr, rust_vec_len, data_len),
-33 => wire__crate__api__composition__composition_reference_clear_beat_markers_impl(ptr, rust_vec_len, data_len),
-35 => wire__crate__api__composition__composition_reference_document_revision_impl(ptr, rust_vec_len, data_len),
-36 => wire__crate__api__composition__composition_reference_duration_frames_impl(ptr, rust_vec_len, data_len),
-37 => wire__crate__api__composition__composition_reference_fps_impl(ptr, rust_vec_len, data_len),
-38 => wire__crate__api__composition__composition_reference_frame_at_time_impl(ptr, rust_vec_len, data_len),
-39 => wire__crate__api__composition__composition_reference_get_layers_impl(ptr, rust_vec_len, data_len),
-40 => wire__crate__api__composition__composition_reference_get_markers_impl(ptr, rust_vec_len, data_len),
-41 => wire__crate__api__composition__composition_reference_get_model_impl(ptr, rust_vec_len, data_len),
-42 => wire__crate__api__composition__composition_reference_get_settings_impl(ptr, rust_vec_len, data_len),
-43 => wire__crate__api__composition__composition_reference_get_size_impl(ptr, rust_vec_len, data_len),
-44 => wire__crate__api__composition__composition_reference_get_work_area_impl(ptr, rust_vec_len, data_len),
-45 => wire__crate__api__composition__composition_reference_play_impl(ptr, rust_vec_len, data_len),
-46 => wire__crate__api__composition__composition_reference_playback_tier_impl(ptr, rust_vec_len, data_len),
-47 => wire__crate__api__composition__composition_reference_render_frame_impl(ptr, rust_vec_len, data_len),
-48 => wire__crate__api__composition__composition_reference_render_frame_with_preview_impl(ptr, rust_vec_len, data_len),
-49 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
-50 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
-51 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
-52 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
-53 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
-54 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
-55 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
-56 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
-57 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
-58 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
-59 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
-60 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
-61 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
-64 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
-66 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
-67 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
-68 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
-69 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
-70 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
-71 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
-73 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
-75 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
-78 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
-79 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
-81 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
-83 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
-84 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
-85 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
-86 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
-87 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
-88 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
-89 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
-90 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
-91 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
-92 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
-93 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
-94 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
-95 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
-96 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
-97 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
-98 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
-99 => wire__crate__api__layer__layer_reference_get_retime_impl(ptr, rust_vec_len, data_len),
-100 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
-101 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
-102 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
-103 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
-104 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
-105 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
-106 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
-108 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
-109 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
-110 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
-111 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
-112 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
-113 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
-114 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
-115 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
-116 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
-117 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
-118 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
-119 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
-120 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
-121 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
-122 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
-123 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
-124 => wire__crate__api__layer__layer_reference_set_retime_enabled_impl(ptr, rust_vec_len, data_len),
-125 => wire__crate__api__layer__layer_reference_set_retime_interpolation_impl(ptr, rust_vec_len, data_len),
-126 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
-127 => wire__crate__api__layer__layer_reference_set_retime_reverse_impl(ptr, rust_vec_len, data_len),
-128 => wire__crate__api__layer__layer_reference_set_retime_speed_impl(ptr, rust_vec_len, data_len),
-129 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
-130 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
-131 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
-132 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
-133 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
-134 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
-135 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
-136 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
-137 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
-138 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
-139 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
-140 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
-141 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
-142 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
-143 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
-144 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
-145 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
-146 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
-147 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
-148 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
-149 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
-150 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
-151 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
-152 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
-154 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
-155 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
-156 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
-157 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
-158 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
-159 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
-160 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
-161 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
-162 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
-163 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
-164 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
-165 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
+7 => wire__crate__api__effect__BridgeEffectInstance_serialize_impl(ptr, rust_vec_len, data_len),
+8 => wire__crate__api__effect__BridgeEffectInstance_set_value_impl(ptr, rust_vec_len, data_len),
+9 => wire__crate__api__state__LumitBridgeState_get_current_project_impl(ptr, rust_vec_len, data_len),
+10 => wire__crate__api__state__LumitBridgeState_new_project_impl(ptr, rust_vec_len, data_len),
+11 => wire__crate__api__state__LumitBridgeState_open_project_impl(ptr, rust_vec_len, data_len),
+12 => wire__crate__api__audio__audio_clock_impl(ptr, rust_vec_len, data_len),
+13 => wire__crate__api__audio__audio_pause_impl(ptr, rust_vec_len, data_len),
+14 => wire__crate__api__audio__audio_seek_impl(ptr, rust_vec_len, data_len),
+15 => wire__crate__api__audio__audio_stop_impl(ptr, rust_vec_len, data_len),
+16 => wire__crate__api__shell__boot_log_impl(ptr, rust_vec_len, data_len),
+17 => wire__crate__api__composition__bridge_comp_settings_defaults_impl(ptr, rust_vec_len, data_len),
+18 => wire__crate__api__cache__cache_stats_impl(ptr, rust_vec_len, data_len),
+19 => wire__crate__api__cache__clear_cache_impl(ptr, rust_vec_len, data_len),
+20 => wire__crate__api__cache__clear_vram_cache_impl(ptr, rust_vec_len, data_len),
+21 => wire__crate__api__composition__composition_reference_add_adjustment_layer_impl(ptr, rust_vec_len, data_len),
+22 => wire__crate__api__composition__composition_reference_add_camera_layer_impl(ptr, rust_vec_len, data_len),
+23 => wire__crate__api__composition__composition_reference_add_footage_layer_impl(ptr, rust_vec_len, data_len),
+24 => wire__crate__api__composition__composition_reference_add_null_layer_impl(ptr, rust_vec_len, data_len),
+25 => wire__crate__api__composition__composition_reference_add_precomp_layer_impl(ptr, rust_vec_len, data_len),
+26 => wire__crate__api__composition__composition_reference_add_sequence_layer_impl(ptr, rust_vec_len, data_len),
+27 => wire__crate__api__composition__composition_reference_add_solid_layer_impl(ptr, rust_vec_len, data_len),
+28 => wire__crate__api__composition__composition_reference_add_text_layer_impl(ptr, rust_vec_len, data_len),
+29 => wire__crate__api__composition__composition_reference_audio_play_impl(ptr, rust_vec_len, data_len),
+30 => wire__crate__api__composition__composition_reference_audio_prepare_impl(ptr, rust_vec_len, data_len),
+31 => wire__crate__api__composition__composition_reference_cached_frames_impl(ptr, rust_vec_len, data_len),
+32 => wire__crate__api__composition__composition_reference_clear_beat_markers_impl(ptr, rust_vec_len, data_len),
+34 => wire__crate__api__composition__composition_reference_document_revision_impl(ptr, rust_vec_len, data_len),
+35 => wire__crate__api__composition__composition_reference_duration_frames_impl(ptr, rust_vec_len, data_len),
+36 => wire__crate__api__composition__composition_reference_fps_impl(ptr, rust_vec_len, data_len),
+37 => wire__crate__api__composition__composition_reference_frame_at_time_impl(ptr, rust_vec_len, data_len),
+38 => wire__crate__api__composition__composition_reference_get_layers_impl(ptr, rust_vec_len, data_len),
+39 => wire__crate__api__composition__composition_reference_get_markers_impl(ptr, rust_vec_len, data_len),
+40 => wire__crate__api__composition__composition_reference_get_model_impl(ptr, rust_vec_len, data_len),
+41 => wire__crate__api__composition__composition_reference_get_settings_impl(ptr, rust_vec_len, data_len),
+42 => wire__crate__api__composition__composition_reference_get_size_impl(ptr, rust_vec_len, data_len),
+43 => wire__crate__api__composition__composition_reference_get_work_area_impl(ptr, rust_vec_len, data_len),
+44 => wire__crate__api__composition__composition_reference_play_impl(ptr, rust_vec_len, data_len),
+45 => wire__crate__api__composition__composition_reference_playback_tier_impl(ptr, rust_vec_len, data_len),
+46 => wire__crate__api__composition__composition_reference_render_frame_impl(ptr, rust_vec_len, data_len),
+47 => wire__crate__api__composition__composition_reference_render_frame_with_preview_impl(ptr, rust_vec_len, data_len),
+48 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
+49 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
+50 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+51 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
+52 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
+53 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
+54 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
+55 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
+56 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
+57 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
+58 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
+59 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
+60 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
+63 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
+65 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
+66 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
+67 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
+68 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
+69 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
+70 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
+72 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
+74 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
+77 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
+78 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
+80 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
+82 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
+83 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
+84 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
+85 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
+86 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
+87 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
+88 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
+89 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
+90 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
+91 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
+92 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
+93 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
+94 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
+95 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
+96 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
+97 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
+98 => wire__crate__api__layer__layer_reference_get_retime_impl(ptr, rust_vec_len, data_len),
+99 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
+100 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
+101 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
+102 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
+103 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
+104 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
+105 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
+107 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
+108 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
+109 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
+110 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
+111 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
+112 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
+113 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
+114 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
+115 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
+116 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
+117 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
+118 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
+119 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
+120 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
+121 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
+122 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
+123 => wire__crate__api__layer__layer_reference_set_retime_enabled_impl(ptr, rust_vec_len, data_len),
+124 => wire__crate__api__layer__layer_reference_set_retime_interpolation_impl(ptr, rust_vec_len, data_len),
+125 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
+126 => wire__crate__api__layer__layer_reference_set_retime_reverse_impl(ptr, rust_vec_len, data_len),
+127 => wire__crate__api__layer__layer_reference_set_retime_speed_impl(ptr, rust_vec_len, data_len),
+128 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
+129 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
+130 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
+131 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
+132 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
+133 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
+134 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
+135 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
+136 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
+137 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
+138 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
+139 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
+140 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
+141 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
+142 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
+143 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
+144 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
+145 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
+146 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
+147 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
+148 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
+149 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
+150 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
+151 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
+153 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
+154 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
+155 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
+156 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
+157 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
+158 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
+159 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
+160 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
+161 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
+162 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
+163 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
+164 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -7711,21 +7647,6 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<BridgeError>> for BridgeError {
     fn into_into_dart(self) -> FrbWrapper<BridgeError> {
-        self.into()
-    }
-}
-
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<EffectInstance> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
-            .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<EffectInstance> {}
-
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<EffectInstance>> for EffectInstance {
-    fn into_into_dart(self) -> FrbWrapper<EffectInstance> {
         self.into()
     }
 }
@@ -9457,13 +9378,6 @@ impl SseEncode for BridgeError {
     }
 }
 
-impl SseEncode for EffectInstance {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
-    }
-}
-
 impl SseEncode for LumitBridgeState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -9484,17 +9398,6 @@ impl SseEncode
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BridgeError>>
-{
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        let (ptr, size) = self.sse_encode_raw();
-        <usize>::sse_encode(ptr, serializer);
-        <i32>::sse_encode(size, serializer);
-    }
-}
-
-impl SseEncode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -11006,20 +10909,6 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_lumit_flutter_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>::increment_strong_count(ptr as _);
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_lumit_flutter_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>::decrement_strong_count(ptr as _);
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_lumit_flutter_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
         ptr: *const std::ffi::c_void,
     ) {
@@ -11086,20 +10975,6 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BridgeError>>::decrement_strong_count(ptr as _);
-    }
-
-    #[wasm_bindgen]
-    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>::increment_strong_count(ptr as _);
-    }
-
-    #[wasm_bindgen]
-    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-        ptr: *const std::ffi::c_void,
-    ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]

--- a/crates/lumit-core/src/model.rs
+++ b/crates/lumit-core/src/model.rs
@@ -1048,10 +1048,19 @@ pub struct Layer {
 }
 
 impl Layer {
-    /// The identity Retime for a layer `duration` seconds long: two linear keys
-    /// running source time alongside local time, so the layer plays at source
-    /// rate. What Ctrl+Alt+T installs — the AE Time Remap starting state.
-    pub fn identity_retime(duration: Rational) -> Property {
+    /// The identity Retime across a layer's own span: two linear keys running
+    /// source time alongside local time, so the layer plays at source rate.
+    /// What Ctrl+Alt+T installs — the AE Time Remap starting state.
+    ///
+    /// `from` and `to` are the layer's **local** in and out points — its comp
+    /// span less its `start_offset` — not zero and its duration (K-212). A
+    /// trimmed layer's visible range does not begin at its own zero, and keys
+    /// that stopped short of it froze the tail: past the last key a property
+    /// holds, so the part of the layer beyond `duration` played one frame over
+    /// and over. Spanning the real range is also what puts the two keys on the
+    /// layer's start and end where the Timeline draws them, rather than at the
+    /// start of the composition.
+    pub fn identity_retime(from: Rational, to: Rational) -> Property {
         let key = |time: Rational, value: f64| crate::anim::Keyframe {
             time,
             value,
@@ -1060,8 +1069,8 @@ impl Layer {
         };
         Property {
             animation: crate::anim::Animation::Keyframed(vec![
-                key(Rational::ZERO, 0.0),
-                key(duration, duration.to_f64()),
+                key(from, from.to_f64()),
+                key(to, to.to_f64()),
             ]),
             extra: serde_json::Map::new(),
         }

--- a/crates/lumit-core/src/ops.rs
+++ b/crates/lumit-core/src/ops.rs
@@ -1000,6 +1000,112 @@ pub fn edit_layer_span(
     }
 }
 
+/// The span a layer takes when its Retime is switched off (K-211).
+///
+/// **In plain terms:** while a layer is retimed it can be any length, because
+/// it chooses which source moment each of its own frames shows. Switch that off
+/// and the layer plays at source rate again, so it has to be re-hung on the
+/// source. The frame that was already showing at the in point is the anchor:
+/// the layer keeps its in point and shows that same frame there, then carries
+/// on at source rate until either the source runs out or the layer's existing
+/// out point arrives — whichever comes first. It never grows: a layer trimmed
+/// short stays short.
+///
+/// `anchor` is the source moment showing at `in_point`, read through the map
+/// that is about to be removed. `source_length` is the source's own length, or
+/// `None` when it has none (or could not be read) — then only the anchor is
+/// honoured and the out point is left alone.
+///
+/// Returns `(in_point, out_point, start_offset)`, or `None` when the arithmetic
+/// would overflow or the result would not be a real span — in which case the
+/// caller leaves the span exactly as it found it.
+#[must_use]
+pub fn unretimed_span(
+    in_point: CompTime,
+    out_point: CompTime,
+    anchor: crate::time::SourceTime,
+    source_length: Option<Duration>,
+) -> Option<(CompTime, CompTime, CompTime)> {
+    // Layer time zero goes wherever it must for `anchor` to show at the in
+    // point: an un-retimed layer reads its source at its own clock, so the
+    // offset *is* the difference between the two.
+    let start_offset = in_point.sub_dur(Duration(anchor.0)).ok()?;
+    let out = match source_length {
+        Some(len) => {
+            let available = len.0.checked_sub(anchor.0).ok()?;
+            // Anchored at or past the end of the source there is nothing to
+            // measure from; the layer holds its last frame and keeps its span.
+            if available.is_negative() || available.is_zero() {
+                out_point
+            } else {
+                out_point.min(in_point.add_dur(Duration(available)).ok()?)
+            }
+        }
+        None => out_point,
+    };
+    (out > in_point).then_some((in_point, out, start_offset))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod unretime_tests {
+    use super::*;
+    use crate::time::{Rational, SourceTime};
+
+    fn ct(secs: i64) -> CompTime {
+        CompTime(Rational::new(secs, 1).unwrap())
+    }
+    fn st(secs: i64) -> SourceTime {
+        SourceTime(Rational::new(secs, 1).unwrap())
+    }
+    fn dur(secs: i64) -> Duration {
+        Duration(Rational::new(secs, 1).unwrap())
+    }
+
+    /// The simple case: the layer was showing the source's first frame, so it
+    /// simply plays from there until the source runs out.
+    #[test]
+    fn anchored_on_the_first_frame_runs_to_the_source_end() {
+        // In at comp 10, showing source 0, and a 5-second source: the layer
+        // ends at comp 15 however long the retimed version was.
+        let (i, o, off) = unretimed_span(ct(10), ct(100), st(0), Some(dur(5))).unwrap();
+        assert_eq!((i, o, off), (ct(10), ct(15), ct(10)));
+    }
+
+    /// Anchored part-way in, only what is left of the source is available.
+    #[test]
+    fn anchored_mid_source_runs_out_sooner() {
+        let (i, o, off) = unretimed_span(ct(10), ct(100), st(2), Some(dur(5))).unwrap();
+        assert_eq!(i, ct(10));
+        assert_eq!(o, ct(13), "three seconds of source were left");
+        assert_eq!(off, ct(8), "source zero sits two seconds before the in");
+    }
+
+    /// It never grows: a layer already shorter than the source keeps its length.
+    #[test]
+    fn a_trimmed_layer_keeps_its_length() {
+        let (_, o, _) = unretimed_span(ct(10), ct(12), st(0), Some(dur(5))).unwrap();
+        assert_eq!(o, ct(12));
+    }
+
+    /// No readable length — missing media, or a kind with no source of its own
+    /// — re-anchors and leaves the out point alone rather than guessing.
+    #[test]
+    fn no_source_length_leaves_the_out_point_alone() {
+        let (i, o, off) = unretimed_span(ct(10), ct(100), st(2), None).unwrap();
+        assert_eq!((i, o, off), (ct(10), ct(100), ct(8)));
+    }
+
+    /// Anchored at or past the end of the source, there is nothing left to
+    /// measure: the span survives intact rather than collapsing to nothing.
+    #[test]
+    fn an_anchor_past_the_source_end_keeps_the_span() {
+        let (_, o, off) = unretimed_span(ct(10), ct(20), st(5), Some(dur(5))).unwrap();
+        assert_eq!(o, ct(20));
+        assert_eq!(off, ct(5));
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod span_edit_tests {

--- a/crates/lumit-core/src/store.rs
+++ b/crates/lumit-core/src/store.rs
@@ -815,7 +815,7 @@ mod tests {
 
         // Identity over ten seconds, then half of it: local 4 → source 2.
         let ten = Rational::new(10, 1).unwrap();
-        let mut retime = Layer::identity_retime(ten);
+        let mut retime = Layer::identity_retime(Rational::ZERO, ten);
         if let crate::anim::Animation::Keyframed(keys) = &mut retime.animation {
             keys[1].value = 5.0;
         }

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3302,3 +3302,44 @@ frames and then went dead: "dragging a footage edge only moves one frame". Both 
 carry keys now. It only ever bit the source-backed kinds, because they are the only ones
 with a ghost to appear, and only when the pointer moved in more than one event — which is
 why the first round of tests, each dragging in a single synthetic step, all passed.
+
+**K-212 · DECIDED · Keyframes live in the layer's time and cross on the composition's
+clock.** From the owner (2026-07-30): switching Retime on put its two keys "where the start
+and end points would be if the layer's position was still at the start of the comp". They
+were, and so was every other keyframe on any layer that had been moved — the report caught a
+seam fault whose only unmissable face is the two keys Retime creates for you.
+
+**The engine keys properties in layer-local time, and that is right.** Every evaluation
+path — the render plan, the transform sampler, the cache-key hasher — reads a property at
+`comp time − start_offset`, so a layer's animation travels with the layer when it is
+dragged along the timeline. That is the behaviour an editor must have; nothing about it
+changes.
+
+**The frontend thinks in comp frames, and that is also right.** The ruler counts comp
+frames, a lane is drawn against the comp's axis, and a key drag commits where the pointer
+is. Asking the interface to hold two clocks would put the conversion in every row, lane,
+curve and field that touches a key.
+
+**So the bridge converts, and it is the only place that does.** `BridgeScalar::read_at`
+carries each key out by the owning layer's `start_offset`; `animation_at` carries it back.
+Both take the offset as an argument with no default, so a new reader cannot quietly forget
+one — the compiler asked for it at all forty-odd call sites when the signatures changed.
+Everything that crosses carrying keys goes through them: the transform group, the Retime
+property, effect parameters, a camera's zoom, a volume curve, and the staged
+`BridgeEffectInstance` — which now carries its layer's offset, because a handle read out of
+a layer is the only place that fact is known. `BridgeEffectInstance::new` stopped being
+exposed to Dart in the same move: it was never called from there, and a constructor with no
+layer would have no honest offset to take.
+
+**Retime's two keys span the layer's own in and out.** `Layer::identity_retime` took a
+duration and keyed zero and that duration; it now takes the layer's local in and out points.
+Two faults in one: on screen the keys sat at the start of the composition, and in the model
+a trimmed layer's map stopped short of its tail — past the last key a property holds, so
+everything beyond `duration` played one frame over and over. Spanning the real range fixes
+both, and keeps the promise that switching Retime on changes nothing visible.
+
+**Not done: the pre-K-197 speed map.** The Source card's segment store has the same
+"identity across `0..duration`" shape and the same tail problem on a trimmed layer. It is
+not keyframed, so nothing draws it in the wrong place, and it is the arm the ponytail
+comment in `Layer::source_time_at` marks for deletion; it is left alone rather than being
+half-migrated. Recorded here so the next person meets it deliberately.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3248,3 +3248,47 @@ peaks. The rest — a precomp's duration, whether Retime is on, where the start 
 is worked out once per *document revision* and cached; `CompModel` now exposes that revision
 so a panel can cache anything derived from the model honestly. Frames come from exact
 integer arithmetic on the comp's rate rather than a `frame_at` call per layer per frame.
+
+**K-211 · DECIDED · Letting go of Retime re-hangs the layer on its source, and a
+trimmed layer shows how far its media reaches.** From the owner (2026-07-30), refining
+K-210. Two halves, both about the same thing: a layer's relationship with the material
+behind it should be visible, and should survive being switched about.
+
+**Switching Retime off re-anchors the layer.** While it is retimed a layer can be any
+length, because it chooses which source moment each of its own frames shows; when the map
+goes away it plays at source rate again and has to be given a length. Holding the stretched
+length (K-210's first answer) was wrong: it left the layer showing material the source does
+not have. The rule now is the frame already on screen. The layer keeps its **in point** and
+shows the **same frame** there — so if that was the source's first frame it simply starts
+from the beginning, and if it was some way in it carries on from there. From that anchor it
+runs at source rate until either the source runs out or its own out point arrives,
+**whichever comes first**. It never grows: a layer trimmed short stays short. One undo step
+covers the removal and the span together.
+
+The anchor is snapped to the **comp's** frame grid rather than kept at full precision. The
+start offset it produces is what every later trim measures from, and an offset sitting
+between two frames puts the layer's own zero between two frames for good; the timeline edits
+in whole frames, so the anchor does too. Both routes to a retime behave identically — the
+Retime property (K-197) and the Source card's speed map — because both make the same promise.
+
+`unretimed_span` is a pure function in `lumit-core::ops`, next to `edit_layer_span`: this is
+span arithmetic, and it is the kind of rule that must be provable rather than observed. The
+bridge supplies the two facts it cannot derive — the source moment showing at the in point,
+read through the map that is about to go, and the source's own length. No readable length
+(missing media, a build without the media feature) re-anchors and leaves the out point
+alone, the same "no length is never a guessed length" rule K-210 set.
+
+**A trimmed layer shows its source's reach.** A Footage, audio or Precomp layer that is not
+retimed and does not fill its source draws a **faint outlined rectangle spanning the whole
+source**, behind the bar, in the layer's own label colour. What shows past each end is
+exactly the material trimmed away, and because it is drawn behind, the layer reads as one
+clip with the middle solid rather than as three objects. It is absent when the bar already
+fills the source, absent on the kinds with no source, and absent under Retime, where "the
+source's reach" is not a fact about the layer at all. It sits with K-210's corner triangles
+in one vocabulary: a triangle says *this end can go no further*, the ghost says *this end
+could go further, and this is how far*.
+
+**Both marks travel with a move.** They are drawn from the source's reach, which moves with
+the layer: sliding a bar along the timeline carries its start offset, so the bounds slide
+with it. Drawn from the document's bounds alone, a bar being moved appeared to leave its
+limit behind — the fix is one shift applied to both marks while a move is in flight.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3199,3 +3199,52 @@ applies to most of the geometry in an interface icon set. Not applied at even wi
 the stroke already covers whole pixels and the nudge is what would blur it. At fractional
 display scalings (150%) no offset makes a stroke whole; that is inherent and is stated in
 the note rather than papered over.
+
+**K-210 · DECIDED · A layer's ends are handles, and its source is the limit.** From the
+owner (2026-07-30): the start and end of a layer must be draggable to change its length,
+for every layer kind — and a Footage, audio or Precomp layer must not be draggable to show
+what its source does not hold, unless it is retimed.
+
+**Trimming for every kind.** Dragging either end of a bar trims that end; dragging its
+middle moves it, as before. The grab zone at each end is 8px but never more than a third of
+the bar, which is what makes a short bar draggable at all: at a flat 6px a two-frame bar was
+entirely edge, so it could be trimmed but never moved. The pointer takes the horizontal
+resize arrow over each zone, because an affordance nobody can see is one nobody uses — the
+gesture existed before this entry and the report was that it did not.
+
+**The source is the limit.** A layer whose source has a length of its own trims within it:
+the in point stops at the source's first frame (the layer's own time zero, which is where
+`start_offset` puts it on the comp timeline) and the out point stops at its last. That is
+Footage — picture and sound alike — and Precomp, whose length is the nested comp's duration.
+Every generated kind (Solid, Text, Adjustment, Null, Camera, Sequence) has nothing to run
+out of and trims freely. **Retime takes both limits off** (docs/04-RETIMING.md): a retimed
+layer maps its own local time onto source time, so its length stops being the source's
+business and it stretches as far as it is dragged. Both routes to a retime count — the
+Retime property (K-197) and the Source card's older speed map — because both make the same
+promise. Moving a bar is never limited: `start_offset` travels with it.
+
+**A bound never drags an edge that is already outside it.** A layer stretched while retimed
+and then un-retimed keeps the length it has; the limit holds its end still rather than
+snapping it back, and pulling back towards the source is always allowed. Anything else would
+silently destroy work on a switch toggle.
+
+**Media that will not read leaves the ends free.** A missing file, or a build with no media
+feature, answers "no length" — and no length means no limit, never a limit guessed at. A
+layer must never be cropped by the absence of an answer.
+
+**The marks: a small triangle in the top corner of the bar** on the side that is at its
+limit, drawn in the same ink as the clip splits so the bar keeps one vocabulary. Present
+only on the kinds that have a source, absent the moment Retime is on — the mark and the
+rule are the same fact, so they can never disagree on screen.
+
+**Where the rule lives.** In the panel, not the engine. `SetLayerSpan` still accepts any
+span that is not inverted: AE import, project load and `trim_to_source_end` all legitimately
+write spans the drag would refuse, and an op that second-guesses its caller would break
+them. The gesture is what is bounded, and the bound is a pure function with its own tests.
+
+**What it costs per rebuild: nothing (K-184).** A footage length comes from probing the file,
+so it is asked once per layer off the build and kept for the session, like the waveform
+peaks. The rest — a precomp's duration, whether Retime is on, where the start offset sits —
+is worked out once per *document revision* and cached; `CompModel` now exposes that revision
+so a panel can cache anything derived from the model honestly. Frames come from exact
+integer arithmetic on the comp's rate rather than a `frame_at` call per layer per frame.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -3292,3 +3292,13 @@ could go further, and this is how far*.
 the layer: sliding a bar along the timeline carries its start offset, so the bounds slide
 with it. Drawn from the document's bounds alone, a bar being moved appeared to leave its
 limit behind — the fix is one shift applied to both marks while a move is in flight.
+
+**The trap the ghost set, recorded because it cost a working gesture.** The outline is a
+second child of the bar's `Stack`, and it appears the moment a trim starts. Unkeyed,
+Flutter matches a `Stack`'s children by position, so the ghost arriving took the bar's slot
+and the bar's element — with it the recogniser holding the drag in the gesture arena — was
+rebuilt from scratch mid-gesture. The bar moved by the first pointer event's worth of
+frames and then went dead: "dragging a footage edge only moves one frame". Both children
+carry keys now. It only ever bit the source-backed kinds, because they are the only ones
+with a ghost to appear, and only when the pointer moved in more than one event — which is
+why the first round of tests, each dragging in a single synthetic step, all passed.

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -529,6 +529,22 @@ keyframe marquee. Still to build: `=`/`-`/`\`, and edge-follow during playback.
   a missing file must never silently crop a layer. Moving a bar is never limited: the
   start offset travels with it, so what fits its source keeps fitting it.
 
+  **A trimmed layer shows its source's reach (K-211).** A source-backed layer that is not
+  retimed and does not fill its source draws a faint outlined rectangle spanning the whole
+  source, behind the bar and in the layer's own label colour — so what shows past each end
+  is exactly the material trimmed away. Absent when the bar already fills its source, on
+  the kinds with no source, and under Retime. One vocabulary with the corner triangles: a
+  triangle says *this end can go no further*, the outline says *this end could, and this
+  is how far*. Both travel with a bar being moved, because the source's reach moves with it.
+
+  **Switching Retime off re-hangs the layer on its source (K-211).** A retimed layer may be
+  any length; when the map goes away it plays at source rate again and needs a length. It
+  keeps its in point and the frame showing there, then runs at source rate until either the
+  source runs out or its own out point arrives, whichever comes first — it never grows, so
+  a layer trimmed short stays short. One undo step covers the removal and the span. Both
+  routes to a retime behave the same way, and media with no readable length re-anchors and
+  leaves the out point alone.
+
   **Both halves move (K-208).** While the drag is in flight the stack shows where the drop
   would land: the lifted layer slides towards its slot and the layers it passes slide the
   other way — in the outline **and** in the lane area at once, from one drag state and one

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -515,6 +515,20 @@ keyframe marquee. Still to build: `=`/`-`/`\`, and edge-follow during playback.
   **name** in the outline moves it up or down the stack — drop it on a row and it takes
   that row's place, as one undo step. A locked layer neither drags nor accepts a drop.
 
+  **The ends are handles, and the source is the limit (K-210).** Dragging the last few
+  pixels of either end of a bar trims that end — the pointer shows the horizontal resize
+  arrow there, and the grab zone never takes more than a third of a short bar, so even a
+  two-frame bar keeps a middle to move by. A layer whose source has a length of its own —
+  Footage (picture or sound) and Precomp — trims **within** it: the in point cannot go
+  earlier than the source's first frame, the out point cannot go past its last, and a bar
+  already at that limit draws a small triangle in that top corner. Every generated kind
+  (Solid, Text, Adjustment, Null, Camera, Sequence) has no such source and trims freely,
+  with no corner marks. **Retime removes both limits and both marks**: a retimed layer
+  maps its own local time onto source time (docs/04-RETIMING.md), so its length is no
+  longer the source's business. Media whose length cannot be read leaves the ends free —
+  a missing file must never silently crop a layer. Moving a bar is never limited: the
+  start offset travels with it, so what fits its source keeps fitting it.
+
   **Both halves move (K-208).** While the drag is in flight the stack shows where the drop
   would land: the lifted layer slides towards its slot and the layers it passes slide the
   other way — in the outline **and** in the lane area at once, from one drag state and one

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -159,6 +159,17 @@ other side of this boundary.
     `CompositionReference::time_of_frame`/`frame_at_time` exist so no frontend
     has to do that arithmetic itself: at 29.97 fps a frame is 1001/30000 s, and a
     keyframe placed in floating point does not land on the frame it was set on.
+- **Keyframe times cross on the composition's clock (K-212).** The engine keys every
+    animatable property in the layer's **own** time — comp time less its `start_offset` —
+    which is what makes a layer's animation travel with it when it is moved. The frontend
+    thinks in comp frames: that is what the ruler counts, what a lane draws against, and
+    what a key drag commits. So the seam converts, in both directions, by the owning
+    layer's `start_offset`: `BridgeScalar::read_at` carries a key out to comp time,
+    `animation_at` carries it back. Both take the offset as an argument rather than
+    defaulting it, so a new reader cannot forget one. Anything crossing with keyframes in
+    it — the whole transform, a Retime property, an effect parameter, a camera's zoom, a
+    volume curve, a staged `BridgeEffectInstance` — carries the same conversion. Read raw,
+    every key on a layer that had been moved drew at the start of the composition.
 
 ### Versioning
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -930,7 +930,14 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   because it genuinely *is* every other property — there is no Retime-specific code in any
   of those places. Switching it on installs two keys running source time alongside layer
   time, so the picture does not move; drag the second key later and the clip plays slower,
-  drag it earlier and it plays faster. That is deliberately *all* it does for now: no speed
+  drag it earlier and it plays faster. **The two keys land on the layer's own start and
+  end** — where it currently sits on the timeline, and where its ends currently are if you
+  have trimmed it (K-212). That sounds obvious and was not: keyframes are stored in the
+  layer's *own* clock, which is what makes a layer's animation travel with it when you slide
+  the layer along the timeline, and the Timeline draws in the composition's clock. The two
+  are converted for each other in exactly one place, at the engine boundary; before that,
+  every keyframe on a layer that had been moved was drawn as though the layer still began at
+  the start of the composition, and Retime's own two keys made it impossible to miss. That is deliberately *all* it does for now: no speed
   ramps, no ease presets, no freeze command. `Layer::source_time_at` is the one function
   that answers the question, so what the renderer decodes and what the frame cache files it
   under can never drift apart. The older, much larger machinery below still answers for

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1470,7 +1470,18 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   ruler with each layer's bar on its own *lane*). Each bar wears its layer's **label
   colour** — the same chip its outline swatch shows (K-189) — so a tall stack reads at a
   glance and picking a new label recolours the bar. Drag a layer's bar body to slide it
-  earlier or later in time (one undo per drag); drag its ends to trim. A layer twirled
+  earlier or later in time (one undo per drag); drag its ends to trim — the pointer turns
+  into the horizontal resize arrow over the last few pixels of each end, which is where
+  the trim grab lives. **The ends know what the source holds** (K-210): a Footage, audio
+  or Precomp layer stops where its media does — you cannot drag its head earlier than the
+  clip's first frame or its tail past the last, and when an end is sitting on that limit a
+  small triangle appears in that top corner of the bar to say so. Every generated kind —
+  Solid, Text, Adjustment, Null, Camera — has no source to run out of, so both its ends go
+  wherever you drag them and neither wears a triangle. Switch **Retime** on and the limits
+  come off (and the triangles go): a retimed layer chooses which source moment each of its
+  own frames shows, so it can be stretched to any length you like. Sliding a bar along the
+  timeline is never limited — moving carries the content with it, so a clip that fits its
+  source still fits it wherever it lands. A layer twirled
   open shows its **keyframes as diamonds on the lanes**: drag a diamond to move that
   keyframe in time, or drag a box on empty lane space to select the diamonds inside it.
   Dragging never scrolls the timeline — the wheel and the scrollbars do: a plain wheel

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1481,7 +1481,19 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   come off (and the triangles go): a retimed layer chooses which source moment each of its
   own frames shows, so it can be stretched to any length you like. Sliding a bar along the
   timeline is never limited — moving carries the content with it, so a clip that fits its
-  source still fits it wherever it lands. A layer twirled
+  source still fits it wherever it lands.
+  **Trim one back and you can see what you cut off**: a faint outline runs behind the bar
+  as far as the media reaches, so the trimmed-away head or tail shows as an empty extension
+  of the clip — drag the end back out and the bar fills it again. It appears only when there
+  is something to show, and never while Retime is on.
+  **Turning Retime off puts the layer back on its source.** A retimed layer can be any
+  length, so when you switch the retime off Lumit has to give it one again, and it does that
+  from the frame you are already looking at: the layer keeps its start, still shows that
+  same frame there, and plays at normal speed from there until the footage runs out (or
+  until where the layer already ended, if that came first — it never gets longer than it
+  was). So a clip that started on its first frame simply plays from the beginning again,
+  and one parked half-way in carries on from half-way in. It is one undo either way.
+  A layer twirled
   open shows its **keyframes as diamonds on the lanes**: drag a diamond to move that
   keyframe in time, or drag a box on empty lane space to select the diamonds inside it.
   Dragging never scrolls the timeline — the wheel and the scrollbars do: a plain wheel

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -395,6 +395,17 @@ remains worthwhile but is now much lower stakes. Registering a texture still
 cannot happen in a widget test; `integration_test/shared_texture_test.dart`
 (run by hand on a real window) is the coverage.
 
+**The Windows shared-texture test races, rarely (seen 2026-07-30).**
+`lumit-gpu`'s `shared::tests::the_legacy_handle_yields_the_pixels_angle_style` failed one
+CI run with `[0, 0, 0, 0]` where the orange should be, and passed on the run before and the
+run after with nothing between them touching that code. The cause is the missing handshake
+the module note already records: `present` ends with a D3D11 `CopyResource` and a `Flush`,
+which *submits* the copy without waiting for it, and the test's reader opens the shared
+texture on a third device with no keyed mutex to wait on — so it can map the surface before
+the copy has landed. Fix it with the reader waiting on a `D3D11_QUERY_EVENT` (test-side, no
+change to the shipping path) or by landing the keyed-mutex handshake K-177 defers. Wants a
+Windows machine to write it on: a blind fix cannot be run before it is pushed.
+
 **Playback scheduler — what remains.** The ring landed (2026-07-27): renders run
 ahead of the clock into a bounded ring sized by measured p95 cost
 ([impl/playback-scheduler.md](impl/playback-scheduler.md) §5), presents pace

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -30,6 +30,7 @@ import 'package:lumit_flutter/src/rust/api/composition.dart';
 import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/keymap.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
+import 'package:lumit_flutter/src/rust/api/project_item.dart';
 import 'package:provider/provider.dart';
 
 import '../icons/icons.dart';
@@ -75,7 +76,20 @@ const double _rulerHeight =
 
 /// How near the end of a bar counts as grabbing its edge to trim rather than its
 /// middle to move.
-const double _trimGrab = 6;
+const double _trimGrab = 8;
+
+/// Which part of a bar [width] pixels wide a press at [dx] takes hold of.
+///
+/// Each trim zone is [_trimGrab] wide but never more than a third of the bar,
+/// so a bar only a few frames long still keeps a middle to move by — without
+/// the cap, a short bar was all edge and could not be dragged along the
+/// timeline at all.
+BarGrab barGrabAt(double dx, double width) {
+  final edge = min(_trimGrab, width / 3);
+  if (dx < edge) return BarGrab.trimIn;
+  if (dx > width - edge) return BarGrab.trimOut;
+  return BarGrab.move;
+}
 
 /// A layer drag in flight: the index lifted, and the index it would land on.
 ///
@@ -272,6 +286,23 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
   /// One lane's worth of buckets: plenty for any panel width.
   static const int _peakBuckets = 2048;
 
+  /// Each Footage layer's source length in comp frames, by layer id. Cached
+  /// for the same reason [_hasAudio] is: the answer comes from probing the
+  /// file with FFmpeg, which must never happen in a build. Absent means "not
+  /// asked yet"; a null value means the answer never came (no media feature,
+  /// missing file), which leaves that layer's ends free.
+  final Map<String, int?> _footageFrames = {};
+
+  /// How far each layer's ends may be dragged, by layer id (K-210) — what the
+  /// bars trim within and draw their corner marks from.
+  Map<String, BarBounds> _barBounds = {};
+
+  /// The document revision [_barBounds] was worked out at. A precomp's length
+  /// and a layer's Retime are both one edit away from changing, so the bounds
+  /// are taken again whenever the document moves — and never in between, which
+  /// is what keeps a rebuild free of bridge calls (K-184).
+  BigInt? _boundsRevision;
+
   /// Fetch peaks for any layer whose Waveform twirl is open and unanswered.
   void _refreshPeaks(List<BridgeLayerEntry> layers) {
     for (final entry in layers) {
@@ -286,6 +317,87 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
         setState(() => _peaks[id] = peaks);
       });
     }
+  }
+
+  /// Work out how far every layer's ends may be dragged (K-210).
+  ///
+  /// Two costs, kept apart. A **footage** length means opening the file, so it
+  /// is asked once per layer, off the build, and kept for the session — the
+  /// same bargain [_refreshPeaks] strikes. Everything else is a cheap read that
+  /// an edit can change (a precomp lengthened in its comp settings, Retime
+  /// switched on), so the whole table is rebuilt when — and only when — the
+  /// document revision moves.
+  void _refreshBounds(CompModel model, int fpsNum, int fpsDen) {
+    final layers = model.layers;
+    for (final entry in layers) {
+      final id = entry.layer.internallayerId.toString();
+      if (entry.info.kind != BridgeLayerKind.footage ||
+          _footageFrames.containsKey(id)) {
+        continue;
+      }
+      // Claim the slot first, so a rebuild mid-probe does not probe twice.
+      _footageFrames[id] = null;
+      final ItemReference? source;
+      try {
+        source = entry.layer.getSourceItem();
+      } catch (_) {
+        continue;
+      }
+      if (source is! ItemReference_Footage) continue;
+      source.field0.mediaInfo().then((info) {
+        if (!mounted || info == null) return;
+        setState(() {
+          _footageFrames[id] = frameOfTime(info.duration, fpsNum, fpsDen);
+          // The answer changes the bounds, and the document has not moved:
+          // forget the revision so the next build works them out again.
+          _boundsRevision = null;
+        });
+      });
+    }
+
+    final revision = model.revision;
+    if (revision != null && revision == _boundsRevision) return;
+    _boundsRevision = revision;
+    _barBounds = {
+      for (final entry in layers)
+        entry.layer.internallayerId.toString():
+            _boundsOf(entry, fpsNum, fpsDen),
+    };
+  }
+
+  /// One layer's bounds, from what its kind can be asked cheaply.
+  BarBounds _boundsOf(BridgeLayerEntry entry, int fpsNum, int fpsDen) {
+    final info = entry.info;
+    // Retime frees both ends (docs/04-RETIMING.md): the Retime property
+    // (K-197), and the Source card's speed map, which is the same promise by
+    // the older route and is still live in the interface.
+    var retimed = info.retime != null;
+    int? sourceFrames;
+    try {
+      switch (info.kind) {
+        case BridgeLayerKind.footage:
+          retimed = retimed || entry.layer.getRetime() != null;
+          sourceFrames = _footageFrames[entry.layer.internallayerId.toString()];
+        case BridgeLayerKind.precomp:
+          final source = entry.layer.getSourceItem();
+          if (source is ItemReference_Composition) {
+            sourceFrames = frameOfTime(
+                source.field0.getSettings().duration, fpsNum, fpsDen);
+          }
+        default:
+          // Every generated kind: nothing to run out of, both ends free.
+          sourceFrames = null;
+      }
+    } catch (_) {
+      // A layer that has gone, or a source that cannot be read: free ends
+      // rather than a bar pinned to a guess.
+      return BarBounds.free;
+    }
+    return barBounds(
+      startOffsetFrame: frameOfTime(info.span.startOffset, fpsNum, fpsDen),
+      sourceFrames: sourceFrames,
+      retimed: retimed,
+    );
   }
 
   /// Twirl a fold open or shut. Shutting one drops the selection inside it
@@ -850,6 +962,9 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
     ];
     _refreshAudio(layers);
     _refreshPeaks(layers);
+    // Every layer, not the filtered list: a bar hidden by the search box still
+    // has ends, and they must be known the moment it comes back.
+    _refreshBounds(ui.model, fpsNum, fpsDen);
 
     // The property rows on screen, in display order — what a Shift+click
     // range runs along — and the graph channels the selection resolves to,
@@ -1406,6 +1521,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                                     ui.cacheChanged
                                                   ]),
                                                   dragPreview: _barDrag,
+                                                  bounds: _barBounds,
                                                 ),
                                               ),
                                             ),
@@ -1979,6 +2095,161 @@ BarDragPreview barDragPreview(String layerId, BarGrab grab, int delta) =>
       BarGrab.trimIn => BarDragPreview(layerId, delta, 0, 0),
       BarGrab.trimOut => BarDragPreview(layerId, 0, delta, 0),
     };
+
+/// How far a layer's ends may be dragged, in comp frames (K-210).
+///
+/// **In plain terms:** a Footage, audio or Precomp layer can only show what its
+/// source actually holds, so its bar stops where the media does — its head
+/// cannot be dragged earlier than the source's first frame, and its tail cannot
+/// be dragged past its last. Every generated kind — Solid, Text, Adjustment,
+/// Null, Camera, Sequence — has no such source, so both its ends are free and
+/// it is whatever length the user drags it to. Switching **Retime** on frees
+/// the ends too (docs/04-RETIMING.md): a retimed layer decides for itself which
+/// source moment each of its own frames shows, so its length stops being the
+/// source's business.
+class BarBounds {
+  /// The earliest frame the in point may be trimmed to; null = the head is free.
+  final int? minIn;
+
+  /// The latest frame the out point may be trimmed to; null = the tail is free.
+  final int? maxOut;
+
+  const BarBounds({this.minIn, this.maxOut});
+
+  /// Both ends free: every generated kind, anything retimed, and any source
+  /// whose length could not be read.
+  static const BarBounds free = BarBounds();
+
+  @override
+  bool operator ==(Object other) =>
+      other is BarBounds && other.minIn == minIn && other.maxOut == maxOut;
+
+  @override
+  int get hashCode => Object.hash(minIn, maxOut);
+}
+
+/// The bounds one layer's bar trims within.
+///
+/// [startOffsetFrame] is where the layer's own time zero sits on the comp
+/// timeline, which is where its source's first frame shows; [sourceFrames] is
+/// the source's length in comp frames, or null when the layer has no source of
+/// its own — or when its length could not be read at all, which leaves the ends
+/// free rather than pinning them to a guess (missing media must never silently
+/// crop a layer).
+BarBounds barBounds({
+  required int startOffsetFrame,
+  required int? sourceFrames,
+  required bool retimed,
+}) =>
+    retimed || sourceFrames == null
+        ? BarBounds.free
+        : BarBounds(
+            minIn: startOffsetFrame,
+            maxOut: startOffsetFrame + sourceFrames,
+          );
+
+/// How far a grab of [grab] may actually travel when the gesture has moved
+/// [delta] frames: inside the layer's source, and never far enough to turn the
+/// bar inside out — a bar always keeps at least one frame.
+///
+/// A **move** is never clamped. Moving carries the start offset with the bar,
+/// so a layer that sits inside its source stays inside it however far it
+/// travels; only the two trims can run out of source.
+///
+/// A bound never drags an edge that is *already* outside it — a layer whose
+/// Retime was switched off after being stretched keeps the length it has, and
+/// its ends stay where the user left them until they are dragged back in.
+int clampBarDelta({
+  required BarGrab grab,
+  required int delta,
+  required int inFrame,
+  required int outFrame,
+  required BarBounds bounds,
+}) {
+  switch (grab) {
+    case BarGrab.move:
+      return delta;
+    case BarGrab.trimIn:
+      var want = inFrame + delta;
+      final earliest = bounds.minIn;
+      if (earliest != null) want = max(want, min(earliest, inFrame));
+      return min(want, outFrame - 1) - inFrame;
+    case BarGrab.trimOut:
+      var want = outFrame + delta;
+      final latest = bounds.maxOut;
+      if (latest != null) want = min(want, max(latest, outFrame));
+      return max(want, inFrame + 1) - outFrame;
+  }
+}
+
+/// An exact time as a comp frame number, without asking the engine (K-184).
+///
+/// The same floor `FrameRate::frame_at` takes, in whole integers so a long
+/// timeline cannot drift the way a double would: a time `num/den` seconds at
+/// `fpsNum/fpsDen` frames a second is `num·fpsNum / (den·fpsDen)`, rounded
+/// down — and down for negative times too, which is what a layer starting
+/// before the comp needs.
+int frameOfTime(BridgeRational time, int fpsNum, int fpsDen) {
+  final den = time.den.toInt() * fpsDen;
+  if (den <= 0) return 0;
+  final scaled = time.num.toInt() * fpsNum;
+  final quotient = scaled ~/ den;
+  return scaled % den != 0 && scaled < 0 ? quotient - 1 : quotient;
+}
+
+/// The corner marks that say a bar has run out of source (K-210): a small
+/// triangle in the top-left corner when the head is as early as its media
+/// allows, and one in the top-right when the tail is as late. Drawn only on the
+/// kinds that have a source to run out of, and never on a retimed layer, whose
+/// ends are free.
+class BarEndMarksPainter extends CustomPainter {
+  final bool atIn;
+  final bool atOut;
+  final Color colour;
+
+  /// The triangle's legs. Small enough to read as a corner cut on a 22px row
+  /// rather than as a badge sitting on the bar.
+  static const double leg = 5;
+
+  const BarEndMarksPainter({
+    required this.atIn,
+    required this.atOut,
+    required this.colour,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.width <= 0) return;
+    // Never let the two marks meet in the middle of a very short bar: a bar
+    // narrower than both legs draws marks scaled to fit it instead.
+    final l = min(leg, size.width / 2);
+    final paint = Paint()..color = colour;
+    if (atIn) {
+      canvas.drawPath(
+        Path()
+          ..moveTo(0, 0)
+          ..lineTo(l, 0)
+          ..lineTo(0, l)
+          ..close(),
+        paint,
+      );
+    }
+    if (atOut) {
+      canvas.drawPath(
+        Path()
+          ..moveTo(size.width, 0)
+          ..lineTo(size.width - l, 0)
+          ..lineTo(size.width, l)
+          ..close(),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(BarEndMarksPainter old) =>
+      old.atIn != atIn || old.atOut != atOut || old.colour != colour;
+}
 
 /// The waveform lane's painter: the layer's source peaks, mapped through its
 /// live in/out/offset so dragging or trimming the bar carries the transients
@@ -3373,6 +3644,11 @@ class _LayerArea extends StatelessWidget {
   /// lanes, so the peaks move with the gesture rather than on release.
   final ValueNotifier<BarDragPreview?> dragPreview;
 
+  /// How far each layer's ends may be dragged, by layer id (K-210). A layer
+  /// with no entry has free ends — the honest answer while a source length is
+  /// still being read.
+  final Map<String, BarBounds> bounds;
+
   /// The lanes' vertical scroll — the outline mirrors it, and the thumb in
   /// the gutter beside this area is the one the user grabs.
   final ScrollController vScroll;
@@ -3422,6 +3698,7 @@ class _LayerArea extends StatelessWidget {
     required this.onChanged,
     required this.cacheRevision,
     required this.dragPreview,
+    required this.bounds,
     required this.vScroll,
     required this.selectedKeys,
     required this.onKeysSelected,
@@ -3597,6 +3874,11 @@ class _LayerArea extends StatelessWidget {
                                                   onSelect(layers[i].layer),
                                               onChanged: onChanged,
                                               dragPreview: dragPreview,
+                                              bounds: bounds[layers[i]
+                                                      .layer
+                                                      .internallayerId
+                                                      .toString()] ??
+                                                  BarBounds.free,
                                             ),
                                             // One lane per fold-out row the outline shows,
                                             // from the same list it builds: keyframe rows
@@ -4203,6 +4485,10 @@ class _Bar extends StatefulWidget {
   /// Where the live preview is published, for the waveform lane to follow.
   final ValueNotifier<BarDragPreview?> dragPreview;
 
+  /// How far this layer's ends may be dragged (K-210). [BarBounds.free] for
+  /// every kind that has no source to run out of.
+  final BarBounds bounds;
+
   const _Bar({
     super.key,
     required this.comp,
@@ -4213,6 +4499,7 @@ class _Bar extends StatefulWidget {
     required this.onSelect,
     required this.onChanged,
     required this.dragPreview,
+    required this.bounds,
   });
 
   @override
@@ -4312,17 +4599,24 @@ class _BarState extends State<_Bar> {
                     : (d) => setState(() {
                           _delta = 0;
                           _deltaPx = 0;
-                          _grab = _downDx < _trimGrab
-                              ? BarGrab.trimIn
-                              : _downDx > width - _trimGrab
-                                  ? BarGrab.trimOut
-                                  : BarGrab.move;
+                          _grab = barGrabAt(_downDx, width);
                         }),
                 onHorizontalDragUpdate: widget.razor || held
                     ? null
                     : (d) => setState(() {
                           _deltaPx += d.delta.dx;
-                          _delta = widget.axis.frameAt(_deltaPx);
+                          // The pointer keeps travelling; the bar does not.
+                          // Held against the source's ends (K-210) and against
+                          // itself, so a trim can neither run past the media
+                          // nor turn the bar inside out — and dragging back
+                          // picks the edge up again from where it stuck.
+                          _delta = clampBarDelta(
+                            grab: _grab ?? BarGrab.move,
+                            delta: widget.axis.frameAt(_deltaPx),
+                            inFrame: inFrame,
+                            outFrame: outFrame,
+                            bounds: widget.bounds,
+                          );
                           _publishPreview();
                         }),
                 onHorizontalDragEnd: widget.razor || held
@@ -4357,6 +4651,33 @@ class _BarState extends State<_Bar> {
                           bottom: 0,
                           child: Container(width: 1, color: t.surface0),
                         ),
+                      // The two trim zones say so under the pointer: a bar
+                      // whose ends can be taken hold of should not have to be
+                      // discovered by trial. Inside the gesture detector, not
+                      // over it, so hovering never costs the drag its events.
+                      if (!held && !widget.razor) ...[
+                        _trimCursor(width, left: true),
+                        _trimCursor(width, left: false),
+                      ],
+                      // The corner marks: this bar is as long as its source
+                      // allows in that direction (K-210).
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: CustomPaint(
+                            key: ValueKey<String>(
+                                'tl-bar-ends-${widget.entry.layer.internallayerId}'),
+                            painter: BarEndMarksPainter(
+                              atIn: widget.bounds.minIn != null &&
+                                  drawIn <= widget.bounds.minIn!,
+                              atOut: widget.bounds.maxOut != null &&
+                                  drawOut >= widget.bounds.maxOut!,
+                              // The same ink the clip splits use, so the bar
+                              // keeps one vocabulary of marks.
+                              colour: t.surface0,
+                            ),
+                          ),
+                        ),
+                      ),
                     ],
                   ),
                 ),
@@ -4364,6 +4685,23 @@ class _BarState extends State<_Bar> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  /// One end's hover strip: the pointer becomes the horizontal resize arrow
+  /// over exactly the width [barGrabAt] treats as that end.
+  Widget _trimCursor(double width, {required bool left}) {
+    final edge = min(_trimGrab, width / 3);
+    return Positioned(
+      left: left ? 0 : null,
+      right: left ? null : 0,
+      top: 0,
+      bottom: 0,
+      width: edge,
+      child: const MouseRegion(
+        cursor: SystemMouseCursors.resizeLeftRight,
+        child: SizedBox.expand(),
       ),
     );
   }
@@ -4380,7 +4718,18 @@ class _BarState extends State<_Bar> {
   /// and the start offset together is a single undo step.
   void _commit(int inFrame, int outFrame) {
     final grab = _grab;
-    final delta = _delta;
+    // Clamped once more on the way out: a source length that arrived from its
+    // probe part-way through the gesture only reaches the bar on the next
+    // build, and what is committed must obey the bounds in force at release.
+    final delta = grab == null
+        ? 0
+        : clampBarDelta(
+            grab: grab,
+            delta: _delta,
+            inFrame: inFrame,
+            outFrame: outFrame,
+            bounds: widget.bounds,
+          );
     setState(() {
       _delta = 0;
       _deltaPx = 0;

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -4550,6 +4550,22 @@ class _BarState extends State<_Bar> {
     final left = widget.axis.xOf(drawIn);
     final width = (widget.axis.xOf(drawOut) - left).clamp(2.0, 1e6);
 
+    // The source's reach travels with a move: sliding a layer along the
+    // timeline carries its start offset, so the media it can show moves with
+    // it. Without this the marks and the ghost stayed behind while the bar
+    // went, and a bar at its limit looked as though it had left the limit.
+    final shift = _grab == BarGrab.move ? _delta : 0;
+    final minIn = widget.bounds.minIn == null ? null : widget.bounds.minIn! + shift;
+    final maxOut =
+        widget.bounds.maxOut == null ? null : widget.bounds.maxOut! + shift;
+    // Where the untrimmed source would reach (K-211): drawn behind the bar, so
+    // what shows past each end is exactly the material trimmed away. Only when
+    // there is something to show — a bar filling its source draws no ghost.
+    final ghost = (minIn != null && maxOut != null) &&
+            (drawIn > minIn || drawOut < maxOut)
+        ? (widget.axis.xOf(minIn), widget.axis.xOf(maxOut))
+        : null;
+
     // The bar fills the row's whole height rather than floating inside an
     // inset, so a layer reads as a solid band; the lane area's own hairline
     // overlay draws the row seam over it (K-190).
@@ -4557,6 +4573,29 @@ class _BarState extends State<_Bar> {
       height: _rowHeight,
       child: Stack(
         children: [
+          if (ghost != null)
+            Positioned(
+              left: ghost.$1,
+              width: (ghost.$2 - ghost.$1).clamp(1.0, 1e6),
+              top: 0,
+              bottom: 0,
+              child: IgnorePointer(
+                key: ValueKey<String>(
+                    'tl-bar-ghost-${widget.entry.layer.internallayerId}'),
+                child: Container(
+                  decoration: BoxDecoration(
+                    // The layer's own colour, faint: this is the same clip,
+                    // shown as far as it goes, not a second object.
+                    color: t.labelColour(info.label).withValues(alpha: 0.10),
+                    border: Border.all(
+                      color: t.labelColour(info.label).withValues(alpha: 0.45),
+                      width: 1,
+                    ),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+            ),
           Positioned(
             left: left,
             width: width,
@@ -4667,10 +4706,8 @@ class _BarState extends State<_Bar> {
                             key: ValueKey<String>(
                                 'tl-bar-ends-${widget.entry.layer.internallayerId}'),
                             painter: BarEndMarksPainter(
-                              atIn: widget.bounds.minIn != null &&
-                                  drawIn <= widget.bounds.minIn!,
-                              atOut: widget.bounds.maxOut != null &&
-                                  drawOut >= widget.bounds.maxOut!,
+                              atIn: minIn != null && drawIn <= minIn,
+                              atOut: maxOut != null && drawOut >= maxOut,
                               // The same ink the clip splits use, so the bar
                               // keeps one vocabulary of marks.
                               colour: t.surface0,

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -4571,17 +4571,25 @@ class _BarState extends State<_Bar> {
     // overlay draws the row seam over it (K-190).
     return SizedBox(
       height: _rowHeight,
+      // **Both children are keyed.** The ghost comes and goes as the bar is
+      // trimmed, and without keys the children were matched by position: the
+      // ghost appearing took the bar's slot, so the bar's element — and with it
+      // the gesture recogniser holding the drag — was rebuilt from scratch
+      // mid-gesture. The bar moved by the first update's frames and then went
+      // dead, which is what "dragging a footage edge only moves one frame"
+      // was. Keys keep each child matched to its own element however many
+      // there are.
       child: Stack(
         children: [
           if (ghost != null)
             Positioned(
+              key: ValueKey<String>(
+                  'tl-bar-ghost-${widget.entry.layer.internallayerId}'),
               left: ghost.$1,
               width: (ghost.$2 - ghost.$1).clamp(1.0, 1e6),
               top: 0,
               bottom: 0,
               child: IgnorePointer(
-                key: ValueKey<String>(
-                    'tl-bar-ghost-${widget.entry.layer.internallayerId}'),
                 child: Container(
                   decoration: BoxDecoration(
                     // The layer's own colour, faint: this is the same clip,
@@ -4597,6 +4605,8 @@ class _BarState extends State<_Bar> {
               ),
             ),
           Positioned(
+            key: ValueKey<String>(
+                'tl-bar-body-${widget.entry.layer.internallayerId}'),
             left: left,
             width: width,
             top: 0,

--- a/flutter_ui/lib/src/rust/api/effect.dart
+++ b/flutter_ui/lib/src/rust/api/effect.dart
@@ -10,9 +10,9 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'package:uuid/uuid.dart';
 part 'effect.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `animation`, `param`, `presets_in`, `read_instance_info`, `read`, `read`, `read`, `read`, `write`, `write`, `write`
+// These functions are ignored because they are not marked as `pub`: `animation_at`, `param`, `presets_in`, `read_at`, `read_at`, `read_at`, `read_instance_info`, `read`, `write_at`, `write_at`, `write`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
-// These functions are ignored (category: IgnoreBecauseExplicitAttribute): `get_effects`
+// These functions are ignored (category: IgnoreBecauseExplicitAttribute): `get_effects`, `new`
 
 /// Every built-in effect, in schema order — the Add-effect menu's source of
 /// truth ([`lumit_core::fx::BUILTINS`]), and the frb form of v0's `list_effects`.
@@ -84,12 +84,6 @@ abstract class BridgeEffectInstance implements RustOpaqueInterface {
 
   String name();
 
-  // HINT: Make it `#[frb(sync)]` to let it become the default constructor of Dart class.
-  static Future<BridgeEffectInstance> newInstance(
-          {required EffectInstance effect}) =>
-      BridgeLib.instance.api
-          .crateApiEffectBridgeEffectInstanceNew(effect: effect);
-
   String serialize();
 
   /// Overwrite a parameter on this staged copy. Nothing is committed — see the
@@ -99,9 +93,6 @@ abstract class BridgeEffectInstance implements RustOpaqueInterface {
   /// control can never quietly change what a parameter *is*.
   void setValue({required String id, required BridgeEffectValue value});
 }
-
-// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<EffectInstance>>
-abstract class EffectInstance implements RustOpaqueInterface {}
 
 /// A bezier side's After Effects-compatible handle: `speed` in value-units per
 /// second, `influence` as a fraction of the gap to the neighbouring key.

--- a/flutter_ui/lib/src/rust/api/layer.dart
+++ b/flutter_ui/lib/src/rust/api/layer.dart
@@ -16,7 +16,7 @@ import 'project_item.dart';
 import 'retime.dart';
 import 'solid.dart';
 
-// These functions are ignored because they are not marked as `pub`: `clip_under`, `commit_clips`, `commit`, `comp_time`, `composition`, `core`, `item`, `project`, `rational_of`, `read_layer_info`, `read`, `with_effects`, `write`
+// These functions are ignored because they are not marked as `pub`: `clip_under`, `commit_clips`, `commit`, `comp_time`, `composition`, `core`, `item`, `project`, `rational_of`, `read_layer_info`, `read`, `reanchored_span`, `source_length`, `unretime_op`, `with_effects`, `write`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `comp_id`, `id`, `new`, `project_id`
 
@@ -838,6 +838,11 @@ class LayerReference {
   /// edit. Off removes the map entirely rather than setting 100%, because
   /// "not retimed" and "retimed to exactly 1×" are different states in the
   /// file and only the first skips the resampler.
+  ///
+  /// Off also re-hangs the layer on its source, exactly as the Retime property
+  /// does (K-211): it keeps its in point and the frame showing there, then
+  /// plays at source rate until the source runs out or its own out point
+  /// arrives, whichever comes first. It never grows. One undo step covers both.
   void setRetimeEnabled({required bool on_}) => BridgeLib.instance.api
       .crateApiLayerLayerReferenceSetRetimeEnabled(that: this, on_: on_);
 
@@ -928,6 +933,12 @@ class LayerReference {
   /// to key, exactly as AE's Time Remap does. Off removes the property
   /// rather than flattening it: "not retimed" and "retimed to exactly 1×" are
   /// different states in the file, and only the first skips the map.
+  ///
+  /// Off also re-hangs the layer on its source (K-211). A retimed layer can be
+  /// any length, so when the map goes away the layer has to be given one
+  /// again: it keeps its in point and the frame showing there, then plays at
+  /// source rate until the source runs out or its own out point arrives,
+  /// whichever comes first. It never grows. One undo step covers both.
   bool toggleRetimeProperty() =>
       BridgeLib.instance.api.crateApiLayerLayerReferenceToggleRetimeProperty(
         that: this,

--- a/flutter_ui/lib/src/rust/api/layer.dart
+++ b/flutter_ui/lib/src/rust/api/layer.dart
@@ -16,7 +16,7 @@ import 'project_item.dart';
 import 'retime.dart';
 import 'solid.dart';
 
-// These functions are ignored because they are not marked as `pub`: `clip_under`, `commit_clips`, `commit`, `comp_time`, `composition`, `core`, `item`, `project`, `rational_of`, `read_layer_info`, `read`, `reanchored_span`, `source_length`, `unretime_op`, `with_effects`, `write`
+// These functions are ignored because they are not marked as `pub`: `clip_under`, `commit_clips`, `commit`, `comp_time`, `composition`, `core`, `item`, `project`, `rational_of`, `read_at`, `read_layer_info`, `reanchored_span`, `source_length`, `unretime_op`, `with_effects`, `write_at`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `comp_id`, `id`, `new`, `project_id`
 

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -87,7 +87,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1057667678;
+  int get rustContentHash => -2112594183;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -116,9 +116,6 @@ abstract class BridgeLibApi extends BaseApi {
 
   String crateApiEffectBridgeEffectInstanceName(
       {required BridgeEffectInstance that});
-
-  Future<BridgeEffectInstance> crateApiEffectBridgeEffectInstanceNew(
-      {required EffectInstance effect});
 
   String crateApiEffectBridgeEffectInstanceSerialize(
       {required BridgeEffectInstance that});
@@ -615,15 +612,6 @@ abstract class BridgeLibApi extends BaseApi {
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_BridgeErrorPtr;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_EffectInstance;
-
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_EffectInstance;
-
-  CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_EffectInstancePtr;
-
-  RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_LumitBridgeState;
 
   RustArcDecrementStrongCountFnType
@@ -801,34 +789,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
-  Future<BridgeEffectInstance> crateApiEffectBridgeEffectInstanceNew(
-      {required EffectInstance effect}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-            effect, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 7, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance,
-        decodeErrorData: null,
-      ),
-      constMeta: kCrateApiEffectBridgeEffectInstanceNewConstMeta,
-      argValues: [effect],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta get kCrateApiEffectBridgeEffectInstanceNewConstMeta =>
-      const TaskConstMeta(
-        debugName: "BridgeEffectInstance_new",
-        argNames: ["effect"],
-      );
-
-  @override
   String crateApiEffectBridgeEffectInstanceSerialize(
       {required BridgeEffectInstance that}) {
     return handler.executeSync(SyncTask(
@@ -836,7 +796,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -866,7 +826,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
             that, serializer);
         sse_encode_String(id, serializer);
         sse_encode_box_autoadd_bridge_effect_value(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -890,7 +850,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_project_reference,
@@ -916,7 +876,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_StreamSink_scoped_change_Sse(onChangeStream, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_project_reference,
@@ -943,7 +903,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         sse_encode_opt_StreamSink_scoped_change_Sse(onChangeStream, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_project_reference,
@@ -967,7 +927,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_audio_clock,
@@ -989,7 +949,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1012,7 +972,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_f_64(secs, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1034,7 +994,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 15)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1056,7 +1016,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 16)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -1078,7 +1038,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_comp_settings,
@@ -1101,7 +1061,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -1123,7 +1083,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -1145,7 +1105,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -1170,7 +1130,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1198,7 +1158,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1227,7 +1187,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_footage_reference(footage, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1255,7 +1215,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1284,7 +1244,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_composition_reference(comp, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1312,7 +1272,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1340,7 +1300,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1367,7 +1327,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -1395,7 +1355,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_f_64(start, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1422,7 +1382,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1453,7 +1413,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_u_64(frames, serializer);
         sse_encode_f_32(scale, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1479,7 +1439,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1509,7 +1469,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_u_32(sensitivityPercent, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 34, port: port_);
+            funcId: 33, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -1536,7 +1496,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -1564,7 +1524,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_i_64,
@@ -1592,7 +1552,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -1618,7 +1578,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_i_64,
@@ -1645,7 +1605,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_layer_reference,
@@ -1672,7 +1632,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_marker,
@@ -1699,7 +1659,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_comp_model,
@@ -1725,7 +1685,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_comp_settings,
@@ -1752,7 +1712,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_comp_size,
@@ -1778,7 +1738,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_span,
@@ -1811,7 +1771,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_64(from, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_bridge_playback_mode(mode, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1837,7 +1797,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -1869,7 +1829,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_64(frame, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_bridge_playback_mode(mode, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1905,7 +1865,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1941,7 +1901,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_box_autoadd_bridge_transform(transform, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -1978,7 +1938,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_u_32(kind, serializer);
         sse_encode_list_list_prim_u_8_strict(colours, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2007,7 +1967,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_list_bridge_marker(markers, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2035,7 +1995,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2065,7 +2025,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2093,7 +2053,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2124,7 +2084,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_export_spec(spec, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2151,7 +2111,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2179,7 +2139,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_rational,
@@ -2204,7 +2164,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2226,7 +2186,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_state,
@@ -2254,7 +2214,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(preset, serializer);
         sse_encode_String(compName, serializer);
         sse_encode_String(template, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_preset,
@@ -2278,7 +2238,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_folder_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -2305,7 +2265,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 62, port: port_);
+            funcId: 61, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_lumit_media_status,
@@ -2332,7 +2292,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 63, port: port_);
+            funcId: 62, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_media_info,
@@ -2359,7 +2319,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2387,7 +2347,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_u_32(maxEdge, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 65, port: port_);
+            funcId: 64, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_rendered_frame,
@@ -2412,7 +2372,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2439,7 +2399,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_box_autoadd_item_reference(item, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2464,7 +2424,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2489,7 +2449,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -2516,7 +2476,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2540,7 +2500,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_conflict,
@@ -2566,7 +2526,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(json, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 72, port: port_);
+            funcId: 71, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2590,7 +2550,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2615,7 +2575,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_keymap_preset(preset, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 74, port: port_);
+            funcId: 73, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2641,7 +2601,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(chord, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -2670,7 +2630,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(action, serializer);
         sse_encode_String(chord, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 76, port: port_);
+            funcId: 75, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2697,7 +2657,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 77, port: port_);
+            funcId: 76, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2721,7 +2681,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(query, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_binding,
@@ -2743,7 +2703,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -2769,7 +2729,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 80, port: port_);
+            funcId: 79, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -2794,7 +2754,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2822,7 +2782,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(buckets, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 82, port: port_);
+            funcId: 81, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_audio_peaks,
@@ -2848,7 +2808,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2875,7 +2835,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2900,7 +2860,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2927,7 +2887,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2953,7 +2913,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -2980,7 +2940,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3004,7 +2964,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -3030,7 +2990,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -3056,7 +3016,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_clip,
@@ -3082,7 +3042,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -3109,7 +3069,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_info,
@@ -3135,7 +3095,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_kind,
@@ -3160,7 +3120,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8,
@@ -3186,7 +3146,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_matte,
@@ -3211,7 +3171,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3237,7 +3197,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_Uuid,
@@ -3263,7 +3223,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_retime,
@@ -3289,7 +3249,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -3315,7 +3275,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_item_reference,
@@ -3341,7 +3301,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_span,
@@ -3367,7 +3327,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_switches,
@@ -3393,7 +3353,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_text_document,
@@ -3419,7 +3379,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_transform,
@@ -3445,7 +3405,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_scalar,
@@ -3472,7 +3432,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 107, port: port_);
+            funcId: 106, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3497,7 +3457,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3522,7 +3482,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3549,7 +3509,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3577,7 +3537,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3604,7 +3564,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3631,7 +3591,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_usize(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3662,7 +3622,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_i_64(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3689,7 +3649,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_reveal_kind(kind, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_reveal_groups,
@@ -3716,7 +3676,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3743,7 +3703,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(index, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3770,7 +3730,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(zoom, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3801,7 +3761,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_bool(enabled, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3830,7 +3790,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3857,7 +3817,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_8(label, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3884,7 +3844,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_matte(matte, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3911,7 +3871,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_Uuid(parent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3938,7 +3898,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3966,7 +3926,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_retime_interp(interpolation, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3994,7 +3954,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4021,7 +3981,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bool(allow, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4048,7 +4008,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_f_64(percent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4075,7 +4035,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4105,7 +4065,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_layer_switch(switch_, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4132,7 +4092,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_text_document(document, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4162,7 +4122,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_transform_prop(prop, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4192,7 +4152,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_transform_prop(props, serializer);
         sse_encode_list_bridge_scalar(values, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4219,7 +4179,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4245,7 +4205,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4270,7 +4230,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(project, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_autosave,
@@ -4292,7 +4252,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -4315,7 +4275,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_effect_info,
@@ -4338,7 +4298,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_param_info,
@@ -4361,7 +4321,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_preset_info,
@@ -4383,7 +4343,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -4405,7 +4365,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -4434,7 +4394,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
         sse_encode_u_32(keep, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4460,7 +4420,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -4486,7 +4446,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_history,
@@ -4513,7 +4473,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_footage_reference,
@@ -4539,7 +4499,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4569,7 +4529,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(name, serializer);
         sse_encode_opt_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_composition_reference,
@@ -4595,7 +4555,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4621,7 +4581,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -4646,7 +4606,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4673,7 +4633,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_recovery,
@@ -4701,7 +4661,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 153, port: port_);
+            funcId: 152, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4729,7 +4689,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_StreamSink_worker_response_Sse(onReponse, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4754,7 +4714,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4778,7 +4738,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -4803,7 +4763,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_bridge_scalar(scalar, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -4826,7 +4786,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -4851,7 +4811,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -4876,7 +4836,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_solid_def,
@@ -4903,7 +4863,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
         sse_encode_box_autoadd_bridge_solid_def(definition, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4927,7 +4887,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -4950,7 +4910,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -4973,7 +4933,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_viewer_transport,
@@ -4996,7 +4956,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -5031,14 +4991,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError;
 
   RustArcIncrementStrongCountFnType
-      get rust_arc_increment_strong_count_EffectInstance => wire
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance;
-
-  RustArcDecrementStrongCountFnType
-      get rust_arc_decrement_strong_count_EffectInstance => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance;
-
-  RustArcIncrementStrongCountFnType
       get rust_arc_increment_strong_count_LumitBridgeState => wire
           .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState;
 
@@ -5066,14 +5018,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BridgeErrorImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
-  EffectInstance
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EffectInstanceImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -5114,14 +5058,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BridgeErrorImpl.frbInternalDcoDecode(raw as List<dynamic>);
-  }
-
-  @protected
-  EffectInstance
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return EffectInstanceImpl.frbInternalDcoDecode(raw as List<dynamic>);
   }
 
   @protected
@@ -6648,15 +6584,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   }
 
   @protected
-  EffectInstance
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return EffectInstanceImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
-  }
-
-  @protected
   LumitBridgeState
       sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           SseDeserializer deserializer) {
@@ -6698,15 +6625,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return BridgeErrorImpl.frbInternalSseDecode(
-        sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
-  }
-
-  @protected
-  EffectInstance
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return EffectInstanceImpl.frbInternalSseDecode(
         sse_decode_usize(deserializer), sse_decode_i_32(deserializer));
   }
 
@@ -8438,16 +8356,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-        (self as EffectInstanceImpl).frbInternalSseEncode(move: true),
-        serializer);
-  }
-
-  @protected
-  void
       sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           LumitBridgeState self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -8493,16 +8401,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
         (self as BridgeErrorImpl).frbInternalSseEncode(move: null), serializer);
-  }
-
-  @protected
-  void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_usize(
-        (self as EffectInstanceImpl).frbInternalSseEncode(move: null),
-        serializer);
   }
 
   @protected
@@ -10050,26 +9948,6 @@ class BridgeErrorImpl extends RustOpaque implements BridgeError {
         BridgeLib.instance.api.rust_arc_decrement_strong_count_BridgeError,
     rustArcDecrementStrongCountPtr:
         BridgeLib.instance.api.rust_arc_decrement_strong_count_BridgeErrorPtr,
-  );
-}
-
-@sealed
-class EffectInstanceImpl extends RustOpaque implements EffectInstance {
-  // Not to be used by end users
-  EffectInstanceImpl.frbInternalDcoDecode(List<dynamic> wire)
-      : super.frbInternalDcoDecode(wire, _kStaticData);
-
-  // Not to be used by end users
-  EffectInstanceImpl.frbInternalSseDecode(BigInt ptr, int externalSizeOnNative)
-      : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
-
-  static final _kStaticData = RustArcStaticData(
-    rustArcIncrementStrongCount:
-        BridgeLib.instance.api.rust_arc_increment_strong_count_EffectInstance,
-    rustArcDecrementStrongCount:
-        BridgeLib.instance.api.rust_arc_decrement_strong_count_EffectInstance,
-    rustArcDecrementStrongCountPtr: BridgeLib
-        .instance.api.rust_arc_decrement_strong_count_EffectInstancePtr,
   );
 }
 

--- a/flutter_ui/lib/src/rust/frb_generated.io.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.io.dart
@@ -45,10 +45,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
           ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeErrorPtr;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_EffectInstancePtr => wire
-          ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstancePtr;
-
-  CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_LumitBridgeStatePtr => wire
           ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeStatePtr;
 
@@ -63,11 +59,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          dynamic raw);
-
-  @protected
-  EffectInstance
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           dynamic raw);
 
   @protected
@@ -93,11 +84,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          dynamic raw);
-
-  @protected
-  EffectInstance
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           dynamic raw);
 
   @protected
@@ -585,11 +571,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
           SseDeserializer deserializer);
 
   @protected
-  EffectInstance
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          SseDeserializer deserializer);
-
-  @protected
   LumitBridgeState
       sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           SseDeserializer deserializer);
@@ -612,11 +593,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          SseDeserializer deserializer);
-
-  @protected
-  EffectInstance
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           SseDeserializer deserializer);
 
   @protected
@@ -1173,11 +1149,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer);
-
-  @protected
-  void
       sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           LumitBridgeState self, SseSerializer serializer);
 
@@ -1200,11 +1171,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   void
       sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
           BridgeError self, SseSerializer serializer);
-
-  @protected
-  void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer);
 
   @protected
   void
@@ -1865,38 +1831,6 @@ class BridgeLibWire implements BaseWire {
           'frbgen_lumit_flutter_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError');
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeErrorPtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstancePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_lumit_flutter_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance');
-  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance =
-      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstancePtr
-          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
-
-  void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-    ffi.Pointer<ffi.Void> ptr,
-  ) {
-    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-      ptr,
-    );
-  }
-
-  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstancePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
-          'frbgen_lumit_flutter_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance');
-  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance =
-      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstancePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void

--- a/flutter_ui/lib/src/rust/frb_generated.web.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.web.dart
@@ -47,10 +47,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
           .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError;
 
   CrossPlatformFinalizerArg
-      get rust_arc_decrement_strong_count_EffectInstancePtr => wire
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance;
-
-  CrossPlatformFinalizerArg
       get rust_arc_decrement_strong_count_LumitBridgeStatePtr => wire
           .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState;
 
@@ -65,11 +61,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          dynamic raw);
-
-  @protected
-  EffectInstance
-      dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           dynamic raw);
 
   @protected
@@ -95,11 +86,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          dynamic raw);
-
-  @protected
-  EffectInstance
-      dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           dynamic raw);
 
   @protected
@@ -587,11 +573,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
           SseDeserializer deserializer);
 
   @protected
-  EffectInstance
-      sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          SseDeserializer deserializer);
-
-  @protected
   LumitBridgeState
       sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           SseDeserializer deserializer);
@@ -614,11 +595,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   BridgeError
       sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          SseDeserializer deserializer);
-
-  @protected
-  EffectInstance
-      sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           SseDeserializer deserializer);
 
   @protected
@@ -1175,11 +1151,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   void
-      sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer);
-
-  @protected
-  void
       sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           LumitBridgeState self, SseSerializer serializer);
 
@@ -1202,11 +1173,6 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   void
       sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
           BridgeError self, SseSerializer serializer);
-
-  @protected
-  void
-      sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          EffectInstance self, SseSerializer serializer);
 
   @protected
   void
@@ -1820,18 +1786,6 @@ class BridgeLibWire implements BaseWire {
           .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
               ptr);
 
-  void rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          int ptr) =>
-      wasmModule
-          .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-              ptr);
-
-  void rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          int ptr) =>
-      wasmModule
-          .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-              ptr);
-
   void rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLumitBridgeState(
           int ptr) =>
       wasmModule
@@ -1865,14 +1819,6 @@ extension type BridgeLibWasmModule._(JSObject _) implements JSObject {
 
   external void
       rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError(
-          int ptr);
-
-  external void
-      rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
-          int ptr);
-
-  external void
-      rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerEffectInstance(
           int ptr);
 
   external void

--- a/flutter_ui/lib/state/comp_model.dart
+++ b/flutter_ui/lib/state/comp_model.dart
@@ -72,6 +72,16 @@ class CompModel extends ChangeNotifier {
     return _model?.motionBlurEnabled ?? false;
   }
 
+  /// The engine revision the held model was read at, or null before the first
+  /// read. What a panel caching something *derived* from the model compares
+  /// against: the cache is good for as long as this number is, and an edit
+  /// moves it. Reading it freshens the model first, so it never reports a
+  /// revision older than what the caller is about to draw.
+  BigInt? get revision {
+    _freshen();
+    return _revision;
+  }
+
   /// Point the model at [comp] (or null) and read it.
   void bind(CompositionReference? comp) {
     _comp = comp;

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1238,6 +1238,52 @@ void main() {
           find.byKey(ValueKey<String>('tl-bar-ends-${layer.internallayerId}')));
       expect((marks.painter as BarEndMarksPainter).atIn, isFalse);
       expect((marks.painter as BarEndMarksPainter).atOut, isFalse);
+      expect(
+          find.byKey(ValueKey<String>('tl-bar-ghost-${layer.internallayerId}')),
+          findsNothing,
+          reason: 'no source, nothing to show past the ends');
+    });
+
+    /// A trimmed source-backed layer shows where its media would reach — the
+    /// faint outline behind the bar (K-211) — and stops showing it once the bar
+    /// fills the source, or once Retime makes "the source's reach" meaningless.
+    testWidgets('a trimmed precomp shows how far its source reaches',
+        (tester) async {
+      final p = withComp();
+      final inner = p.state.project!.newComposition(name: 'Inner');
+      final layer = p.comp.addPrecompLayer(comp: inner);
+      final sourceFrames = inner.durationFrames().toInt();
+      final ghost =
+          find.byKey(ValueKey<String>('tl-bar-ghost-${layer.internallayerId}'));
+
+      await mount(tester, p);
+      expect(ghost, findsNothing,
+          reason: 'a layer filling its source has nothing left to show');
+
+      // Crop the tail: the outline now reaches past it, to the source's end.
+      layer.setSpan(
+        span: BridgeSpan(
+          inPoint: p.comp.timeOfFrame(frame: 0),
+          outPoint: p.comp.timeOfFrame(frame: sourceFrames - 300),
+          startOffset: p.comp.timeOfFrame(frame: 0),
+        ),
+      );
+      p.uiState.model.refresh();
+      await tester.pumpAndSettle();
+      expect(ghost, findsOneWidget);
+      final fill =
+          find.byKey(ValueKey<String>('tl-bar-fill-${layer.internallayerId}'));
+      expect(tester.getRect(ghost).right,
+          greaterThan(tester.getRect(fill).right),
+          reason: 'it reaches past the trimmed end');
+      expect(tester.getRect(ghost).left, closeTo(tester.getRect(fill).left, 0.5),
+          reason: 'and not past the end that is still at the source start');
+
+      // Retime on: the source has no reach worth drawing any more.
+      layer.toggleRetimeProperty();
+      p.uiState.model.refresh();
+      await tester.pumpAndSettle();
+      expect(ghost, findsNothing);
     });
 
     /// A layer can start BEFORE the comp (docs/TODO: "re-introduce"): drag a

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -16,6 +16,7 @@ import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 import 'package:uuid/uuid.dart';
 import 'package:lumit_flutter/panels/project_panel_frb.dart';
+import 'package:lumit_flutter/panels/layer_fold_frb.dart';
 import 'package:lumit_flutter/panels/timeline_panel_frb.dart';
 import 'package:lumit_flutter/state/timeline_columns.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
@@ -1208,6 +1209,41 @@ void main() {
           find.byKey(ValueKey<String>('tl-bar-ends-${layer.internallayerId}')));
       expect((retimedMarks.painter as BarEndMarksPainter).atOut, isFalse,
           reason: 'no limit, no mark');
+    });
+
+    /// Switching Retime on keys the layer where it *is* (K-212): the two
+    /// diamonds land on its own start and end, not at the start of the
+    /// composition. Fails without the comp-clock conversion at the seam — the
+    /// keys drew at frames 0 and (duration) however far along the layer sat.
+    testWidgets('the Retime keys land on the layer, not the comp start',
+        (tester) async {
+      final p = withComp();
+      final inner = p.state.project!.newComposition(name: 'Inner');
+      final layer = p.comp.addPrecompLayer(comp: inner);
+      // Moved along the timeline and trimmed a little off its head, so its own
+      // zero is neither the comp's zero nor its in point.
+      layer.setSpan(
+        span: BridgeSpan(
+          inPoint: p.comp.timeOfFrame(frame: 180),
+          outPoint: p.comp.timeOfFrame(frame: 480),
+          startOffset: p.comp.timeOfFrame(frame: 120),
+        ),
+      );
+      layer.toggleRetimeProperty();
+      p.uiState.model.refresh();
+      await mount(tester, p);
+
+      final keys = layer.getRetimeProperty()! as BridgeScalar_Keyframed;
+      final frames = [
+        for (final key in keys.field0) p.comp.frameAtTime(time: key.time)
+      ];
+      expect(frames, [180, 480],
+          reason: 'the keys sit on the layer\'s own start and end');
+
+      // And that is where the lane draws them, in the panel's own arithmetic.
+      final fps = p.comp.fps();
+      expect([for (final key in keys.field0) laneKeyFrame(key, fps).round()],
+          [180, 480]);
     });
 
     /// A generated layer has no source to run out of: both ends go wherever

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1069,6 +1069,177 @@ void main() {
           (trimOut.deltaIn, trimOut.deltaOut, trimOut.offsetShift), (0, 7, 0));
     });
 
+    /// Which part of a bar a press takes hold of. The third-of-the-bar cap is
+    /// the point: without it a short bar is all edge and cannot be moved.
+    test('barGrabAt keeps a middle on even the shortest bar', () {
+      expect(barGrabAt(2, 100), BarGrab.trimIn);
+      expect(barGrabAt(50, 100), BarGrab.move);
+      expect(barGrabAt(97, 100), BarGrab.trimOut);
+      // Nine pixels wide: three each way, and a middle that still moves.
+      expect(barGrabAt(1, 9), BarGrab.trimIn);
+      expect(barGrabAt(4.5, 9), BarGrab.move);
+      expect(barGrabAt(8, 9), BarGrab.trimOut);
+    });
+
+    /// The rule the ends obey (K-210): a source-backed layer stops where its
+    /// media does, and Retime takes the limits off.
+    test('barBounds pins a source-backed layer and frees a retimed one', () {
+      expect(
+        barBounds(startOffsetFrame: 10, sourceFrames: 50, retimed: false),
+        const BarBounds(minIn: 10, maxOut: 60),
+      );
+      expect(
+        barBounds(startOffsetFrame: 10, sourceFrames: 50, retimed: true),
+        BarBounds.free,
+        reason: 'Retime decides its own source times, so the ends are free',
+      );
+      expect(
+        barBounds(startOffsetFrame: 10, sourceFrames: null, retimed: false),
+        BarBounds.free,
+        reason: 'a generated layer — or media that would not read — is free',
+      );
+    });
+
+    /// What the clamp actually does to a gesture in flight.
+    test('clampBarDelta holds a trim inside its source', () {
+      const bounds = BarBounds(minIn: 10, maxOut: 60);
+      int clamp(BarGrab grab, int delta,
+              {int inFrame = 20, int outFrame = 50, BarBounds b = bounds}) =>
+          clampBarDelta(
+              grab: grab,
+              delta: delta,
+              inFrame: inFrame,
+              outFrame: outFrame,
+              bounds: b);
+
+      expect(clamp(BarGrab.trimIn, -5), -5, reason: 'room to spare');
+      expect(clamp(BarGrab.trimIn, -50), -10,
+          reason: 'the head stops on the source\'s first frame');
+      expect(clamp(BarGrab.trimOut, 50), 10,
+          reason: 'the tail stops on the source\'s last frame');
+      expect(clamp(BarGrab.trimOut, 500, b: BarBounds.free), 500,
+          reason: 'a free end goes wherever it is dragged');
+      // A move carries the start offset, so it can never leave the source.
+      expect(clamp(BarGrab.move, 900), 900);
+      // Never inside out: a bar always keeps at least one frame.
+      expect(clamp(BarGrab.trimIn, 100), 29);
+      expect(clamp(BarGrab.trimOut, -100), -29);
+      // A layer already longer than its source keeps the length it has: the
+      // bound holds it still rather than dragging it back.
+      expect(clamp(BarGrab.trimOut, 5, inFrame: 20, outFrame: 80), 0);
+      expect(clamp(BarGrab.trimOut, -5, inFrame: 20, outFrame: 80), -5,
+          reason: 'pulling it back towards the source is always allowed');
+    });
+
+    /// Frames from exact times, in integers (K-184): the panel maps a start
+    /// offset without asking the engine, and must floor the way `frame_at`
+    /// does — including for a layer that starts before the comp.
+    test('frameOfTime floors the way the engine does', () {
+      BridgeRational r(int num, int den) => BridgeRational(num: num, den: den);
+      expect(frameOfTime(r(1, 1), 30, 1), 30);
+      expect(frameOfTime(r(1, 2), 30, 1), 15);
+      expect(frameOfTime(r(1, 30), 24, 1), 0, reason: 'floors, never rounds');
+      expect(frameOfTime(r(-1, 1), 30, 1), -30);
+      expect(frameOfTime(r(-1, 30), 24, 1), -1,
+          reason: 'negative times floor downwards, as div_euclid does');
+      expect(frameOfTime(r(1, 1), 30000, 1001), 29,
+          reason: '29.97: one second is 29 whole frames');
+    });
+
+    /// A Precomp layer cannot be trimmed past the comp it holds — and turning
+    /// Retime on takes the limit off (K-210). Fails without the clamp: the
+    /// tail simply followed the pointer.
+    testWidgets('a precomp bar stops at the end of its source', (tester) async {
+      final p = withComp();
+      final inner = p.state.project!.newComposition(name: 'Inner');
+      // A short source, so the tail can reach the end of it in one drag.
+      final settings = inner.getSettings();
+      inner.setSettings(
+        settings: BridgeCompSettings(
+          name: settings.name,
+          width: settings.width,
+          height: settings.height,
+          fpsNum: settings.fpsNum,
+          fpsDen: settings.fpsDen,
+          duration: const BridgeRational(num: 5, den: 1),
+        ),
+      );
+      final layer = p.comp.addPrecompLayer(comp: inner);
+      final sourceFrames = inner.durationFrames().toInt();
+      // Well inside the source, so there is room to drag outward.
+      layer.setSpan(
+        span: BridgeSpan(
+          inPoint: p.comp.timeOfFrame(frame: 0),
+          outPoint: p.comp.timeOfFrame(frame: 200),
+          startOffset: p.comp.timeOfFrame(frame: 0),
+        ),
+      );
+      await mount(tester, p);
+
+      final fill =
+          find.byKey(ValueKey<String>('tl-bar-fill-${layer.internallayerId}'));
+      // Far more than the source has left: the tail must stop, not follow.
+      await tester.dragFrom(
+        Offset(tester.getRect(fill).right - 2, tester.getRect(fill).center.dy),
+        const Offset(400, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(p.comp.frameAtTime(time: layer.getSpan().outPoint), sourceFrames,
+          reason: 'the tail landed on the source\'s last frame');
+
+      // The corner mark says why it stopped.
+      final marks = tester.widget<CustomPaint>(
+          find.byKey(ValueKey<String>('tl-bar-ends-${layer.internallayerId}')));
+      expect((marks.painter as BarEndMarksPainter).atOut, isTrue);
+
+      // Retime on: the layer now decides its own source times, so it stretches.
+      layer.toggleRetimeProperty();
+      p.uiState.model.refresh();
+      await tester.pumpAndSettle();
+      await tester.dragFrom(
+        Offset(tester.getRect(fill).right - 2, tester.getRect(fill).center.dy),
+        const Offset(100, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(p.comp.frameAtTime(time: layer.getSpan().outPoint),
+          greaterThan(sourceFrames),
+          reason: 'a retimed layer is any length the user drags it to');
+      final retimedMarks = tester.widget<CustomPaint>(
+          find.byKey(ValueKey<String>('tl-bar-ends-${layer.internallayerId}')));
+      expect((retimedMarks.painter as BarEndMarksPainter).atOut, isFalse,
+          reason: 'no limit, no mark');
+    });
+
+    /// A generated layer has no source to run out of: both ends go wherever
+    /// they are dragged, and neither wears a corner mark.
+    testWidgets('a solid bar trims freely and wears no marks', (tester) async {
+      final p = withComp();
+      final layer = p.comp.addSolidLayer();
+      layer.setSpan(
+        span: BridgeSpan(
+          inPoint: p.comp.timeOfFrame(frame: 0),
+          outPoint: p.comp.timeOfFrame(frame: 200),
+          startOffset: p.comp.timeOfFrame(frame: 0),
+        ),
+      );
+      await mount(tester, p);
+
+      final fill =
+          find.byKey(ValueKey<String>('tl-bar-fill-${layer.internallayerId}'));
+      await tester.dragFrom(
+        Offset(tester.getRect(fill).right - 2, tester.getRect(fill).center.dy),
+        const Offset(120, 0),
+      );
+      await tester.pumpAndSettle();
+      expect(
+          p.comp.frameAtTime(time: layer.getSpan().outPoint), greaterThan(200));
+
+      final marks = tester.widget<CustomPaint>(
+          find.byKey(ValueKey<String>('tl-bar-ends-${layer.internallayerId}')));
+      expect((marks.painter as BarEndMarksPainter).atIn, isFalse);
+      expect((marks.painter as BarEndMarksPainter).atOut, isFalse);
+    });
+
     /// A layer can start BEFORE the comp (docs/TODO: "re-introduce"): drag a
     /// bar left past frame zero and the span goes negative, carrying its
     /// content with it — the comp shows the part that overlaps.

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1247,6 +1247,48 @@ void main() {
     /// A trimmed source-backed layer shows where its media would reach — the
     /// faint outline behind the bar (K-211) — and stops showing it once the bar
     /// fills the source, or once Retime makes "the source's reach" meaningless.
+    /// The one-frame bug: the ghost outline appearing part-way through a trim
+    /// took the bar's place in its Stack, so the bar's element — and the
+    /// recogniser holding the drag — was rebuilt mid-gesture. The bar moved by
+    /// the first pointer event's frames and then went dead, which read as "the
+    /// edge only moves one frame". Fails without the keys on the Stack's
+    /// children; a single-event drag hides it, so this one moves in steps, as
+    /// a hand does.
+    testWidgets('a source-backed edge follows the pointer the whole way',
+        (tester) async {
+      final p = withComp();
+      final inner = p.state.project!.newComposition(name: 'Inner');
+      final layer = p.comp.addPrecompLayer(comp: inner);
+      await mount(tester, p);
+
+      final fill =
+          find.byKey(ValueKey<String>('tl-bar-fill-${layer.internallayerId}'));
+      final rect = tester.getRect(fill);
+      final before = p.comp.frameAtTime(time: layer.getSpan().outPoint);
+      // A mouse: precise pointers have a one-pixel slop, so every step of this
+      // counts as movement. Ten steps, the way a hand drags.
+      final gesture = await tester.startGesture(
+          Offset(rect.right - 2, rect.center.dy),
+          kind: PointerDeviceKind.mouse);
+      for (var i = 0; i < 10; i++) {
+        await gesture.moveBy(const Offset(-4, 0));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Forty pixels of pointer, at this zoom, is far more than the couple of
+      // frames one event carries.
+      final after = p.comp.frameAtTime(time: layer.getSpan().outPoint);
+      final perPixel = (before - after) / 40;
+      expect(perPixel, greaterThan(3),
+          reason: 'the edge tracked all forty pixels, not just the first four');
+      expect(
+          find.byKey(ValueKey<String>('tl-bar-ghost-${layer.internallayerId}')),
+          findsOneWidget,
+          reason: 'and the ghost that used to break it is on screen');
+    });
+
     testWidgets('a trimmed precomp shows how far its source reaches',
         (tester) async {
       final p = withComp();


### PR DESCRIPTION
Dragging either end of a layer's bar trims it, on every layer kind; a source-backed layer can no longer be dragged to show what its source does not hold (**K-211**); letting go of Retime re-hangs the layer on its source and a trimmed layer shows how far its media reaches (**K-212**); and keyframes now cross the bridge on the composition's clock, so they draw where they actually are (**K-213**).

> Numbered K-210/211/212 for most of its review; `main` took K-210 for the dropper in the meantime, so everything moved up one on the merge. The entries say so themselves.

## Trimming, and the limits (K-211)

Edge trimming existed but could not be found: a flat 6px grab zone with no cursor feedback, and on a short bar the two zones met in the middle, so it could be trimmed but never moved. The zones are 8px now, capped at a third of the bar each (`barGrabAt`), and the pointer takes the horizontal resize arrow over them.

**The source is the limit.** Footage — picture and sound alike — and Precomp trim within their source: the in point stops on the source's first frame, the out point on its last. Generated kinds (Solid, Text, Adjustment, Null, Camera, Sequence) have nothing to run out of and trim freely. **Retime takes both limits off**, by either route. Moving a bar is never limited: the start offset travels with it. Media whose length will not read leaves the ends free rather than pinned to a guess.

**The corner marks.** A small triangle in the bar's top-left or top-right corner when that end is as far as its source allows, in the same ink as the clip splits. Absent on the kinds with no source, and gone the moment Retime is on.

## Letting go of Retime (K-212)

It **re-anchors on the frame already on screen**: the layer keeps its in point, still shows that same frame there, and runs at source rate until either the source runs out or its own out point arrives — whichever comes first. It never grows, so a layer trimmed short stays short. One undo step covers the removal and the span, and both retime routes let go the same way. The anchor snaps to the comp's frame grid, because the start offset it produces is what every later trim measures from. `unretimed_span` is a pure function in `lumit-core::ops`; the bridge supplies only the two facts it cannot derive.

## The source's reach (K-212)

A trimmed, un-retimed, source-backed layer draws a **faint outlined rectangle spanning the whole source, behind the bar** — so what shows past each end is exactly the material trimmed away. One vocabulary with the triangles: a triangle says *this end can go no further*, the outline says *it could, and this is how far*. Both marks travel with a bar being moved.

## Keyframes on the composition's clock (K-213)

Reported from the app: switching Retime on put its two keys "where the start and end points would be if the layer's position was still at the start of the comp". They were — and so was **every** keyframe on any layer that had been moved. The report caught a seam fault whose only unmissable face is the two keys Retime creates for you.

The engine keys every property in layer-local time (comp time less `start_offset`), which is what makes a layer's animation travel with it when the bar is dragged; the frontend thinks in comp frames, which is what the ruler counts and what a key drag commits. Only the conversion was missing. The bridge does it now, in one place: `read_at` carries a key out by the owning layer's offset, `animation_at` carries it back, and both take the offset with **no default**, so a new reader cannot forget one — the compiler asked for it at every call site when the signatures changed. The transform group, the Retime property, effect parameters, a camera's zoom, a volume curve and the staged `BridgeEffectInstance` all go through them; that handle now carries its layer's offset. `BridgeEffectInstance::new` stopped being exposed to Dart in the same move (never called from there, and a constructor with no layer has no honest offset to take) — the only removal from the generated API.

Retime's own keys now span the layer's local in and out rather than zero and its duration. That was two faults in one: on screen the keys sat at the comp start, and in the model a trimmed layer's map stopped short of its tail — past the last key a property holds, so everything beyond `duration` played one frame over and over.

## The one-frame bug, and why the first tests missed it

Also reported from the app: dragging a footage or precomp edge moved it a frame or two and then went dead. The ghost is a second child of the bar's `Stack` and appears the moment a trim starts; unkeyed, Flutter matches a `Stack`'s children by position, so the ghost arriving took the bar's slot and the bar's element — with it the recogniser holding the drag — was rebuilt mid-gesture. Both children are keyed now.

It only bit the source-backed kinds (the only ones with a ghost) and only when the pointer moved in **more than one event** — which is why the first round of widget tests, each dragging in a single synthetic step, all passed. Reproduced against a real 5-second H.264 clip, then pinned with a Precomp test that drags in ten mouse steps and measures frames per pixel across the whole gesture: without the keys it is zero.

## Cost per rebuild: nothing (K-184)

A footage length comes from probing the file, so it is asked once per layer off the build and kept for the session, the same bargain the waveform peaks strike. The rest is worked out once per *document revision*; `CompModel` now exposes that revision. Frames come from exact integer arithmetic on the comp's rate rather than a bridge call per layer. Budget suite unchanged: mount 33, click 6, twirl 8, scrub 7.

## Docs

`docs/07-UI-SPEC.md` §4.7 states the trim rules; `docs/17-BRIDGE-CONTRACT.md` states the keyframe-clock rule at the seam it belongs to; `docs/GUIDE.md` gains the plain-English passes; `docs/02-DECISIONS.md` appends **K-211**, **K-212** and **K-213**, including why the trim bound lives in the panel, why the re-anchor lives in the engine, the keyed-children trap, and the pre-K-197 speed map deliberately left alone.

## Tests

Rust: five unit tests for `unretimed_span`; a bridge test driving a Precomp through retime-on → stretch → retime-off for all three anchor cases; a bridge test that a key written at a comp time reads back at that time and *travels with the layer* when it is moved; and one that enabling Retime keys the layer's own in and out with identity source values.

Dart: four unit tests (`barGrabAt`, `barBounds`, `clampBarDelta`, `frameOfTime`) and five widget tests against the real engine — the source limit and its release under Retime, a Solid trimming freely, the ghost appearing and vanishing, the multi-event drag that fails without the `Stack` keys, and the Retime keys landing on the layer rather than the comp start.

Verified locally with the engine built (FFmpeg 7.1) on the merged tree: `cargo fmt --check`, clippy and `cargo test --workspace` green; `flutter analyze` clean; full `flutter test` at 416 passed / 21 failed, the failing set byte-identical to the same tree without these changes — this container's missing GPU and audio device. Bridge bindings regenerated at the pinned frb 2.12.0 after the merge, and CI's codegen-freshness job agrees.

## Notes on CI

`main` moved under the branch mid-review and the generated bridge conflicted; the merge takes both sides' sources and re-runs codegen rather than hand-merging generated files. All nine checks are green on the merged head.

One earlier run failed `lumit-gpu`'s `the_legacy_handle_yields_the_pixels_angle_style` with all zeros where the orange should be — between two runs of this branch that passed, with nothing in that commit touching GPU code, and green on `main`. It is the handshake the module note already admits is missing: `present` flushes the D3D11 copy without waiting for it, and the test's reader opens the shared texture on a third device with no keyed mutex. Rather than blind-patch Windows GPU code that cannot be run before it is pushed, the race is written up in `docs/TODO.md` with both cures.