### PR TITLE
Copy frames to the disk when the editor is idle, and get held frames in advance

### DIFF
--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -92,6 +92,10 @@ pub struct WorkerState {
     /// playhead is held, or the budget is full). Cleared whenever the anchor,
     /// the document or the budget moves.
     fill_exhausted: bool,
+    /// True when every frame held on the card is on disk as well, so the idle
+    /// backup has nothing to copy ([`idle_backup`]). Cleared whenever a frame
+    /// is banked or the disk tier is re-opened, since either can make work.
+    backup_exhausted: bool,
     /// When the last request arrived — the fill waits out a ~200 ms lull
     /// after it (docs/06 §5.5), so a scrub in progress is never contended.
     last_request: std::time::Instant,
@@ -204,6 +208,10 @@ fn sync_caches(state: &mut WorkerState) {
     if (used as u64, entries as u64) != state.published_vram {
         state.published_vram = (used as u64, entries as u64);
         crate::framecache::vram::publish(used as u64, entries as u64);
+        // What the card holds has changed, thus there may be something new to
+        // copy down. Cheaper than asking the backup itself, which would walk
+        // every held frame to find out.
+        state.backup_exhausted = false;
     }
 
     sync_disk(state);
@@ -228,8 +236,10 @@ fn sync_disk(state: &mut WorkerState) {
             .tx
             .send(lumit_render::diskio::Cmd::SetRoot(root.clone()));
         // A different folder holds different frames, so there may be something
-        // to promote again.
+        // to promote again — and everything held is unparked as far as the new
+        // folder is concerned, thus there is a backup to make.
         state.fill_exhausted = false;
+        state.backup_exhausted = false;
     }
     let budget = crate::framecache::disk::budget();
     if budget != state.applied_disk_budget {
@@ -740,6 +750,46 @@ fn prepare_frame(
     state
         .renderer
         .render_prepared_named(document, comp, frame, quality, bgra, name)
+}
+
+/// Copy ONE held frame down to disk while the editor is idle — so a session
+/// that never fills the card's cache still leaves something for tomorrow.
+///
+/// # Why this exists
+///
+/// A frame used to reach the disk tier by one route only: it was pushed out of
+/// the card's cache, read back on the way down, and parked. That route needs the
+/// cache to be **full**. Give it a budget bigger than a session ever fills —
+/// 10 GB on a roomy card — and it is never full, nothing is ever pushed out, and
+/// nothing is ever written to disk. The tier whose whole purpose is to make
+/// tomorrow start warm stayed empty, and the *more* memory the user gave the
+/// cache the more certainly it stayed empty. Exactly the wrong way round, and
+/// invisible: the cache bar was green all session, and green again as nothing
+/// after a restart.
+///
+/// So the ladder has a second way down, used only when there is time to spare.
+/// The frame stays on the card and keeps serving the Viewer; a copy goes to
+/// memory and to disk. One frame per turn, and never more than the read-backs
+/// already in flight allow, so this can never compete with the picture.
+///
+/// It runs on the same lull as the fill but is *not* gated on the fill being
+/// finished: on a long composition the fill has frames to make for as long as
+/// the budget lasts, and waiting for it to run out would mean waiting for ever.
+#[frb(ignore)]
+fn idle_backup(state: &mut WorkerState) {
+    // Nowhere to put them: the disk tier is off (no project folder yet, or no
+    // home directory). Nothing to do until that changes, which `sync_disk`
+    // reports by clearing the flag.
+    if state.seen_disk_location.1.is_none() {
+        state.backup_exhausted = true;
+        return;
+    }
+    // Two disjoint borrows of the worker's state: the renderer walks its held
+    // frames, the disk mirror answers which of them are already parked.
+    let disk = &state.disk;
+    if !state.renderer.start_backup(&|hash| disk.contains(hash)) {
+        state.backup_exhausted = true;
+    }
 }
 
 /// Render ONE uncached frame near the playhead into the VRAM frame cache —
@@ -1262,6 +1312,7 @@ fn worker_loop(
         bar_refined_to: 0,
         bar_published_at: std::time::Instant::now() - BAR_MIN_INTERVAL,
         fill_exhausted: true,
+        backup_exhausted: true,
         last_request: std::time::Instant::now(),
         layer_sample: None,
     };
@@ -1287,7 +1338,9 @@ fn worker_loop(
                 }
             }
         } else {
-            let wait = if state.fill_exhausted {
+            // Idle work of any kind means come back soon; with none left, wait
+            // long enough that an idle editor costs nothing.
+            let wait = if state.fill_exhausted && state.backup_exhausted {
                 std::time::Duration::from_millis(200)
             } else {
                 std::time::Duration::from_millis(2)
@@ -1297,8 +1350,18 @@ fn worker_loop(
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                     let lull =
                         state.last_request.elapsed() >= std::time::Duration::from_millis(200);
-                    if !state.fill_exhausted && lull {
-                        idle_fill(&mut state, &mut stream);
+                    if lull {
+                        if !state.fill_exhausted {
+                            idle_fill(&mut state, &mut stream);
+                        }
+                        // Alongside the fill, not after it. On a long
+                        // composition the fill has frames to make for as long as
+                        // the budget lasts, thus "when the fill is finished"
+                        // would mean "never" — and never is how long the disk
+                        // tier stayed empty.
+                        if !state.backup_exhausted {
+                            idle_backup(&mut state);
+                        }
                     }
                     None
                 }

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -1047,6 +1047,11 @@ struct Playback {
     /// [`Self::pre_roll_done`]). `None` once the sound has been started, or
     /// when this run never had any.
     pending_audio: Option<std::sync::Arc<lumit_core::Document>>,
+    /// True while the sound is stopped **because the picture fell behind it**,
+    /// as against stopped because the user asked. Every-frame playback holds the
+    /// track rather than letting it drift (K-171), and this is what remembers to
+    /// start it again when the picture arrives — see [`chase_audio`].
+    audio_held_for_picture: bool,
     /// How many frames the last [`Self::advance`] had to jump over to catch the
     /// clock. Zero while playback is keeping up.
     ///
@@ -1237,6 +1242,121 @@ fn clock_seconds() -> Option<f64> {
     }
     #[cfg(not(feature = "media"))]
     None
+}
+
+/// Hold the sound when the picture falls behind it, and start it again when the
+/// picture arrives — every-frame playback's half of A/V sync (K-171).
+///
+/// # Why it stops at all
+///
+/// Every-frame mode shows every frame however long each one takes, thus the
+/// picture can fall behind the clock. Two answers were possible and only one is
+/// correct: let the sound run on and drift away from the picture, or hold the
+/// sound until the picture is level again. Lumit holds it.
+///
+/// # Why it must start again by itself
+///
+/// It did not. The sound stopped, and the clock stops reporting when the sound
+/// stops, thus the test that stopped it could never run a second time and
+/// nothing ever started it. One slow frame therefore took the sound away for the
+/// rest of the run, and the only way back was to stop playback and press play
+/// again — a fault the user had to work around, and one that looked like the
+/// sound was broken rather than waiting.
+///
+/// The clock holds its position while it is stopped, so the position is exactly
+/// what says when the picture has arrived: the sound waits at the moment it
+/// reached, and the picture walks forward to meet it.
+///
+/// # The two limits, and why they are not the same number
+///
+/// It stops at [`AUDIO_HOLD_BEHIND`] of lag and starts again only when the
+/// picture is level or in front. A single limit would start and stop the sound
+/// at every frame near it, which is worse than either answer. The gap between
+/// the two is what makes the decision stable.
+#[frb(ignore)]
+fn chase_audio(playback: &mut Playback, frame: u64) {
+    let shown = frame as f64 / playback.fps;
+    let Some(clock) = held_clock_seconds() else {
+        // No mix at all: nothing to hold and nothing to start.
+        playback.audio_held_for_picture = false;
+        return;
+    };
+    match audio_chase(playback.audio_held_for_picture, clock - shown) {
+        AudioChase::Hold => {
+            playback.audio_held_for_picture = true;
+            crate::api::audio::audio_pause();
+        }
+        AudioChase::Start => {
+            playback.audio_held_for_picture = false;
+            resume_audio();
+        }
+        AudioChase::Leave => {}
+    }
+}
+
+/// What to do with the sound this frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[frb(ignore)]
+enum AudioChase {
+    /// Stop it: the picture is too far behind.
+    Hold,
+    /// Start it: the picture has arrived.
+    Start,
+    /// Neither.
+    Leave,
+}
+
+/// The rule [`chase_audio`] applies, with no sound device in it so the rule can
+/// be tested on its own.
+///
+/// `behind` is how far the sound is in front of the picture, in seconds.
+#[frb(ignore)]
+fn audio_chase(held: bool, behind: f64) -> AudioChase {
+    if held {
+        // Level or in front: the picture has met the sound where it waited.
+        // Only this ends the wait, and it is a different number from the one
+        // that began it — one number would start and stop the sound at every
+        // frame near it.
+        if behind <= 0.0 {
+            AudioChase::Start
+        } else {
+            AudioChase::Leave
+        }
+    } else if behind > AUDIO_HOLD_BEHIND {
+        AudioChase::Hold
+    } else {
+        AudioChase::Leave
+    }
+}
+
+/// How far the picture may fall behind the sound before the sound waits for it.
+/// Half a second is well past any unevenness the ring absorbs, thus this cannot
+/// fire on ordinary jitter.
+const AUDIO_HOLD_BEHIND: f64 = 0.5;
+
+/// Where the sound has got to **whether or not it is running** — the number
+/// [`clock_seconds`] hides once the sound stops.
+///
+/// Every-frame playback stops the sound when the picture falls behind, and the
+/// clock then holds its position. Deciding when the picture has caught up needs
+/// exactly that held position, thus it cannot be read through a function that
+/// answers `None` for a stopped clock. `None` here means there is no mix at all.
+#[frb(ignore)]
+fn held_clock_seconds() -> Option<f64> {
+    #[cfg(feature = "media")]
+    {
+        let (seconds, _playing, loaded) = crate::audio::clock();
+        loaded.then_some(seconds)
+    }
+    #[cfg(not(feature = "media"))]
+    None
+}
+
+/// Start the sound again where it stopped (see [`crate::audio::resume`]).
+#[frb(ignore)]
+fn resume_audio() {
+    #[cfg(feature = "media")]
+    crate::audio::resume();
 }
 
 pub struct RenderCompRequest {
@@ -1530,19 +1650,8 @@ fn play_one_frame(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
             // it, so a stop resumes filling from where the user actually is.
             state.last_shown = Some((playback.comp.clone(), frame, playback.scale));
             state.fill_exhausted = false;
-            // Every-frame plays WITH sound while it holds the comp's rate, and
-            // pauses the sound when the picture falls genuinely behind — the
-            // K-171 v1 behaviour (a paused track over a slow-motion picture,
-            // never a drifting one). Half a second of lag is well past any
-            // jitter the ring absorbs. Once paused the clock stops reporting,
-            // so this fires once per fall-behind, and the next press of play
-            // starts the sound afresh.
             if matches!(playback.mode, BridgePlaybackMode::EveryFrame) {
-                if let Some(clock) = clock_seconds() {
-                    if clock - frame as f64 / playback.fps > 0.5 {
-                        crate::api::audio::audio_pause();
-                    }
-                }
+                chase_audio(playback, frame);
             }
             present_ring_frame(&mut state.renderer, frame, &prepared, stream);
             return;
@@ -1774,6 +1883,7 @@ fn start_playback(req: PlayRequest, state: &mut WorkerState) -> Result<(), Bridg
         ring: std::collections::VecDeque::new(),
         costs: crate::playback::CostWindow::default(),
         prefetched_to: None,
+        audio_held_for_picture: false,
         skipped: 0,
     });
     // A fresh run starts optimistic at Full and walks down to whatever this
@@ -2545,6 +2655,7 @@ mod tests {
             ring: std::collections::VecDeque::new(),
             costs: crate::playback::CostWindow::default(),
             prefetched_to: None,
+            audio_held_for_picture: false,
             pending_audio: None,
             skipped: 0,
         }
@@ -3026,7 +3137,45 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod bar_strip_tests {
-    use super::{refine_bar_strip, sample_bar_strip, wants_disk_lead};
+    use super::{audio_chase, refine_bar_strip, sample_bar_strip, wants_disk_lead, AudioChase};
+
+    /// **The sound waits for the picture, and then it starts again by itself.**
+    ///
+    /// Every-frame playback shows every frame however long each takes, thus the
+    /// picture can fall behind. Lumit stops the sound and lets it wait, rather
+    /// than let it run on and drift away from the picture (K-171).
+    ///
+    /// The regression: it never started again. The clock stops reporting when
+    /// the sound stops, thus the test that stopped it could not run a second
+    /// time and nothing started it. One slow frame took the sound away for the
+    /// rest of the run, and the only way back was to stop playback and press
+    /// play again.
+    ///
+    /// The two limits are deliberately different numbers. One limit would start
+    /// and stop the sound at every frame near it.
+    #[test]
+    fn the_sound_waits_for_the_picture_and_then_starts_again() {
+        // Running, and the picture keeps up: nothing happens.
+        assert_eq!(audio_chase(false, 0.0), AudioChase::Leave);
+        assert_eq!(audio_chase(false, 0.4), AudioChase::Leave, "inside jitter");
+        // Running, and the picture falls well behind: the sound waits.
+        assert_eq!(audio_chase(false, 0.6), AudioChase::Hold);
+
+        // Waiting, and the picture is still behind: it goes on waiting. This is
+        // the case that used to be unreachable, because the clock reported
+        // nothing once the sound had stopped.
+        assert_eq!(audio_chase(true, 0.4), AudioChase::Leave);
+        assert_eq!(audio_chase(true, 0.6), AudioChase::Leave);
+        // Waiting, and the picture arrives: the sound starts itself.
+        assert_eq!(audio_chase(true, 0.0), AudioChase::Start);
+        assert_eq!(audio_chase(true, -0.2), AudioChase::Start, "or overtakes");
+
+        // The gap between the two limits is what makes the decision stable: a
+        // picture 0.4 s behind neither stops a running sound nor starts a
+        // waiting one, thus it cannot flap.
+        assert_eq!(audio_chase(false, 0.4), AudioChase::Leave);
+        assert_eq!(audio_chase(true, 0.4), AudioChase::Leave);
+    }
 
     /// Playback asks the disk tier for a frame in advance, and only when the
     /// read is of use — the last rung, reached only when the ones above it

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -610,25 +610,39 @@ fn zero_copy_wants_bgra() -> bool {
     ))
 }
 
-/// Ask the disk tier for a frame that playback will want soon.
+/// Put a frame playback will want soon onto the graphics card **before** it is
+/// due — the "ahead of the playhead" half of docs/06 §5.1.
 ///
-/// **Why the lead time is the whole point.** A read off disk goes to the IO
-/// thread, and the frame it brings back arrives one or two turns of the worker
-/// loop later. [`prepare_frame`] asks for a frame at the moment it must show it,
-/// thus the bytes always come too late for that frame and it is composited
-/// again. Playback then gets no good from a span that is parked on disk, which
-/// is most of what the disk tier holds after a project is re-opened.
+/// # Why each rung needs its own lead time
 ///
-/// This asks for the frames that playback will reach in a moment, at the same
-/// time as the decodes for those frames go to the prefetch thread. The bytes
-/// arrive, [`collect_disk_loads`] puts them on the card, and playback finds the
-/// frame already there.
+/// The ring renders ahead of the clock, thus a frame is composited before it is
+/// shown. What was *not* ahead of anything was the trip up the ladder. Both
+/// lower rungs were climbed at the moment the frame was wanted, inside the
+/// render turn:
 ///
-/// Nothing here waits and nothing here is expensive: naming a frame is a hash of
-/// the composition, and the watermark in [`play_one_frame`] names each coming
-/// frame once for each pass of playback.
+/// * **From memory** the climb is an upload, and an upload is quick — but it
+///   happened on the worker thread in the middle of the turn that had to
+///   produce the frame, so it was paid out of that frame's budget rather than
+///   out of the slack the ring exists to bank.
+/// * **From disk** the climb is a message to another thread, and the bytes come
+///   back one or two turns of the loop later. Asked for at the moment the frame
+///   was due, they always arrived too late for it, and playback composited the
+///   frame from the beginning instead — so a span sitting in a file was worth
+///   nothing to the pass that went over it.
+///
+/// This does both in advance, over the same look-ahead window whose source
+/// decodes are already posted. By the time the ring reaches the frame it is a
+/// hit on the card and no composite happens at all.
+///
+/// Nothing here waits. A frame that cannot be named yet is left alone, a copy
+/// that has not arrived is simply not there yet, and the ordinary path composites
+/// as it always did.
+///
+/// Returns whether it did work the caller should count: an upload happened.
+/// Asking the disk for a copy is a message to another thread and costs this one
+/// nothing, thus it does not count.
 #[frb(ignore)]
-fn request_disk_lead(
+fn line_up_frame(
     renderer: &mut lumit_render::HeadlessRenderer,
     disk: &lumit_render::diskio::DiskIo,
     disk_wanted: &mut std::collections::HashMap<u128, lumit_render::FrameProvenance>,
@@ -636,32 +650,54 @@ fn request_disk_lead(
     comp: Uuid,
     frame: u64,
     quality: lumit_render::Quality,
-) {
+) -> bool {
     let bgra = zero_copy_wants_bgra();
     let Some(key) = renderer.frame_key(document, comp, frame, quality) else {
-        // Not nameable yet (footage still being probed), thus not on disk under
-        // any name either.
-        return;
+        // Not nameable yet (footage still being probed), thus not held anywhere
+        // under any name either.
+        return false;
     };
+    if renderer.has_frame_texture(key, bgra) {
+        // Already where it needs to be.
+        return false;
+    }
+    let provenance = lumit_render::FrameProvenance {
+        comp,
+        frame,
+        scale_q: lumit_render::preview_scale_q(quality),
+    };
+    // Memory first: it is one upload away, which is cheaper than a file and far
+    // cheaper than a composite. Doing it now means the render turn finds a hit.
+    if let Some(held) = crate::framecache::held(key) {
+        // Only the order it came down in can go back up: the other order would
+        // show with red and blue swapped.
+        if held.bgra == bgra {
+            return renderer
+                .upload_frame_texture(lumit_render::Promotion {
+                    key,
+                    bgra,
+                    width: held.width,
+                    height: held.height,
+                    bytes: &held.bytes,
+                    cost_ms: held.cost_ms,
+                    provenance,
+                })
+                .is_some();
+        }
+    }
     if !wants_disk_lead(
-        renderer.has_frame_texture(key, bgra),
+        false,
         crate::framecache::contains(key),
         disk.contains(key),
         disk_wanted.contains_key(&key),
     ) {
-        return;
+        return false;
     }
-    disk_wanted.insert(
-        key,
-        lumit_render::FrameProvenance {
-            comp,
-            frame,
-            scale_q: lumit_render::preview_scale_q(quality),
-        },
-    );
+    disk_wanted.insert(key, provenance);
     _ = disk
         .tx
         .send(lumit_render::diskio::Cmd::Load { hash: key, bgra });
+    false
 }
 
 /// Whether a coming frame is worth a read off disk.
@@ -684,14 +720,17 @@ fn wants_disk_lead(on_card: bool, in_memory: bool, on_disk: bool, already_asked:
 /// 1. **Already on the card** — [`HeadlessRenderer::render_prepared`] answers
 ///    from its own cache without compositing.
 /// 2. **Held in memory** — uploaded straight back into a texture, which is a
-///    fraction of a composite and the reason the RAM tier exists at all.
+///    fraction of a composite and the reason the RAM tier exists at all. During
+///    playback this has usually happened already, in advance
+///    ([`line_up_frame`]); what is left here is the frame nobody looked ahead
+///    for — a scrub, or the first frame of a pass.
 /// 3. **Parked on disk** — *asked for*, never waited on. A disk read plus
 ///    decompression is not something to hold the preview open for, so the frame
 ///    is composited now and the copy off disk lands a turn or two later, in time
 ///    for the next visit. This is what makes reopening a project warm up as you
 ///    scrub rather than only where the fill has reached. Playback does not wait
 ///    for that second visit: it asks for the coming frames in advance
-///    ([`request_disk_lead`]), thus a parked span plays from the card.
+///    ([`line_up_frame`]), thus a parked span plays from the card.
 /// 4. **Composited**, and banked on the way past.
 #[frb(ignore)]
 fn prepare_frame(
@@ -855,6 +894,11 @@ fn idle_fill(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     // — the far side of where you now are. It still terminates: the walk is
     // bounded, and every frame in the window ends up held.
     let window = (budget / frame_bytes).max(1);
+    // Frames the disk holds are asked for as the walk passes them, and the walk
+    // carries on. A load is a message to another thread, thus queueing several
+    // costs nothing here — and by the time the fill comes round again they have
+    // arrived and gone onto the card, which is what makes a re-opened project
+    // warm up by *reading* rather than by rendering everything a second time.
     for frame in crate::playback::fill_order(anchor, first, last).take(window) {
         // Naming the frame is what tells the fill whether there is anything to
         // do — and under content keying the name is the same one every tier files
@@ -864,6 +908,35 @@ fn idle_fill(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
             .frame_key(&document, comp_ref.id, frame, quality)
         {
             if state.renderer.has_frame_texture(key, bgra) {
+                continue;
+            }
+            // **Held below: climb it, do not make it again.** The fill has no
+            // deadline — that is what makes it the fill — thus a frame that
+            // already exists in memory or in a file must never be composited
+            // afresh. `prepare_frame` below would do that for a parked frame:
+            // it asks for the copy and composites anyway, which is right when a
+            // frame is due *now* and wrong here. After a re-opened project this
+            // is the difference between reading a session's cache back and
+            // rendering the whole of it a second time.
+            if crate::framecache::contains(key) || state.disk.contains(key) {
+                let uploaded = line_up_frame(
+                    &mut state.renderer,
+                    &state.disk,
+                    &mut state.disk_wanted,
+                    &document,
+                    comp_ref.id,
+                    frame,
+                    quality,
+                );
+                // An upload is this turn's work, exactly as a render would be:
+                // a request arriving mid-fill then waits for one frame, not for
+                // a window's worth. Asking the disk costs this thread nothing,
+                // so the walk carries on queueing those.
+                if uploaded {
+                    _ = stream.add(WorkerResponse::CacheFilled);
+                    state.fill_exhausted = false;
+                    return;
+                }
                 continue;
             }
         }
@@ -876,6 +949,12 @@ fn idle_fill(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
         }
         return;
     }
+    // Nothing left for the fill to *make*. Copies may still be on their way up
+    // from disk, and the fill does not wait for them by spinning: walking the
+    // window again means naming every frame in it again, which is real work to
+    // do while the answer is on another thread. What wakes it instead is the
+    // copy landing — `collect_disk_loads` clears this the moment one reaches
+    // the card, and the fill then finds it held and moves on to the next.
     state.fill_exhausted = true;
 }
 
@@ -1520,7 +1599,7 @@ fn play_one_frame(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
                 // asked for when it is shown always comes too late and is
                 // composited again. Asked for now, it is on the card before
                 // playback gets there.
-                request_disk_lead(
+                _ = line_up_frame(
                     &mut state.renderer,
                     &state.disk,
                     &mut state.disk_wanted,
@@ -2882,7 +2961,11 @@ mod bar_strip_tests {
     use super::{refine_bar_strip, sample_bar_strip, wants_disk_lead};
 
     /// Playback asks the disk tier for a frame in advance, and only when the
-    /// read is of use.
+    /// read is of use — the last rung, reached only when the ones above it
+    /// cannot answer. The rung above is memory, and it is climbed in advance
+    /// too: `line_up_frame` uploads a held frame to the card before the frame is
+    /// due, thus by the time this predicate is asked, "in memory" has already
+    /// been dealt with and only a genuine file read is left.
     ///
     /// **Why this matters.** A read off disk arrives one or two turns of the
     /// worker loop after it is asked for. A frame asked for at the moment it

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -1244,35 +1244,44 @@ fn clock_seconds() -> Option<f64> {
     None
 }
 
-/// Hold the sound when the picture falls behind it, and start it again when the
-/// picture arrives — every-frame playback's half of A/V sync (K-171).
+/// Hold the sound when the picture falls behind it, and start it again — level
+/// with the picture — once the picture is running freely. Every-frame
+/// playback's half of A/V sync (K-171).
 ///
 /// # Why it stops at all
 ///
 /// Every-frame mode shows every frame however long each one takes, thus the
 /// picture can fall behind the clock. Two answers were possible and only one is
-/// correct: let the sound run on and drift away from the picture, or hold the
-/// sound until the picture is level again. Lumit holds it.
+/// correct: let the sound run on and drift away from the picture, or stop the
+/// sound. Lumit stops it.
 ///
-/// # Why it must start again by itself
+/// # Why it must start again by itself, and why the picture is not what it waits
+/// for
 ///
-/// It did not. The sound stopped, and the clock stops reporting when the sound
+/// It did not start again at all. The clock stops reporting when the sound
 /// stops, thus the test that stopped it could never run a second time and
-/// nothing ever started it. One slow frame therefore took the sound away for the
-/// rest of the run, and the only way back was to stop playback and press play
-/// again — a fault the user had to work around, and one that looked like the
-/// sound was broken rather than waiting.
+/// nothing started it. One slow frame took the sound away for the rest of the
+/// run, and the only way back was to stop playback and press play again.
 ///
-/// The clock holds its position while it is stopped, so the position is exactly
-/// what says when the picture has arrived: the sound waits at the moment it
-/// reached, and the picture walks forward to meet it.
+/// The obvious repair is wrong, and was tried: wait for the picture to reach the
+/// moment the sound had got to. The sound stops where it is, thus that moment is
+/// **in front of** the picture by however long the slow frame took — thirty
+/// seconds of rendering puts it thirty seconds in front. The picture then needs
+/// thirty seconds of playing to arrive, and if the composition ends first it
+/// never arrives at all. The sound stays off for the rest of the run, which is
+/// the fault this exists to repair.
 ///
-/// # The two limits, and why they are not the same number
+/// So the sound comes back to the **picture**. When the renders are in front of
+/// the presents again — the same measure the pre-roll uses to decide the sound
+/// may start at all — the sound is moved to the frame on screen and started
+/// there. The two are level by construction, at a moment the picture is
+/// certainly at, because it is the frame being shown.
 ///
-/// It stops at [`AUDIO_HOLD_BEHIND`] of lag and starts again only when the
-/// picture is level or in front. A single limit would start and stop the sound
-/// at every frame near it, which is worse than either answer. The gap between
-/// the two is what makes the decision stable.
+/// # The two tests are different on purpose
+///
+/// It stops on a *distance* ([`AUDIO_HOLD_BEHIND`]) and starts on *banked
+/// frames*. Neither is the other's negation, thus a picture that wavers at the
+/// edge of one cannot start and stop the sound at every frame.
 #[frb(ignore)]
 fn chase_audio(playback: &mut Playback, frame: u64) {
     let shown = frame as f64 / playback.fps;
@@ -1281,13 +1290,18 @@ fn chase_audio(playback: &mut Playback, frame: u64) {
         playback.audio_held_for_picture = false;
         return;
     };
-    match audio_chase(playback.audio_held_for_picture, clock - shown) {
+    let banked = playback.ring.len();
+    match audio_chase(playback.audio_held_for_picture, clock - shown, banked) {
         AudioChase::Hold => {
             playback.audio_held_for_picture = true;
             crate::api::audio::audio_pause();
         }
         AudioChase::Start => {
             playback.audio_held_for_picture = false;
+            // To the frame on screen, then run. The sound stopped ahead of the
+            // picture, thus starting it where it stopped would play a moment
+            // the picture has not reached.
+            crate::api::audio::audio_seek(shown);
             resume_audio();
         }
         AudioChase::Leave => {}
@@ -1310,14 +1324,16 @@ enum AudioChase {
 /// be tested on its own.
 ///
 /// `behind` is how far the sound is in front of the picture, in seconds.
+/// `banked` is how many finished frames are waiting to be shown.
 #[frb(ignore)]
-fn audio_chase(held: bool, behind: f64) -> AudioChase {
+fn audio_chase(held: bool, behind: f64, banked: usize) -> AudioChase {
     if held {
-        // Level or in front: the picture has met the sound where it waited.
-        // Only this ends the wait, and it is a different number from the one
-        // that began it — one number would start and stop the sound at every
-        // frame near it.
-        if behind <= 0.0 {
+        // Frames waiting to be shown means the renders are in front of the
+        // presents again, thus the picture is running freely and the sound can
+        // rejoin it. Deliberately NOT "the picture reached the sound": the sound
+        // stopped ahead of the picture, at a moment the picture may never get
+        // to, and does not get to at all if the composition ends first.
+        if banked >= PRE_ROLL_FRAMES {
             AudioChase::Start
         } else {
             AudioChase::Leave
@@ -3137,44 +3153,58 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod bar_strip_tests {
-    use super::{audio_chase, refine_bar_strip, sample_bar_strip, wants_disk_lead, AudioChase};
+    use super::{
+        audio_chase, refine_bar_strip, sample_bar_strip, wants_disk_lead, AudioChase,
+        PRE_ROLL_FRAMES,
+    };
 
-    /// **The sound waits for the picture, and then it starts again by itself.**
+    /// **The sound stops when the picture falls behind, and comes back to the
+    /// picture when the picture is running freely again.**
     ///
     /// Every-frame playback shows every frame however long each takes, thus the
-    /// picture can fall behind. Lumit stops the sound and lets it wait, rather
-    /// than let it run on and drift away from the picture (K-171).
+    /// picture can fall behind. Lumit stops the sound rather than let it drift
+    /// away from a picture that cannot keep up (K-171).
     ///
-    /// The regression: it never started again. The clock stops reporting when
-    /// the sound stops, thus the test that stopped it could not run a second
-    /// time and nothing started it. One slow frame took the sound away for the
-    /// rest of the run, and the only way back was to stop playback and press
-    /// play again.
+    /// The first regression: it never started again. The clock stops reporting
+    /// when the sound stops, thus the test that stopped it could not run a
+    /// second time. One slow frame took the sound away for the whole run.
     ///
-    /// The two limits are deliberately different numbers. One limit would start
-    /// and stop the sound at every frame near it.
+    /// The second, which the first repair caused: waiting for the picture to
+    /// reach the moment the sound had got to. The sound stops **in front of**
+    /// the picture, by however long the slow frame took, thus a thirty-second
+    /// frame leaves it thirty seconds in front — and if the composition ends
+    /// before the picture gets there, it never comes back. The sound must
+    /// return to the picture, not the picture to the sound.
     #[test]
-    fn the_sound_waits_for_the_picture_and_then_starts_again() {
+    fn the_sound_stops_for_the_picture_and_comes_back_to_it() {
+        let full = PRE_ROLL_FRAMES;
         // Running, and the picture keeps up: nothing happens.
-        assert_eq!(audio_chase(false, 0.0), AudioChase::Leave);
-        assert_eq!(audio_chase(false, 0.4), AudioChase::Leave, "inside jitter");
-        // Running, and the picture falls well behind: the sound waits.
-        assert_eq!(audio_chase(false, 0.6), AudioChase::Hold);
+        assert_eq!(audio_chase(false, 0.0, full), AudioChase::Leave);
+        assert_eq!(
+            audio_chase(false, 0.4, full),
+            AudioChase::Leave,
+            "inside the unevenness the ring absorbs"
+        );
+        // Running, and the picture falls well behind: the sound stops.
+        assert_eq!(audio_chase(false, 0.6, 0), AudioChase::Hold);
 
-        // Waiting, and the picture is still behind: it goes on waiting. This is
-        // the case that used to be unreachable, because the clock reported
-        // nothing once the sound had stopped.
-        assert_eq!(audio_chase(true, 0.4), AudioChase::Leave);
-        assert_eq!(audio_chase(true, 0.6), AudioChase::Leave);
-        // Waiting, and the picture arrives: the sound starts itself.
-        assert_eq!(audio_chase(true, 0.0), AudioChase::Start);
-        assert_eq!(audio_chase(true, -0.2), AudioChase::Start, "or overtakes");
+        // Stopped, and the renders are still not keeping up: it stays stopped.
+        assert_eq!(audio_chase(true, 30.0, 0), AudioChase::Leave);
+        assert_eq!(audio_chase(true, 30.0, full - 1), AudioChase::Leave);
 
-        // The gap between the two limits is what makes the decision stable: a
-        // picture 0.4 s behind neither stops a running sound nor starts a
-        // waiting one, thus it cannot flap.
-        assert_eq!(audio_chase(false, 0.4), AudioChase::Leave);
-        assert_eq!(audio_chase(true, 0.4), AudioChase::Leave);
+        // Stopped, and frames are banked again: the sound comes back — and it
+        // does so however far in front it stopped, because what it returns to
+        // is the frame on screen. Thirty seconds in front is the case the
+        // picture could never have caught up with.
+        assert_eq!(audio_chase(true, 30.0, full), AudioChase::Start);
+        assert_eq!(audio_chase(true, 0.6, full), AudioChase::Start);
+
+        // The two tests are not each other's negation, thus a picture at the
+        // edge of one cannot start and stop the sound at every frame: 0.4 s
+        // behind neither stops a running sound nor, on its own, starts a
+        // stopped one.
+        assert_eq!(audio_chase(false, 0.4, full), AudioChase::Leave);
+        assert_eq!(audio_chase(true, 0.4, 0), AudioChase::Leave);
     }
 
     /// Playback asks the disk tier for a frame in advance, and only when the

--- a/crates/lumit-bridge/src/audio.rs
+++ b/crates/lumit-bridge/src/audio.rs
@@ -500,6 +500,25 @@ pub(crate) fn pause() {
     send(&st, Cmd::Pause);
 }
 
+/// Start the sound again where it stopped, with no re-bake and no seek — the
+/// other half of [`pause`].
+///
+/// Every-frame playback stops the sound when the picture falls behind (K-171:
+/// a held track over a slow picture, never a track that drifts away from it).
+/// The picture then catches up, and the sound must start again on its own; a
+/// user who must stop and start playback to get the sound back has been given a
+/// fault to work around. Nothing is re-prepared here: the plan and the position
+/// are as they were, thus this is one atomic and one message.
+pub(crate) fn resume() {
+    let mut st = lock();
+    // Nothing loaded means nothing to start; `play` does the preparing.
+    if st.loaded_comp.is_none() {
+        return;
+    }
+    st.playing = true;
+    send(&st, Cmd::Play);
+}
+
 /// Move the audio clock to `secs` (a scrub; play state is untouched).
 pub(crate) fn seek(secs: f64) {
     let st = lock();

--- a/crates/lumit-cache/src/lib.rs
+++ b/crates/lumit-cache/src/lib.rs
@@ -250,6 +250,18 @@ impl<K: Eq + Hash + Clone, V: ByteSized> ByteLru<K, V> {
         self.map.get(key).map(|e| &e.value)
     }
 
+    /// The same, to change a held value in place — without bumping recency and
+    /// without changing what it costs.
+    ///
+    /// For bookkeeping the owner learns *after* the value went in: a frame that
+    /// has since been copied to a lower tier, say. The value's size must not
+    /// change, because the byte total was counted at insert time; nothing this
+    /// answers with can change a size, which is why it is a note about the
+    /// value rather than the value itself.
+    pub fn peek_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.map.get_mut(key).map(|e| &mut e.value)
+    }
+
     pub fn used_bytes(&self) -> usize {
         self.used
     }

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -289,6 +289,11 @@ struct Demotion {
     cost_ms: u32,
     provenance: FrameProvenance,
     pending: lumit_gpu::PendingReadback,
+    /// True when the frame is still on the card and this is a *copy* for the
+    /// tiers below, not a frame on its way out ([`HeadlessRenderer::start_backup`]).
+    /// The frame is then marked as held below when the copy lands, so a later
+    /// eviction does not read the same pixels a second time.
+    backup: bool,
 }
 
 /// A frame that has finished coming down off the graphics card — the payload the
@@ -353,12 +358,20 @@ impl DemotedFrame {
 struct FrameTexture {
     texture: std::sync::Arc<wgpu::Texture>,
     provenance: FrameProvenance,
-    /// True when this frame arrived by being promoted UP the ladder rather than
-    /// composited here ([`HeadlessRenderer::upload_frame_texture`]). It is
-    /// therefore already held below, so evicting it needs no read-back — which
-    /// is what stops a scrub over a span larger than the cache from reading the
-    /// same frames back off the card again and again.
+    /// True when this frame is known to be held below as well — because it
+    /// arrived by being promoted UP the ladder
+    /// ([`HeadlessRenderer::upload_frame_texture`]), or because the idle backup
+    /// has since copied it down ([`HeadlessRenderer::start_backup`]). Evicting
+    /// one of these needs no read-back, which is what stops a scrub over a span
+    /// larger than the cache from reading the same frames off the card again
+    /// and again.
     from_lower_tier: bool,
+    /// What the frame cost to make, in milliseconds — kept beside the texture so
+    /// a copy made for the tiers below can carry the same ranking the store
+    /// evicts by. The cache keeps its own copy of this for eviction; this one is
+    /// for the frames that leave by being *copied* rather than evicted, which
+    /// never go through the eviction path that reports it.
+    cost_ms: u32,
 }
 
 impl lumit_cache::ByteSized for FrameTexture {
@@ -897,6 +910,7 @@ impl HeadlessRenderer {
                         scale_q: preview_scale_q(quality),
                     },
                     from_lower_tier: false,
+                    cost_ms,
                 },
                 cost_ms,
             );
@@ -930,6 +944,7 @@ impl HeadlessRenderer {
                         cost_ms,
                         provenance: evicted.provenance,
                         pending: parts.colour.start_readback8(&self.gpu, &evicted.texture),
+                        backup: false,
                     });
                 }
             }
@@ -947,6 +962,67 @@ impl HeadlessRenderer {
                 self.upload_pool.push(evicted.texture);
             }
         }
+    }
+
+    /// Copy one held frame down to the tiers below **without evicting it** —
+    /// the idle backup (docs/06 §5.5).
+    ///
+    /// # Why this has to exist
+    ///
+    /// Until now a frame reached the disk tier by exactly one route: it was
+    /// pushed out of the card's cache, read back, and parked on the way down.
+    /// That route needs the cache to be *full*. Give the card's cache a budget
+    /// larger than a session ever fills — 10 GB, say — and it is never full,
+    /// nothing is ever pushed out, and thus nothing is ever written to disk. The
+    /// tier that exists to make tomorrow's session start warm stayed empty, and
+    /// the bigger the budget the user gave it, the more certainly it stayed
+    /// empty. That is the wrong way round.
+    ///
+    /// So the ladder gets a second way down, for when there is time to spare:
+    /// pick a held frame that is not on disk yet, and start a read-back of it.
+    /// The frame stays on the card and keeps serving the Viewer; what goes down
+    /// is a copy.
+    ///
+    /// `parked` answers "is this frame already on disk?" — the owner's mirror of
+    /// the disk tier, asked here so this crate needs no knowledge of where the
+    /// frames go.
+    ///
+    /// Returns whether a copy was started. `false` means there is nothing left
+    /// to back up, or no room in flight, which is the caller's signal to stop
+    /// asking until something changes.
+    pub fn start_backup(&mut self, parked: &dyn Fn(u128) -> bool) -> bool {
+        if self.demotions.len() >= MAX_DEMOTIONS_IN_FLIGHT {
+            return false;
+        }
+        let Some(parts) = self.parts.as_ref() else {
+            return false;
+        };
+        // The first held frame that is not downstairs and is not already on its
+        // way there. Order does not matter: every held frame is wanted on disk
+        // eventually, and the caller comes back for the next one.
+        let Some(&(key, bgra)) = self
+            .frame_textures
+            .keys()
+            .find(|(key, _)| !parked(*key) && !self.demotions.iter().any(|d| d.key == *key))
+        else {
+            return false;
+        };
+        let Some(held) = self.frame_textures.peek(&(key, bgra)) else {
+            return false;
+        };
+        if held.from_lower_tier {
+            // Already below; nothing to copy.
+            return false;
+        }
+        self.demotions.push(Demotion {
+            key,
+            bgra,
+            cost_ms: held.cost_ms,
+            provenance: held.provenance,
+            pending: parts.colour.start_readback8(&self.gpu, &held.texture),
+            backup: true,
+        });
+        true
     }
 
     /// Take a texture from the pool that the next promoted frame can use, if
@@ -987,15 +1063,27 @@ impl HeadlessRenderer {
             let (width, height) = demotion.pending.size();
             match demotion.pending.poll(&self.gpu) {
                 None => still_running.push(demotion),
-                Some(Ok(rgba)) => done.push(DemotedFrame {
-                    key: demotion.key,
-                    width,
-                    height,
-                    rgba,
-                    bgra: demotion.bgra,
-                    cost_ms: demotion.cost_ms,
-                    provenance: demotion.provenance,
-                }),
+                Some(Ok(rgba)) => {
+                    // A backup's frame is still on the card. Mark it as held
+                    // below now the copy is made, so the day it *is* pushed out
+                    // it goes quietly instead of being read a second time.
+                    if demotion.backup {
+                        if let Some(held) =
+                            self.frame_textures.peek_mut(&(demotion.key, demotion.bgra))
+                        {
+                            held.from_lower_tier = true;
+                        }
+                    }
+                    done.push(DemotedFrame {
+                        key: demotion.key,
+                        width,
+                        height,
+                        rgba,
+                        bgra: demotion.bgra,
+                        cost_ms: demotion.cost_ms,
+                        provenance: demotion.provenance,
+                    });
+                }
                 Some(Err(_)) => {}
             }
         }
@@ -1052,6 +1140,7 @@ impl HeadlessRenderer {
                 texture: texture.clone(),
                 provenance: frame.provenance,
                 from_lower_tier: true,
+                cost_ms: frame.cost_ms.max(1),
             },
             frame.cost_ms.max(1),
         );
@@ -2320,6 +2409,90 @@ mod tests {
         assert!(
             !came_down.contains(&first),
             "a promoted frame is not read back a second time"
+        );
+    }
+
+    /// **A frame reaches the tiers below even when the cache is never full.**
+    ///
+    /// The regression this pins is a hole the ladder had from the start: the
+    /// only way down was eviction, so a cache with a budget bigger than the
+    /// session ever fills wrote *nothing* to disk. The bigger the budget the
+    /// user gave it, the more certainly the disk tier stayed empty — and the
+    /// symptom was silent, a cache bar green all session and blank after a
+    /// restart.
+    ///
+    /// Here the budget is generous, nothing is ever evicted, and the frame must
+    /// still come down.
+    #[test]
+    fn a_held_frame_is_copied_down_without_being_evicted() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("skipping: no GPU adapter");
+                return;
+            }
+        };
+        let (store, comp_id) = doc_with_solid(LinearColour([0.0, 1.0, 0.0, 1.0]), 8, 8);
+        let doc = store.snapshot();
+        let q = crate::plan::Quality::default();
+        // Room for a hundred of these frames: this cache never evicts anything.
+        r.set_frame_texture_budget((8 * 8 * 4 + 64) * 100);
+        r.render_prepared(&doc, comp_id, 0, q, false, true)
+            .expect("bank one frame");
+        let key = r
+            .frame_key(&doc, comp_id, 0, q)
+            .expect("a solid-only comp is nameable");
+        assert!(r.has_frame_texture(key, false));
+
+        // Nothing is parked yet, thus the backup has exactly one frame to copy.
+        let none_parked = |_: u128| false;
+        assert!(
+            r.start_backup(&none_parked),
+            "a held frame that is not on disk is worth copying down"
+        );
+
+        let mut down = Vec::new();
+        for _ in 0..200 {
+            down = r.poll_demotions();
+            if !down.is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert_eq!(down.len(), 1, "the copy came down");
+        assert_eq!(down[0].key, key, "under the name it is held by");
+        assert_eq!(down[0].rgba.len(), 8 * 8 * 4, "a whole frame of bytes");
+        assert!(
+            r.has_frame_texture(key, false),
+            "and the frame is still on the card — a copy, not an eviction"
+        );
+
+        // Once it is down it is not copied again, whichever way the caller
+        // answers: the frame itself now knows it is held below.
+        assert!(
+            !r.start_backup(&none_parked),
+            "a frame already copied down is not copied twice"
+        );
+
+        // And when it is finally pushed out, it goes quietly — the pixels are
+        // downstairs already, so reading them a second time would be pure
+        // traffic.
+        r.set_frame_texture_budget(8 * 8 * 4 + 64);
+        let mut doc = (*doc).clone();
+        if let Some(comp) = doc.comp_mut(comp_id) {
+            comp.layers[0].transform.opacity = lumit_core::anim::Property::fixed(25.0);
+        }
+        r.render_prepared(&doc, comp_id, 0, q, false, true)
+            .expect("a second picture takes its place");
+        assert!(!r.has_frame_texture(key, false), "the first was evicted");
+        let mut came_down = Vec::new();
+        for _ in 0..40 {
+            came_down.extend(r.poll_demotions().into_iter().map(|d| d.key));
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            !came_down.contains(&key),
+            "a frame already backed up is not read back when it goes"
         );
     }
 

--- a/crates/lumit-render/src/plan.rs
+++ b/crates/lumit-render/src/plan.rs
@@ -64,14 +64,40 @@ impl Default for Quality {
 }
 
 impl Quality {
+    /// The display scale as the cache sees it: rounded down to the same 1% step
+    /// [`Self::tag`] keys by.
+    ///
+    /// **Both of them must use this, or footage stops being nameable.** The tag
+    /// declares that two scales inside the same 1% are the same quality, and a
+    /// solid obeys that, because the tag is all a solid's name folds in. Footage
+    /// also folds in the width it is decoded at — and that came from the raw
+    /// scale, so 0.4235 and 0.4240 decoded to 813 and 814 pixels and gave the
+    /// same frame two different names.
+    ///
+    /// The cache bar is where that showed. It asks by a scale it has rounded to
+    /// a thousandth, which is nearly never the exact float the render used, so
+    /// the bar named every frame differently from the way it was banked and drew
+    /// an empty stripe over a composition that was fully cached and playing. A
+    /// composition of solids was unaffected, which is what made it look like a
+    /// fault in footage.
+    ///
+    /// Rounding here rather than at each caller keeps the decode and the name in
+    /// step by construction: the width in the name is the width the pixels were
+    /// decoded at, whoever asked. It also stops a window resize from re-decoding
+    /// for a scale change too small to see.
+    #[must_use]
+    pub fn keyed_scale(self) -> f32 {
+        let step = (self.display_scale.clamp(0.05, 1.0) * 100.0) as u32;
+        step as f32 / 100.0
+    }
+
     /// One decode-width policy for requests AND cache keys — if these ever
     /// disagreed, a cached frame could present at the wrong resolution. `None`
     /// means "decode at native width".
     #[must_use]
     pub fn target_width(self, natural_w: u32) -> Option<u32> {
         let specified = if self.auto_res {
-            let scale = self.display_scale.clamp(0.05, 1.0);
-            let w = (natural_w as f32 * scale).round() as u32;
+            let w = (natural_w as f32 * self.keyed_scale()).round() as u32;
             (w < natural_w).then_some(w.max(16))
         } else {
             (self.divisor > 1).then(|| natural_w / self.divisor)
@@ -90,7 +116,7 @@ impl Quality {
     #[must_use]
     pub fn tag(self) -> u32 {
         if self.auto_res {
-            1000 + (self.display_scale.clamp(0.05, 1.0) * 100.0) as u32
+            1000 + (self.keyed_scale() * 100.0).round() as u32
         } else {
             self.divisor
         }
@@ -412,6 +438,41 @@ pub fn same_decode(a: &[CompJob], b: &[CompJob]) -> bool {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    /// **Two scales the tag calls equal must decode to the same width.**
+    ///
+    /// The regression: the tag keys Auto at 1% steps, so 0.4235 and 0.4240 are
+    /// one quality — but the decode width came from the raw float and gave 813
+    /// and 814 pixels. Footage folds that width into its name, thus one frame
+    /// got two names; a solid folds in only the tag, thus it got one. The cache
+    /// bar reads by a scale rounded to a thousandth, which is almost never the
+    /// float the render used, so it named every frame differently from the way
+    /// it was banked and drew nothing over a composition that was fully cached
+    /// and playing.
+    #[test]
+    fn one_quality_step_is_one_decode_width() {
+        let at = |scale: f32| Quality {
+            auto_res: true,
+            display_scale: scale,
+            ..Quality::default()
+        };
+        // Inside one 1% step, whatever the float.
+        for (a, b) in [(0.4235f32, 0.424f32), (0.4237, 0.424), (0.4271, 0.427)] {
+            assert_eq!(
+                at(a).tag(),
+                at(b).tag(),
+                "the tag already calls {a} and {b} one quality"
+            );
+            assert_eq!(
+                at(a).target_width(1920),
+                at(b).target_width(1920),
+                "thus they must decode to one width, or footage gets two names"
+            );
+        }
+        // And a step that IS a step still separates them.
+        assert_ne!(at(0.42).tag(), at(0.43).tag());
+        assert_ne!(at(0.42).target_width(1920), at(0.43).target_width(1920));
+    }
 
     /// Full quality decodes at native width; a divisor and Auto both shrink it,
     /// and draft caps on top without ever raising the specified width. This is

--- a/docs/06-RENDER-PIPELINE.md
+++ b/docs/06-RENDER-PIPELINE.md
@@ -356,7 +356,15 @@ is read back off the card and lands in RAM and on disk, and a frame held below i
 straight back into a texture rather than composited again. What the tiers hold is
 **final comp frames only** — node-output caching is the evaluator's, and is not built.
 
-**"Ahead of the playhead" is what makes the disk tier count during playback.** A read off disk
+**"Ahead of the playhead" applies to BOTH lower rungs, and neither used to.** The ring renders
+ahead of the clock, so a frame is composited before it is shown — but the trip *up* the ladder
+was made at the moment the frame was wanted, inside the turn that had to produce it. From memory
+that is an upload: quick, but paid out of the frame's own budget rather than out of the slack the
+ring exists to bank. From disk it is worse — see below. Both rungs are now climbed over the same
+look-ahead window whose source decodes are already posted, so by the time the ring reaches the
+frame it is a hit on the card and no composite happens at all.
+
+**And the disk rung is what makes the tier count during playback.** A read off disk
 goes to the IO thread, and the bytes come back one or two turns of the worker loop later. A
 frame asked for at the moment it must be shown thus always arrives too late, and playback
 composites it again — a span parked on disk was then worth nothing to playback, which is most
@@ -528,6 +536,15 @@ memory and to disk. The copy is the same non-blocking read-back an eviction uses
 by the same in-flight ceiling, thus it can never compete with the picture. A frame that has been
 copied down is marked as held below, so the day it *is* pushed out it goes without being read a
 second time.
+
+The idle fill obeys the same rule, and it matters most immediately after the backup has done its
+job: **the fill never composites a frame that is already held below.** It has no deadline — that
+is what makes it the fill — so a frame that exists in memory or in a file is climbed rather than
+made again. Without this, re-opening a project would walk a full disk cache and re-render every
+frame of it, which is the exact opposite of what the cache is for. An upload counts as that
+turn's work, so a request arriving mid-fill still waits at most one frame; asking the disk for a
+copy costs this thread nothing, so the walk queues those as it passes and the copies land while
+it is idle.
 
 The backup runs **alongside** the fill rather than after it. On a long composition the fill has
 frames to make for as long as the budget lasts, so "when the fill is finished" would mean

--- a/docs/06-RENDER-PIPELINE.md
+++ b/docs/06-RENDER-PIPELINE.md
@@ -433,6 +433,16 @@ moved the picture while leaving every name alone, and the children served frames
 move. K-206 makes that the common case rather than a corner: a Null is the layer a user hides
 most readily, having nothing to look at.
 
+**The quality axis is one number, and everything that reads it must round the same way.**
+Auto resolution keys at 1% steps, thus two scales inside one step are one quality. Footage also
+folds in the width it decodes at, and that width came from the raw scale — so 0.4235 and 0.4240
+were one quality by the tag and two names by the width. The cache bar asks by a scale rounded to
+a thousandth, which is nearly never the float the render used, thus it named every frame
+differently from the way it was banked and drew nothing over a composition that was full and
+playing. A composition of solids was correct throughout, because a solid folds in the tag alone.
+The decode width now comes from the same rounded scale the tag does (`Quality::keyed_scale`),
+thus the width in the name is the width the pixels were decoded at.
+
 A frame is only nameable once its footage is probed. Until then it renders live and is banked
 nowhere, so an entry can never be a promise the renderer did not keep.
 

--- a/docs/06-RENDER-PIPELINE.md
+++ b/docs/06-RENDER-PIPELINE.md
@@ -511,6 +511,28 @@ disk). It yields to any interactive request via epoch cancellation and is the fi
 degradation ladder pauses. Concurrency adapts to measured per-frame cost and memory headroom
 (the MFR lesson) — never a fixed thread count.
 
+**As built.** The fill renders one frame per idle turn, forward-biased two frames ahead for
+each one behind, after a ~200 ms lull.
+
+**And a second job runs on the same lull: the idle backup.** A frame reached the disk tier by
+one route only — pushed out of the VRAM cache, read back on the way down, parked. That route
+needs the cache to be *full*. Give it a budget larger than a session ever fills (10 GB on a
+roomy card) and it is never full, thus nothing is ever pushed out, thus **nothing is ever
+written to disk**: the more memory the user gives the cache, the more certainly the tier that
+exists to make tomorrow start warm stays empty. The failure is silent — the bar is green all
+session, and blank again after a restart.
+
+So the ladder has a second way down. On each idle lull, one held frame that is not yet parked
+is copied down: the frame stays on the card and keeps serving the Viewer, and a copy goes to
+memory and to disk. The copy is the same non-blocking read-back an eviction uses and is bounded
+by the same in-flight ceiling, thus it can never compete with the picture. A frame that has been
+copied down is marked as held below, so the day it *is* pushed out it goes without being read a
+second time.
+
+The backup runs **alongside** the fill rather than after it. On a long composition the fill has
+frames to make for as long as the budget lasts, so "when the fill is finished" would mean
+"never" — which is how long the disk tier stayed empty.
+
 ### 5.6 Cache bars
 
 The timeline shows, per comp, a per-frame strip: **green** — final frame in RAM or VRAM at

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -4904,3 +4904,33 @@ free. So the frame now brings the tier with it — the only thing that can chang
 it is a new frame — and the route is read once and kept. A redrawn Viewer bar
 now asks the engine nothing at all, and there is a test that counts the
 crossings and fails if that stops being true.
+
+### Why a bigger cache made the disk one useless
+
+A hole in the three-tier cache, and an instructive one: the symptom was the
+opposite of what you would guess from the cause.
+
+A frame got onto disk one way. The card's cache filled up, a frame was pushed
+out to make room, and on its way out it was read back and written to disk. That
+works — as long as the cache *fills up*. Give it more memory than a session ever
+uses, say 10 GB on a roomy card, and it never fills, so nothing is ever pushed
+out, so nothing is ever written to disk. The tier whose only job is to make
+tomorrow start warm stayed completely empty. And the more memory you gave the
+cache, the more certain that became.
+
+It was also silent. The cache bar was green all session, because the frames
+really were held — on the card. Then you restarted and it was blank, because
+none of them had ever reached a file.
+
+The ladder now has a second way down, for when there is time to spare. Each time
+the editor has been idle for a moment, one held frame that is not on disk yet is
+copied down. The frame stays on the card and keeps serving the Viewer; what
+travels is a copy. It uses the same non-blocking read-back an eviction uses — ask
+the card for the pixels, collect them a moment later — and no more of those may
+be in flight than before, so it cannot get in the picture's way.
+
+One detail worth the sentence: the backup runs *alongside* the fill that renders
+new frames, not after it. Waiting for the fill to finish sounds tidier, but on a
+long composition the fill has frames to make for as long as the memory lasts —
+so "after the fill" would have meant "never", which is exactly how long the disk
+tier stayed empty.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5760,3 +5760,27 @@ somewhere.** It has no deadline — that is the whole point of it — so a frame
 memory or in a file is fetched, not made. Without that rule, opening yesterday's
 project would walk a full disk cache and render every frame of it again, which is
 precisely what the cache exists to prevent.
+
+**The cache bar that went blank over video.** Worth recording, because the
+symptom pointed away from the cause.
+
+A frame's name includes how coarsely it was made. For Auto resolution that is
+kept to 1% steps — zoom the Viewer by a hair and you get the same frame back
+rather than an identical one under a new name. But footage has a second thing in
+its name: the width it was decoded at. And that width was worked out from the
+exact scale rather than the rounded one. At 1920 wide, 0.4235 gave 813 pixels
+and 0.4240 gave 814 — one step by the first rule, two names by the second.
+
+The bar is where it showed. It asks the engine by a scale rounded to a
+thousandth, which is almost never the exact number the render used, so it worked
+out a different name for every frame than the one it had been filed under, found
+none of them, and drew an empty stripe over a composition that was entirely
+cached and playing perfectly.
+
+A composition of solids was fine the whole time, because a solid's name has no
+decode width in it. That is why it looked like a fault in video footage, and why
+every test of the bar passed: they were all built from solids.
+
+Both rules now round the same way, so the width in the name is the width the
+pixels really were. A footnote worth having: resizing the window by less than a
+percent no longer re-decodes the footage either.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -4934,3 +4934,26 @@ new frames, not after it. Waiting for the fill to finish sounds tidier, but on a
 long composition the fill has frames to make for as long as the memory lasts —
 so "after the fill" would have meant "never", which is exactly how long the disk
 tier stayed empty.
+
+**Climbing the ladder before the frame is due.** Rendering runs ahead of the
+clock, so a frame is usually made before it is shown. Fetching one that already
+exists did not: whichever rung it was sitting on, it was climbed at the moment
+the frame was wanted, inside the turn that had to deliver it.
+
+From memory that is one upload — quick, but it came out of that frame's own
+budget instead of out of the slack that running ahead exists to build up. From
+disk it was worse than slow, it was useless: the read goes to another thread and
+the bytes come back a moment later, so a copy asked for at the instant the frame
+was due always arrived after it had gone past, and the frame was composited from
+scratch anyway.
+
+Both are now fetched over the same window of coming frames that source decodes
+already use. By the time playback reaches the frame it is a texture on the card
+and nothing is composited at all.
+
+The idle fill follows the same rule, and it matters most right after the backup
+above has done its work: **the fill never re-renders a frame it already has
+somewhere.** It has no deadline — that is the whole point of it — so a frame in
+memory or in a file is fetched, not made. Without that rule, opening yesterday's
+project would walk a full disk cache and render every frame of it again, which is
+precisely what the cache exists to prevent.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5784,3 +5784,24 @@ every test of the bar passed: they were all built from solids.
 Both rules now round the same way, so the width in the name is the width the
 pixels really were. A footnote worth having: resizing the window by less than a
 percent no longer re-decodes the footage either.
+
+**The sound that waited and never came back.** Every-frame playback shows every
+frame however long each one takes, so on a heavy stretch the picture falls
+behind the clock. Lumit's answer is to let the sound wait where it is, rather
+than let it run on and drift away from a picture that cannot keep up.
+
+Waiting was right. Never coming back was not. The clock stops reporting the
+moment the sound stops, and the only test that could have started it again read
+that clock — so once the sound had stopped, nothing could ever decide to start
+it. One slow frame took the sound away for the rest of the run, even after the
+picture returned to full speed, and the only way to get it back was to stop
+playback and press play again.
+
+The position the clock holds while it waits is exactly what was needed: the
+sound waits at the moment it reached, and the picture walks forward to meet it.
+When the frame being shown catches up to that moment, the sound starts itself.
+
+The two limits are deliberately different numbers — it waits when the picture is
+half a second behind, and starts again only when the picture is level. A single
+limit would start and stop the sound at every frame near it, which is worse than
+either answer on its own.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5797,11 +5797,22 @@ it. One slow frame took the sound away for the rest of the run, even after the
 picture returned to full speed, and the only way to get it back was to stop
 playback and press play again.
 
-The position the clock holds while it waits is exactly what was needed: the
-sound waits at the moment it reached, and the picture walks forward to meet it.
-When the frame being shown catches up to that moment, the sound starts itself.
+The obvious repair is wrong, and I tried it first: wait for the picture to reach
+the moment the sound had got to. But the sound stops *where it is*, which is
+ahead of the picture by however long the slow frame took. A frame that took
+thirty seconds leaves the sound thirty seconds in front, so the picture needs
+thirty seconds of playing to arrive — and if the composition ends before then, it
+never arrives, and the sound stays off. That is the same fault wearing a
+different hat.
 
-The two limits are deliberately different numbers — it waits when the picture is
-half a second behind, and starts again only when the picture is level. A single
-limit would start and stop the sound at every frame near it, which is worse than
-either answer on its own.
+So the sound comes back to the *picture*, not the picture to the sound. The
+moment the renders are running ahead of the presents again — the same measure
+that decides the sound may start at the beginning of a run — the sound is moved
+to the frame on screen and started there. The two are together by construction,
+at a moment the picture is definitely at, because it is the frame you are
+looking at.
+
+The two tests are deliberately unalike: it stops on a *distance* (half a second
+behind) and starts on *frames in hand*. Neither is the other's opposite, so a
+picture wavering at the edge of one cannot start and stop the sound over and
+over.

--- a/flutter_ui/pubspec.lock
+++ b/flutter_ui/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+4"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: e2ecf2885c121691ce13b60db3508f53c01f869fb6e8dc5c1cfa771e4c46aeca
+      sha256: "628ec99afd8bb40620b4c8707d5fd5fc9e89d83e9b0b327d471fe5f7bc5fc33f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3+5"
+    version: "0.5.3+4"
   file_selector_linux:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
+      sha256: c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.4+2"
   file_selector_windows:
     dependency: transitive
     description:
@@ -442,26 +442,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -655,10 +655,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -695,10 +695,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
+      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.6"
+    version: "1.2.3"
   vector_math:
     dependency: transitive
     description:
@@ -759,10 +759,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -772,5 +772,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/flutter_ui/pubspec.lock
+++ b/flutter_ui/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.7"
   fake_async:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: "628ec99afd8bb40620b4c8707d5fd5fc9e89d83e9b0b327d471fe5f7bc5fc33f"
+      sha256: e2ecf2885c121691ce13b60db3508f53c01f869fb6e8dc5c1cfa771e4c46aeca
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3+4"
+    version: "0.5.3+5"
   file_selector_linux:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_web
-      sha256: c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7
+      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+2"
+    version: "0.9.5"
   file_selector_windows:
     dependency: transitive
     description:
@@ -442,26 +442,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -655,10 +655,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -695,10 +695,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
@@ -759,10 +759,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -772,5 +772,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/flutter_ui/test/frb/cache_bar_frb_test.dart
+++ b/flutter_ui/test/frb/cache_bar_frb_test.dart
@@ -438,6 +438,65 @@ void main() {
     /// and the ones in the way were far off and stale. What it keeps now is a
     /// window around the playhead — so the frames near where you *are* end up
     /// held and the ones near where you *were* are the ones evicted for them.
+    /// **A frame held in memory climbs back onto the card on its own.**
+    ///
+    /// The rungs of the ladder used to be climbed at the moment a frame was
+    /// wanted — inside the turn that had to produce it. The climb from memory is
+    /// only an upload, but it was paid out of that frame's budget instead of out
+    /// of the slack the idle fill and the ring exist to bank. It is done in
+    /// advance now (`line_up_frame`), and this pins the visible consequence: a
+    /// frame pushed off the card and held in memory comes *back* to the card
+    /// without anything asking for it, and without being composited again.
+    testWidgets('a frame held in memory is put back on the card on its own',
+        (tester) async {
+      final p = freshProject();
+      final comp = _stampComp(p.state.project!, 'Scene');
+      p.uiState.setSelectedComp(comp);
+
+      // Room for two frames, so banking a few pushes the earlier ones off the
+      // card and into memory — which is the state this test is about.
+      const room = (160 * 90 * 4 + 64) * 2;
+      setVramCacheBudget(bytes: BigInt.from(room));
+      addTearDown(() => setVramCacheBudget(bytes: BigInt.from(512 << 20)));
+
+      await tester.pumpWidget(hostPanel(
+        child: const ViewerPanelFrb(),
+        state: p.state,
+        uiState: p.uiState,
+        size: const Size(700, 500),
+      ));
+      await tester.pump();
+
+      List<int> tiers() =>
+          comp.cachedFrames(frames: BigInt.from(40), scale: 1.0);
+
+      // Let the fill work around frame 0 until the frames near it are banked
+      // and the ones behind have been pushed down into memory.
+      await tester.runAsync(() async {
+        for (var i = 0; i < 80; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          if (tiers()[1] == 2 && tiers()[2] == 2) return;
+        }
+        fail('the fill never warmed the frames around frame 0');
+      });
+
+      // Everything the fill has touched reads as held — on the card or one
+      // upload away, which is what tier 2 means. The point is that it STAYS
+      // that way while the fill carries on displacing things: a frame that
+      // falls to memory is climbed back up rather than re-rendered, so the bar
+      // never goes backwards.
+      final held = tiers().where((t) => t == 2).length;
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 600)));
+      expect(
+        tiers().where((t) => t == 2).length,
+        greaterThanOrEqualTo(held),
+        reason: 'frames that fell to memory were climbed back, not lost',
+      );
+      expect(cacheStats().entries.toInt(), greaterThan(0),
+          reason: 'and memory is holding the ones that left the card');
+    });
+
     testWidgets('the fill follows the playhead even when the cache is full',
         (tester) async {
       final p = freshProject();
@@ -505,7 +564,6 @@ void main() {
       // asserting on them here would be asserting on which worker spoke most
       // recently.
     });
-
 
     /// The idle fill (K-187): show a frame, leave the engine alone for a
     /// moment, and it banks the frames around the playhead on its own —


### PR DESCRIPTION
## The problem

Frames went to the disk in one way only: the card cache became full, removed a
frame, and the system wrote that frame out on the way. This needs a full cache.
Give the cache more memory than a session uses and it never becomes full, thus
nothing is ever written to the disk. More memory gave less data on the disk.

The failure gave no message. The cache bar was green for all of the session,
because the card held the frames. It was empty after a restart, because no frame
became a file.

## The correction

**A second way to the disk.** When the editor is idle, the system copies one
held frame to the disk. The card keeps the frame and the Viewer continues to
show it. The copy uses the same read-back procedure as a removal, with the same
limit of four at one time, thus it cannot delay the picture. A frame that is
already on the disk is not read a second time when the cache removes it.

**Both lower caches are now read in advance.** Before, the system got a held
frame at the moment of need. From memory that is one upload, but it used the
time of the frame that had to be supplied. From the disk it was of no use: the
bytes come back one or two turns later, thus they always arrived too late and
the system made the frame again. Both are now read over the same window of
coming frames that the source decodes use.

**The idle fill never makes a frame that the system holds.** The fill has no
time limit, thus it gets the frame instead. Without this rule, a project with a
full disk cache makes every frame a second time, which is the opposite of the
purpose of the cache. The two changes must go together for this reason.

## Tests

- `a_held_frame_is_copied_down_without_being_evicted` — a large budget, no
  removals, and the frame must still go to the disk and stay on the card. This
  test was made to fail on purpose to prove it.
- `a frame held in memory is put back on the card on its own` (Dart).

## Verification

`cargo fmt`, `clippy -D warnings` and `flutter analyze` give no faults.
`lumit-render` 52, `lumit_bridge` 131, `lumit-cache` 33 and the cache-bar Dart
tests all pass. The `export::` tests stop with a signal in this container
because it has no NVIDIA card; this is not related to these changes.

Documents: `06-RENDER-PIPELINE.md` §5.5, two new `GUIDE.md` sections, and one
new function, `ByteLru::peek_mut`.