### PR TITLE
fix(render): a nested comp's intermediate is transparent (K-241)

### DIFF
--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -539,17 +539,17 @@ pub fn build_comp_draws_at(
                 let nested_draws =
                     build_comp_draws_at(doc, nested, lt, frame_lt, pixels_by_layer, visited);
                 visited.pop();
-                let nbg = nested.background.0;
                 (
                     DrawSource::Nested {
                         width: nested.width,
                         height: nested.height,
-                        background: [
-                            f64::from(nbg[0]),
-                            f64::from(nbg[1]),
-                            f64::from(nbg[2]),
-                            f64::from(nbg[3]),
-                        ],
+                        // A nested comp's intermediate is transparent where
+                        // nothing covers it (K-241). A comp's background colour
+                        // is a viewing backdrop for the comp being looked at,
+                        // not a layer of its own, so filling the intermediate
+                        // with it would turn every gap in a Precomp into opaque
+                        // black and hide the parent's stack behind it.
+                        background: [0.0, 0.0, 0.0, 0.0],
                         draws: nested_draws,
                         camera: nested.camera_pose(lt),
                     },

--- a/crates/lumit-render/src/build/build_tests.rs
+++ b/crates/lumit-render/src/build/build_tests.rs
@@ -181,13 +181,20 @@ fn collapsed_precomp_splices_inner_draws_with_parent_placement() {
     );
     assert_eq!(draws[0].pre, Some(expect));
 
-    // Switch off → the Nested intermediate as before, no pre.
+    // Switch off → the Nested intermediate as before, no pre. The
+    // intermediate clears to nothing, never to the nested comp's own
+    // background colour (K-241): the nested comp here is opaque black, and a
+    // Precomp that painted that black over the parent's stack would be the
+    // "precomps go black where they should be see-through" bug.
     let mut off = parent.clone();
     off.layers[0].switches.collapse = false;
     let mut visited = vec![off.id];
     let draws = build_comp_draws(&doc, &off, 0.0, &map, &mut visited);
     assert_eq!(draws.len(), 1);
-    assert!(matches!(draws[0].source, DrawSource::Nested { .. }));
+    let DrawSource::Nested { background, .. } = &draws[0].source else {
+        panic!("an uncollapsed Precomp renders to an intermediate");
+    };
+    assert_eq!(*background, [0.0, 0.0, 0.0, 0.0]);
     assert!(draws[0].pre.is_none());
 
     // A mask on the Precomp layer forces the intermediate (§1.4) even

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -4624,3 +4624,20 @@ without inventing anything is the evidence that the shape was right.
 **What this closes.** Every whole-list property the Timeline can drag — a mask's opacity, a
 stroke's, a shape item's — is now one op, one undo step, and live on the picture. A property
 added to this family later has one path to join rather than a choice to make.
+
+**K-241 · DECIDED · A nested comp's intermediate is transparent.** A Precomp layer's
+intermediate is cleared to nothing before its inner layers draw, whatever background colour the
+nested comp carries. Until now it was cleared to that colour, and since a new comp's background
+is opaque black, every Precomp arrived as a solid black rectangle: content that was see-through
+inside the nested comp painted black over the parent's stack.
+
+**A background colour is a viewing backdrop, not a layer.** It belongs to the comp you are
+looking at — the Viewer, and the export of that comp. A comp used *as a source* contributes its
+layers and their alpha, nothing else. That is also what After Effects does, and it is why
+collapse was never affected: a collapsed Precomp splices its inner draws straight into the
+parent and never had a background to paint.
+
+**Nothing else reads it differently.** The below-stack re-render (Posterize Time, accumulation
+motion blur) still clears to the comp's own background, because that stack *is* the comp being
+viewed, held at another time. The regression test is in `build_tests.rs`, on the same case that
+already guarded collapse on and off.

--- a/docs/06-RENDER-PIPELINE.md
+++ b/docs/06-RENDER-PIPELINE.md
@@ -98,6 +98,11 @@ the active quality), clipped to its own bounds, then behaves as footage in the p
 masked, effected, transformed like any raster layer. The nested comp is sampled at the parent's
 frame times; its own frame rate governs only its internal keyframe display.
 
+That intermediate is **transparent** where the nested comp's own layers do not cover it
+(K-241). A comp's background colour is the backdrop for looking at *that* comp, not a layer
+inside it, so it is painted only by the comp being viewed or exported — a Precomp layer carries
+the alpha its content has, and the parent's stack shows through the gaps.
+
 **Collapse** (the collapse switch on a Precomp layer) removes the intermediate:
 
 - Inner layers' transforms concatenate with the Precomp layer's transform into single matrices;


### PR DESCRIPTION
### What

An uncollapsed Precomp layer cleared its intermediate to the nested comp's own background colour. A new comp's background is opaque black, so every Precomp arrived as a solid black rectangle and hid the parent's stack wherever its content was see-through.

### Fix

`build_comp_draws_at` emits `DrawSource::Nested` with a transparent clear. A background colour is the backdrop for looking at *that* comp, not a layer inside it: the comp being viewed or exported paints it, a comp used as a source contributes only its layers and their alpha. Collapse was never affected, since it splices inner draws straight into the parent.

The below-stack re-render (Posterize Time, accumulation motion blur) still clears to the comp's own background — that stack *is* the comp being viewed, held at another time.

### Docs

- `docs/06-RENDER-PIPELINE.md` §1.4 states the rule.
- `docs/02-DECISIONS.md` gains K-241.

### Verification

Regression test extends the existing collapse case in `build_tests.rs`; it fails without the fix and passes with it. `cargo fmt --check` and `cargo clippy -p lumit-render` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)