### PR TITLE
The nine-menu bar, and macOS gets the system one (K-242)

### DIFF
--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -3452,9 +3452,13 @@ fn a_keymap_survives_the_json_it_is_stored_as() {
     let saved = keymap_to_json();
 
     keymap_load_preset(BridgeKeymapPreset::AfterEffects);
+    // The rebind is gone: the chord means what the preset says it means, not
+    // what this test made it mean. It used to assert `None` here, which held
+    // only while `Mod+Shift+S` was a spare chord — Save as took it (K-244), and
+    // a preset's own binding proves the replacement better than a blank does.
     assert_eq!(
-        keymap_lookup(BridgeKeyContext::Global, "Mod+Shift+S".into()),
-        None,
+        keymap_lookup(BridgeKeyContext::Global, "Mod+Shift+S".into()).as_deref(),
+        Some("file.save.as"),
         "the preset really replaced it"
     );
 

--- a/crates/lumit-keymap/src/lib.rs
+++ b/crates/lumit-keymap/src/lib.rs
@@ -80,7 +80,16 @@ impl ActionId {
             "comp.settings" => "Composition settings",
             "edit.undo" => "Undo",
             "edit.redo" => "Redo",
+            "edit.select.all" => "Select every layer",
+            "edit.deselect.all" => "Deselect everything",
+            "file.new" => "New project",
+            "file.open" => "Open a project",
             "file.save" => "Save the project",
+            "file.save.as" => "Save the project somewhere else",
+            "file.import" => "Import footage",
+            "file.export" => "Export the composition",
+            "comp.new" => "New composition",
+            "app.settings" => "Open Settings",
             "panel.maximise" => "Maximise the panel under the pointer",
             "graph.toggle" => "Show or hide the graph editor",
             // Tools.
@@ -533,6 +542,20 @@ pub fn default_keymap() -> Keymap {
         row(Global, "Mod+Z", "edit.undo"),
         row(Global, "Mod+Shift+Z", "edit.redo"),
         row(Global, "Mod+S", "file.save"),
+        // The rest of the menu bar's own commands (K-242). After Effects'
+        // chords where it has one and Lumit has not already spent the key:
+        // Mod+N makes a *composition* there and Mod+Alt+N a project, which is
+        // the pair anyone arriving from AE has in their fingers. Settings is
+        // AE's Preferences chord for the same reason.
+        row(Global, "Mod+Alt+N", "file.new"),
+        row(Global, "Mod+O", "file.open"),
+        row(Global, "Mod+Shift+S", "file.save.as"),
+        row(Global, "Mod+I", "file.import"),
+        row(Global, "Mod+Alt+M", "file.export"),
+        row(Global, "Mod+N", "comp.new"),
+        row(Global, "Mod+A", "edit.select.all"),
+        row(Global, "Mod+Shift+A", "edit.deselect.all"),
+        row(Global, "Mod+Alt+;", "app.settings"),
         row(Global, "`", "panel.maximise"),
         row(Global, "Shift+F3", "graph.toggle"),
         // Retime is app-wide, not Timeline-scoped: the shell runs it whatever

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -4641,3 +4641,47 @@ parent and never had a background to paint.
 motion blur) still clears to the comp's own background, because that stack *is* the comp being
 viewed, held at another time. The regression test is in `build_tests.rs`, on the same case that
 already guarded collapse on and off.
+
+**K-242 · DECIDED · The menu bar is the whole application, listed — and on macOS it is the
+system's.** The bar was three menus and a Window heading, which is what the port had time for.
+It is now the nine After Effects menus (File, Edit, Composition, Layer, Effect, Animation, View,
+Window, Help) with the commands each of them will carry, whether or not those commands exist
+yet. A command that is specified and unbuilt is *listed*, marked "(Not implemented)" and drawn
+disabled.
+
+**Why list what does not work.** Two reasons, both about testing. The shape of the finished
+application is visible while it is being built, so a tester knows whether a command is missing
+or broken rather than guessing; and every unbuilt command has a place waiting for it, so
+building one is filling a row in rather than deciding where it goes. The alternative — a short
+menu that grows — hides the plan and re-opens the placement argument once per command.
+
+**One tree, two renderers.** `lumitMenus` returns the bar as data: labels, keymap action ids,
+enablement, ticks. Windows and Linux draw it in the window; macOS hands the same tree to
+`PlatformMenuBar`, so the menus appear in the Mac menu bar like every other Mac application's,
+with About and Settings lifted into the application menu as Apple's guidelines ask. Neither
+renderer holds a list of its own, which is the only arrangement in which the two cannot drift
+apart. iOS and Android are not targets (K-174 is a desktop decision), so there is no third case.
+
+**Shortcuts come from the keymap, never from the menu.** A row names an action id and shows
+whatever chord `lumit-keymap` currently binds to it, so a rebind in Settings ▸ Keymap changes
+the menus too and a menu can never teach a chord that does nothing. Nine new actions joined the
+shipped table for commands that already worked and had no chord — `file.new` (`Ctrl+Alt+N`),
+`file.open`, `file.save.as`, `file.import`, `file.export` (`Ctrl+Alt+M`), `comp.new` (`Ctrl+N`),
+`edit.select.all`, `edit.deselect.all`, and `app.settings` (`Ctrl+Alt+;`). After Effects' own
+chords where it has one: `Ctrl+N` makes a composition there and `Ctrl+Alt+N` a project, which is
+the pair anyone arriving from AE has in their fingers. Each is dispatched in the shell through
+the very function its menu row calls, so a shortcut and its menu item cannot become two
+implementations (the K-203 rule, applied to the rest of the bar).
+
+**Settings is under Edit, and About is under Help.** Preferences-under-Edit is what every
+Windows and Linux application those users know does; macOS moves both rows into the application
+menu, which is what every application *those* users know does. About left Settings ▸ General
+altogether: Settings is for what you change, and a version number is not that.
+
+**Window lists every panel with a tick.** Toggling one adds or drops its pane in the dock, which
+is also what makes it persist — what is stored is the arrangement, so a panel closed today is
+closed after a restart with no new state to keep. The last panel standing cannot be hidden: an
+empty dock has no way back.
+
+**Composition ▸ Add to export queue, not "render queue"** (glossary §9 — *export*, never
+*render*, for anything the user sees).

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -208,6 +208,28 @@ four editing siblings, the Roto tools and the Puppet pins. Each tool's behaviour
 separately in [TODO.md](TODO.md); the snapping switch is likewise a switch nothing reads yet.
 ---
 
+### 1.8 The menu bar (K-242)
+
+The bar carries nine menus in this order: **File, Edit, Composition, Layer, Effect, Animation,
+View, Window, Help**. The arrangement is deliberately After Effects', for the same reason the
+panel layout is.
+
+- Every command the finished application will carry MUST be listed, whether or not it is built.
+  An unbuilt one MUST read "(Not implemented)" after its name and MUST be disabled.
+- A command whose preconditions are absent (no project, no composition, no selected layer) MUST
+  grey out rather than fail when pressed.
+- A row MUST show the chord the keymap currently binds to its action, and MUST take it from the
+  keymap rather than carrying a chord of its own (§15, K-199).
+- On **macOS** the bar MUST be the system menu bar, not an in-window strip, with About and
+  Settings in the application menu. On Windows and Linux Settings sits under Edit and About
+  under Help. The item tree MUST be shared between the two renderings.
+- **Window** MUST list every panel with a tick showing whether it is in the arrangement;
+  toggling one adds or drops it, and the change persists because the arrangement does. The last
+  remaining panel MUST NOT be hideable.
+- **Effect** MUST offer one submenu per effect category, each item applying to *every* selected
+  layer (K-217), and the whole menu MUST be disabled with nothing selected.
+- **File ▸ Open recent** lists the ten most recent project paths, newest first.
+
 ## 2. Viewer
 
 The Viewer displays a comp, a footage item, or a single layer's source. One Viewer exists by
@@ -1591,6 +1613,13 @@ them away the day dispatch started going through the keymap.
 | Global | `Ctrl+M` | Add active comp to export queue |
 | Global | `Ctrl+K` | Composition settings |
 | Global | `Ctrl+Z` / `Ctrl+Shift+Z` | Undo / redo |
+| Global | `Ctrl+Alt+N` / `Ctrl+N` | New project / new composition (After Effects' pairing) |
+| Global | `Ctrl+O` | Open a project |
+| Global | `Ctrl+S` / `Ctrl+Shift+S` | Save / Save as |
+| Global | `Ctrl+I` | Import footage |
+| Global | `Ctrl+Alt+M` | Export the composition |
+| Global | `Ctrl+A` / `Ctrl+Shift+A` | Select all layers / deselect all |
+| Global | `Ctrl+Alt+;` | Settings (Preferences) |
 | Global | `Alt+Shift+1…9` | Switch workspace |
 | Global | `` ` `` | Maximise / restore panel under pointer |
 | Tools | `V` | Selection tool |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5028,3 +5028,36 @@ working the day someone renamed a row, with nothing failing to say so.
 One row and nothing else also means the Retime row above Transform steps aside
 while a reveal is in force. "Show me Scale" that showed Scale *and* Retime would
 be answering a question nobody asked.
+
+### The menu bar, and why it lists things that do not work (K-242)
+
+Open any menu in Lumit and you will see rows greyed out with "(Not implemented)" after them.
+That is on purpose. The menus describe the finished application, not today's build.
+
+The reason is testing. If a menu only listed what works, then a command you could not find would
+be ambiguous — is it missing, is it somewhere else, is it broken? Listing everything answers
+that at a glance: if a row is there and marked, nobody has built it yet; if it is there and
+greyed out with no mark, it exists but the document is not ready for it (no project open, no
+layer selected). And when someone does build one of those commands, there is already a row
+waiting for it, so nobody has to re-argue where it goes.
+
+**One list, drawn two ways.** Windows and Linux put an application's menus inside its window.
+macOS puts them along the top of the screen, in the system menu bar, and expects About and
+Settings to live in a menu named after the application. Lumit does both — but it only has one
+list of menu items. A function called `lumitMenus` builds that list as plain data (a label, a
+shortcut, whether the row is live, whether it is ticked), and then either the in-window bar or
+macOS's own menu system draws it. If there were two lists, one of them would quietly fall behind
+the other; there is one, so it cannot.
+
+**The shortcuts are not written in the menus.** A row does not say "Ctrl+S". It says "the action
+called `file.save`", and the menu asks the keymap what that action is bound to right now. So if
+you rebind Save in Settings ▸ Keymap, the menu changes to match without anyone updating it — and
+a menu can never teach you a shortcut that does nothing, because the same table answers both the
+menu and the keyboard.
+
+**Closing a panel is just rearranging.** The Window menu lists every panel with a tick beside
+it. Ticking one off does not set a "hidden" flag anywhere; it takes the panel out of the
+workspace arrangement, which is the thing Lumit already saves to disk when you drag panels
+about. So a panel you close stays closed after a restart, and no new setting had to be invented
+for it. The one rule is that the last panel cannot be closed — an empty workspace would have no
+menu to get anything back from except this one, and that is a trap rather than a feature.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -366,6 +366,15 @@ setting nothing reads.
 - **Export status still speaks the old idiom** - `export.rs` replies in JSON
     strings (`err_json`) polled on a timer; follow the worker's typed-stream way.
 
+- **The menu bar names its own backlog (K-242).** Every row marked
+    "(Not implemented)" in File/Edit/Composition/Layer/Animation/View/Help is a
+    command with a place waiting for it: Close project, History, Cut/Copy/Paste,
+    layer settings and the mask/transform/blending/matte/style families, the
+    whole Animation menu, the View menu's zoom/resolution/grid/ruler rows,
+    Trim and Crop comp to work area, Add to export queue, Check for updates and
+    the help links. Delete each mark as the command lands. Suggested chords for
+    the AE-shaped ones are in K-242.
+
 ## Later - roadmap features not yet built
 
 Grouped by the phase they belong to in [16-ROADMAP.md](16-ROADMAP.md). A pointer

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:lumit_flutter/shell/comp_settings_frb.dart';
 import 'package:lumit_flutter/shell/precompose_dialog_frb.dart';
 import 'package:lumit_flutter/shell/dock_widget.dart';
 import 'package:lumit_flutter/shell/menu_bar_frb.dart';
+import 'package:lumit_flutter/shell/settings_window_frb.dart';
 import 'package:lumit_flutter/shell/status_line_frb.dart';
 import 'package:lumit_flutter/shell/tool_bar_frb.dart';
 import 'package:lumit_flutter/src/rust/api/cache.dart';
@@ -1220,6 +1221,39 @@ class _LumitAppViewState extends State<LumitAppView> {
             workspace: ui.workspace,
           );
         }
+      // The rest of the menu bar's own commands (K-242). Each calls the very
+      // function its menu row calls, so there is one implementation of "open a
+      // project" rather than a keyboard's copy of one.
+      case 'file.new':
+        state.newProject();
+      case 'file.open':
+        openProjectFrb(state);
+      case 'file.save.as':
+        saveProjectFrb(state, forcePicker: true);
+      case 'file.import':
+        importFootageFrb(state);
+      case 'file.export':
+        if (comp == null) {
+          handled = false;
+        } else {
+          exportFrb(context);
+        }
+      case 'comp.new':
+        if (project == null) {
+          handled = false;
+        } else {
+          newCompositionFrb(context, state);
+        }
+      case 'edit.select.all':
+        if (comp == null) {
+          handled = false;
+        } else {
+          ui.setSelection(comp.getLayers());
+        }
+      case 'edit.deselect.all':
+        ui.clearSelection();
+      case 'app.settings':
+        showSettingsWindowFrb(context);
       case 'file.save':
         // Ctrl+S goes through exactly the same call the File menu's Save does
         // (K-203) — a shortcut with its own path to disk is a second save to

--- a/flutter_ui/lib/shell/about_window_frb.dart
+++ b/flutter_ui/lib/shell/about_window_frb.dart
@@ -1,0 +1,67 @@
+// About Lumit — the window Help ▸ About Lumit opens (K-242).
+//
+// It used to be a section at the bottom of Settings ▸ General, which is where
+// nobody looks for it: Settings is for things you change, and none of this is.
+// The boot log is here rather than in the Debug panel because the first line of
+// it *is* the version, and the rest is what someone pastes into a bug report.
+
+import 'package:flutter/widgets.dart';
+
+import 'package:lumit_flutter/src/rust/api/shell.dart';
+
+import '../widgets/controls.dart';
+
+Future<void> showAboutWindowFrb(BuildContext context) => showLumitModal<void>(
+      context: context,
+      builder: (close) => _AboutWindow(onClose: () => close(null)),
+    );
+
+/// This build of Lumit, as the engine reports it on boot. "Unknown" rather than
+/// an empty line when the log is empty, which is what a test harness sees.
+String lumitVersion() => bootLog().isEmpty ? 'unknown' : bootLog().first;
+
+class _AboutWindow extends StatelessWidget {
+  final VoidCallback onClose;
+  const _AboutWindow({required this.onClose});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    return FloatSurface(
+      width: 420,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text('About Lumit', style: t.bodyPrimary),
+          ),
+          Text(lumitVersion(), style: t.small),
+          const SizedBox(height: 8),
+          Text(
+            'A motion-graphics and compositing editor. '
+            'Free software under the GNU General Public Licence, version 3.',
+            style: t.small,
+          ),
+          const SizedBox(height: 10),
+          for (final line in bootLog().skip(1))
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Text(line, style: t.small),
+            ),
+          const SizedBox(height: 12),
+          Align(
+            alignment: Alignment.centerRight,
+            child: HouseButton(
+              key: const ValueKey('about-close'),
+              small: true,
+              onPressed: onClose,
+              child: Text('Close', style: t.small),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -1,14 +1,28 @@
-// The menu bar, on the flutter_rust_bridge API — the second panel port.
+// The menu bar: nine menus in the After Effects arrangement (K-242).
 //
-// File / Edit / Composition, with the item set taken from the egui menu
-// (shell/app_update.rs) and the v0 menu_bar.dart. Every engine-backed item calls
-// straight through a reference handle, and the file pickers are injectable seams
-// so a widget test never opens a plugin channel.
+// **One tree, two renderers.** [lumitMenus] returns the whole bar as data —
+// labels, shortcuts, enablement, ticks — and nothing in it knows how a menu is
+// drawn. Windows and Linux get the in-app bar at the bottom of this file;
+// macOS hands the same tree to the operating system through `PlatformMenuBar`,
+// so Lumit's menus live in the Mac menu bar where every other Mac app's do,
+// with Settings and About in the application menu as Apple's guidelines ask.
+// Neither renderer holds a list of its own, which is the only way the two
+// cannot drift apart.
 //
-// Undo and Redo grey out from `ProjectReference.history()` rather than being
-// always-enabled: an item you can see is disabled tells you the state of the
+// **What a row can say.** Every engine-backed item calls straight through a
+// reference handle. An item with no action yet is still *listed*, marked
+// "(Not implemented)" and disabled, so the shape of the finished application is
+// visible while it is being built and nobody has to guess whether a command is
+// missing or broken. An item whose command needs something that is not there —
+// no project, no composition, no selected layer — greys out rather than failing
+// when pressed: an item you can see is disabled tells you the state of the
 // document, where one that does nothing when pressed does not.
+//
+// **Shortcuts are the engine's** (K-199). A row shows whatever chord the keymap
+// currently binds to its action id, so rebinding in Settings ▸ Keymap changes
+// the menus too, and a row whose action has no binding simply shows nothing.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:provider/provider.dart';
@@ -20,13 +34,75 @@ import 'package:uuid/uuid.dart';
 
 import '../state/dock.dart';
 import '../state/file_dialogs.dart';
+import '../state/keymap.dart';
+import '../theme/theme.dart';
 import '../widgets/controls.dart';
+import 'about_window_frb.dart';
 import 'command_palette_frb.dart';
 import 'comp_settings_frb.dart';
 import 'precompose_dialog_frb.dart';
 import 'export_dialog_frb.dart';
 import 'recovery_dialog_frb.dart';
 import 'settings_window_frb.dart';
+
+/// One row of a menu: a label with an action, a submenu, or a divider.
+///
+/// [action] is a keymap action id, not a callback — the chord beside the row is
+/// looked up from the live keymap when the bar is built. [todo] marks a command
+/// that is specified but not built; it draws disabled with "(Not implemented)"
+/// after its name. [checked] makes the row a toggle, drawn with a tick column.
+class MenuEntry {
+  final String? label;
+  final VoidCallback? onPressed;
+  final List<MenuEntry>? children;
+  final bool isDivider;
+  final String? action;
+  final bool todo;
+  final bool? checked;
+
+  const MenuEntry(
+    this.label,
+    this.onPressed, {
+    this.action,
+    this.checked,
+  })  : isDivider = false,
+        children = null,
+        todo = false;
+
+  const MenuEntry.divider()
+      : label = null,
+        onPressed = null,
+        children = null,
+        isDivider = true,
+        action = null,
+        todo = false,
+        checked = null;
+
+  const MenuEntry.submenu(this.label, this.children)
+      : onPressed = null,
+        isDivider = false,
+        action = null,
+        todo = false,
+        checked = null;
+
+  /// A command the specification has and the build has not.
+  const MenuEntry.todo(this.label, {this.action})
+      : onPressed = null,
+        children = null,
+        isDivider = false,
+        todo = true,
+        checked = null;
+
+  /// What the row reads as, suffix and all.
+  String get text => todo ? '$label (Not implemented)' : (label ?? '');
+
+  /// Whether pressing this row does anything. A submenu is never "pressed" but
+  /// is still live, so it counts as enabled when it has children.
+  bool get enabled => onPressed != null || (children?.isNotEmpty ?? false);
+}
+
+/// One top-level menu.
+typedef MenuSection = ({String title, List<MenuEntry> items});
 
 class LumitMenuBarFrb extends StatelessWidget {
   final LumitState app;
@@ -47,260 +123,57 @@ class LumitMenuBarFrb extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Half this bar's enablement is about the *selection* — the Effect menu,
+    // Delete, Duplicate, Pre-compose, Retime — and the selection lives in a
+    // ValueNotifier that does not notify the shell state. Without this the bar
+    // would keep whatever selection it was last built with, and every one of
+    // those rows would be greyed out with a layer plainly selected.
+    return ValueListenableBuilder<List<LayerReference>>(
+      valueListenable: context.read<LumitUiState>().selectedLayers,
+      builder: (context, _, __) => _bar(context),
+    );
+  }
+
+  Widget _bar(BuildContext context) {
     final t = ThemeScope.of(context).theme;
-    final project = app.project;
-    // Null while no project is loaded, so every document item is disabled rather
-    // than throwing when pressed.
-    final history = project?.history();
+    final menus = lumitMenus(
+      context,
+      app,
+      openPicker: openPicker,
+      savePicker: savePicker,
+      footagePicker: footagePicker,
+      palette: () => _palette(context),
+    );
+
+    // macOS puts menus in the system bar, not in the window (K-242). The bar
+    // itself draws nothing here; the hotkey holder still has to be in the tree.
+    if (defaultTargetPlatform == TargetPlatform.macOS) {
+      return PlatformMenuBar(
+        menus: platformMenusFor(context, menus),
+        child: _PaletteHotkey(onRequested: () => _palette(context)),
+      );
+    }
 
     return Container(
       height: 26,
       color: t.surface2,
-      child: Row(
-        children: [
-          const SizedBox(width: 4),
-          _menu(context, 'File', [
-            _Item('New project', app.newProject),
-            _Item('Open project…', () => _open(context)),
-            _Item.divider(),
-            // Save is only meaningful once there is a project; without a path it
-            // behaves as Save as, which is what the engine's empty-path refusal
-            // makes us handle explicitly.
-            _Item('Save', project == null ? null : () => _save(context)),
-            _Item(
-                'Save as…',
-                project == null
-                    ? null
-                    : () => _save(context, forcePicker: true)),
-            _Item.divider(),
-            _Item('Import footage…',
-                project == null ? null : () => _import(context)),
-            _Item.divider(),
-            _Item(
-              'Export…',
-              context.read<LumitUiState>().selectedComp == null
-                  ? null
-                  : () => _export(context),
-            ),
-            _Item.divider(),
-            _Item('Recover…', project == null ? null : () => _recover(context)),
-          ]),
-          _menu(context, 'Edit', [
-            _Item(
-              'Undo',
-              (history?.canUndo ?? false) ? () => _undo(context) : null,
-            ),
-            _Item(
-              'Redo',
-              (history?.canRedo ?? false) ? () => _redo(context) : null,
-            ),
-          ]),
-          _menu(context, 'Composition', [
-            _Item('New composition',
-                project == null ? null : () => _newComposition(context)),
-            _Item.divider(),
-            // Layer creation. Every one of these needs a composition to go
-            // into, so they are disabled together rather than each checking.
-            _Item(
-                'Add solid layer', _onComp(context, (c) => c.addSolidLayer())),
-            _Item('Add text layer', _onComp(context, (c) => c.addTextLayer())),
-            _Item('Add camera layer',
-                _onComp(context, (c) => c.addCameraLayer())),
-            _Item('Add adjustment layer',
-                _onComp(context, (c) => c.addAdjustmentLayer())),
-            _Item('Add null layer',
-                _onComp(context, (c) => c.addNullLayer())),
-            _Item('Add sequence layer',
-                _onComp(context, (c) => c.addSequenceLayer())),
-            _Item.divider(),
-            // The selected layer's Retime (K-197). In the menu as well as on
-            // the keyboard (K-198's lesson: a command whose only route is a
-            // chord has no route the day something intercepts the chord).
-            _Item(
-              _retimeLabel(context),
-              _onSelectedLayer(context, (l) => app.toggleRetime(l)),
-            ),
-            _Item(
-              'Pre-compose…',
-              _onPrecompose(context),
-            ),
-            _Item.divider(),
-            _Item('Cut clip at playhead',
-                _onComp(context, (c) => _cutAtPlayhead(context, c))),
-            _Item('Add marker at playhead',
-                _onComp(context, (c) => _markerAtPlayhead(context, c))),
-            _Item.divider(),
-            // Beat detection reads the whole comp's audio and can take
-            // seconds, so it runs off-thread; a comp with no audio does
-            // nothing rather than alarming.
-            _Item(
-                'Detect beats',
-                _onComp(
-                    context,
-                    (c) => c
-                        .detectBeats(sensitivityPercent: 50)
-                        .then((_) {}, onError: (_) {}))),
-            _Item('Clear beat markers',
-                _onComp(context, (c) => c.clearBeatMarkers())),
-            _Item.divider(),
-            _Item(
-              'Composition settings…',
-              context.read<LumitUiState>().selectedComp == null
-                  ? null
-                  : () => _compSettings(context),
-            ),
-          ]),
-          _menu(context, 'Window', [
-            _Item('Command palette…', () => _palette(context)),
-            // The four shipped presets (docs/07 §1.6) behind their own
-            // heading rather than four siblings of everything else: pick an
-            // arrangement and panels move, nothing closes or reloads.
-            _Item.submenu(
-              'Workspaces',
-              [
-                for (final preset in WorkspacePreset.values)
-                  _Item(preset.title, () {
-                    Provider.of<LumitUiState>(context, listen: false)
-                        .workspace
-                        .applyWorkspacePreset(preset);
-                  }),
-                _Item.divider(),
-                _Item('Reset workspace',
-                    () => context.read<LumitUiState>().resetLayout()),
-              ],
-            ),
-            _Item.divider(),
-            _Item('Settings…', () => showSettingsWindowFrb(context)),
-          ]),
-          // Nothing to look at: it is here so `Ctrl+Shift+P` opens the same
-          // palette this bar builds, rather than the shell building a second
-          // one from a list that would drift out of step with these menus.
-          _PaletteHotkey(onRequested: () => _palette(context)),
-        ],
+      // Nine menu names do not fit a narrow window, and a menu you cannot
+      // reach is worse than one you have to scroll to — so the bar scrolls
+      // sideways rather than clipping its last headings away.
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            const SizedBox(width: 4),
+            for (final menu in menus)
+              _MenuButton(title: menu.title, items: menu.items),
+            // Nothing to look at: it is here so `Ctrl+Shift+P` opens the same
+            // palette this bar builds, rather than the shell building a second
+            // one from a list that would drift out of step with these menus.
+            _PaletteHotkey(onRequested: () => _palette(context)),
+          ],
+        ),
       ),
-    );
-  }
-
-  /// Wrap a composition action: null (so the item greys out) when no
-  /// composition is fronted, else the action followed by a redraw.
-  VoidCallback? _onComp(
-      BuildContext context, void Function(CompositionReference) run) {
-    final comp = context.read<LumitUiState>().selectedComp;
-    if (comp == null) return null;
-    return () {
-      run(comp);
-      app.notifyDocumentChanged();
-    };
-  }
-
-  /// The same, for a command that acts on the selected *layer* — greyed out
-  /// with nothing selected rather than offered and inert.
-  VoidCallback? _onSelectedLayer(
-      BuildContext context, void Function(LayerReference) run) {
-    final layer = context.read<LumitUiState>().selectedLayer.value;
-    if (layer == null) return null;
-    return () => run(layer);
-  }
-
-  /// Pre-compose… is live only with a comp open and something selected in it —
-  /// the menu says so by greying out rather than by failing when pressed.
-  VoidCallback? _onPrecompose(BuildContext context) {
-    final ui = context.read<LumitUiState>();
-    final comp = ui.selectedComp;
-    final layers = ui.selectedLayers.value;
-    if (comp == null || layers.isEmpty) return null;
-    return () => showPrecomposeDialogFrb(
-          context: context,
-          comp: comp,
-          selectedLayers: layers,
-          ui: ui,
-          workspace: ui.workspace,
-        );
-  }
-
-  /// What the Retime item says: the command names what it will do, so a layer
-  /// that already has one offers to take it away.
-  String _retimeLabel(BuildContext context) {
-    final layer = context.read<LumitUiState>().selectedLayer.value;
-    if (layer == null) return 'Enable Retime';
-    try {
-      return layer.getRetimeProperty() == null
-          ? 'Enable Retime'
-          : 'Disable Retime';
-    } catch (_) {
-      return 'Enable Retime';
-    }
-  }
-
-  /// Razor the selected layer at the playhead. Only Sequence layers hold
-  /// clips, so on anything else the engine declines and nothing happens.
-  void _cutAtPlayhead(BuildContext context, CompositionReference comp) {
-    final ui = context.read<LumitUiState>();
-    final layer = ui.selectedLayer.value;
-    if (layer == null) return;
-    try {
-      layer.cutClipAt(frame: ui.playheadFrame.value);
-    } catch (_) {}
-  }
-
-  void _markerAtPlayhead(BuildContext context, CompositionReference comp) {
-    final frame = context.read<LumitUiState>().playheadFrame.value;
-    comp.setMarkers(markers: [
-      ...comp.getMarkers(),
-      BridgeMarker(
-        id: UuidValue.fromString(const Uuid().v4()),
-        time: comp.timeOfFrame(frame: frame),
-        label: '',
-      ),
-    ]);
-  }
-
-  Future<void> _open(BuildContext context) async {
-    final path = await (openPicker ?? pickProjectToOpen)();
-    if (path == null) return;
-    app.openProject(path);
-  }
-
-  Future<void> _save(BuildContext context, {bool forcePicker = false}) =>
-      saveProjectFrb(app, forcePicker: forcePicker, picker: savePicker);
-
-  Future<void> _import(BuildContext context) async {
-    await app.importFootagePaths(await (footagePicker ?? pickFootage)());
-  }
-
-  Future<void> _newComposition(BuildContext context) async {
-    final comp = await app.newComposition(context);
-    // Front it, which is what the egui menu does — a comp you just made is the
-    // one you want to work on.
-    if (comp != null && context.mounted) {
-      context.read<LumitUiState>().setSelectedComp(comp);
-    }
-  }
-
-  Future<void> _compSettings(BuildContext context) async {
-    final comp = context.read<LumitUiState>().selectedComp;
-    if (comp == null) return;
-    final applied = await showCompSettingsFrb(context: context, comp: comp);
-    if (applied) app.notifyDocumentChanged();
-  }
-
-  Future<void> _export(BuildContext context) async {
-    final comp = context.read<LumitUiState>().selectedComp;
-    if (comp == null) return;
-    await showExportDialogFrb(context: context, comp: comp);
-  }
-
-  /// Offer to recover work beside the open project.
-  ///
-  /// Only meaningful once the project has a path — recovery is about a *file*,
-  /// and a project that has never been saved has nothing beside it.
-  Future<void> _recover(BuildContext context) async {
-    final path = app.project?.path();
-    if (path == null) return;
-    await showRecoveryDialogFrb(
-      context: context,
-      state: app,
-      projectPath: path,
     );
   }
 
@@ -318,7 +191,7 @@ class LumitMenuBarFrb extends StatelessWidget {
       context: context,
       commands: [
         PaletteCommand(
-          label: 'New project',
+          label: 'New',
           category: 'File',
           run: app.newProject,
         ),
@@ -326,39 +199,40 @@ class LumitMenuBarFrb extends StatelessWidget {
           PaletteCommand(
             label: 'Save',
             category: 'File',
-            run: () => _save(context),
+            run: () => saveProjectFrb(app, picker: savePicker),
           ),
           PaletteCommand(
             label: 'Save as…',
             category: 'File',
-            run: () => _save(context, forcePicker: true),
+            run: () =>
+                saveProjectFrb(app, forcePicker: true, picker: savePicker),
           ),
           PaletteCommand(
-            label: 'Import footage…',
+            label: 'Import…',
             category: 'File',
-            run: () => _import(context),
+            run: () => importFootageFrb(app, picker: footagePicker),
           ),
           PaletteCommand(
             label: 'New composition',
             category: 'Composition',
-            run: () => _newComposition(context),
+            run: () => newCompositionFrb(context, app),
           ),
           PaletteCommand(
             label: 'Undo',
             category: 'Edit',
             shortcut: 'Ctrl+Z',
-            run: () => _undo(context),
+            run: () => undoFrb(app),
           ),
           PaletteCommand(
             label: 'Redo',
             category: 'Edit',
             shortcut: 'Ctrl+Shift+Z',
-            run: () => _redo(context),
+            run: () => redoFrb(app),
           ),
           PaletteCommand(
             label: 'Export…',
             category: 'File',
-            run: () => _export(context),
+            run: () => exportFrb(context),
           ),
           // Every comp, by name: Enter fronts it in the Viewer and Timeline.
           for (final (comp, name) in app.comps())
@@ -385,49 +259,583 @@ class LumitMenuBarFrb extends StatelessWidget {
           ),
         PaletteCommand(
           label: 'Settings…',
-          category: 'File',
+          category: 'Edit',
           run: () => showSettingsWindowFrb(context),
         ),
       ],
     );
   }
-
-  void _undo(BuildContext context) {
-    app.project?.undo();
-    app.notifyDocumentChanged();
-  }
-
-  void _redo(BuildContext context) {
-    app.project?.redo();
-    app.notifyDocumentChanged();
-  }
-
-  Widget _menu(BuildContext context, String title, List<_Item> items) =>
-      _MenuButton(title: title, items: items);
 }
 
-/// One menu row: a label and an action, or a divider. A null action renders the
-/// row disabled rather than hiding it, so the menu's shape does not shift.
-class _Item {
-  final String? label;
-  final VoidCallback? onPressed;
-  final bool isDivider;
+// --- The tree -------------------------------------------------------------
 
-  /// The rows this one opens onto, for a heading like Window → Workspaces.
-  final List<_Item>? children;
+/// Every menu, in bar order. Pure construction: it reads the document and the
+/// shell state and hands back rows, so the two renderers below (and a test)
+/// all see exactly the same bar.
+List<MenuSection> lumitMenus(
+  BuildContext context,
+  LumitState app, {
+  Future<String?> Function()? openPicker,
+  Future<String?> Function()? savePicker,
+  Future<List<String>> Function()? footagePicker,
+  VoidCallback? palette,
+}) {
+  final ui = context.read<LumitUiState>();
+  final project = app.project;
+  // Null while no project is loaded, so every document item is disabled rather
+  // than throwing when pressed.
+  final history = project?.history();
+  final comp = ui.selectedComp;
+  final layer = ui.selectedLayer.value;
+  final layers = ui.selectedLayers.value;
 
-  _Item(this.label, this.onPressed)
-      : isDivider = false,
-        children = null;
-  _Item.divider()
-      : label = null,
-        onPressed = null,
-        isDivider = true,
-        children = null;
-  _Item.submenu(this.label, this.children)
-      : onPressed = null,
-        isDivider = false;
+  /// Wrap a composition action: null (so the item greys out) when no
+  /// composition is fronted, else the action followed by a redraw.
+  VoidCallback? onComp(void Function(CompositionReference) run) {
+    if (comp == null) return null;
+    return () {
+      run(comp);
+      app.notifyDocumentChanged();
+    };
+  }
+
+  /// The same, for a command that acts on the selected *layer* — greyed out
+  /// with nothing selected rather than offered and inert.
+  VoidCallback? onLayer(void Function(LayerReference) run) {
+    if (layer == null) return null;
+    return () => run(layer);
+  }
+
+  return [
+    (title: 'File', items: [
+      MenuEntry('New', app.newProject, action: 'file.new'),
+      MenuEntry('Open project…', () => openProjectFrb(app, picker: openPicker),
+          action: 'file.open'),
+      MenuEntry.submenu('Open recent', [
+        if (ui.workspace.recentProjects.isEmpty)
+          const MenuEntry('Nothing yet', null)
+        else
+          for (final path in ui.workspace.recentProjects)
+            MenuEntry(path, () => app.openProject(path)),
+      ]),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Close project'),
+      // Save is only meaningful once there is a project; without a path it
+      // behaves as Save as, which is what the engine's empty-path refusal
+      // makes us handle explicitly.
+      MenuEntry(
+          'Save',
+          project == null
+              ? null
+              : () => saveProjectFrb(app, picker: savePicker),
+          action: 'file.save'),
+      MenuEntry(
+          'Save as…',
+          project == null
+              ? null
+              : () =>
+                  saveProjectFrb(app, forcePicker: true, picker: savePicker),
+          action: 'file.save.as'),
+      const MenuEntry.divider(),
+      MenuEntry(
+          'Import…',
+          project == null
+              ? null
+              : () => importFootageFrb(app, picker: footagePicker),
+          action: 'file.import'),
+      MenuEntry('Export…', comp == null ? null : () => exportFrb(context),
+          action: 'file.export'),
+      const MenuEntry.divider(),
+      // Not in the specified list, and kept: recovering work beside a project
+      // is the one command whose absence costs a day's work.
+      MenuEntry('Recover…',
+          project?.path() == null ? null : () => _recover(context, app)),
+    ]),
+    (title: 'Edit', items: [
+      MenuEntry('Undo', (history?.canUndo ?? false) ? () => undoFrb(app) : null,
+          action: 'edit.undo'),
+      MenuEntry('Redo', (history?.canRedo ?? false) ? () => redoFrb(app) : null,
+          action: 'edit.redo'),
+      const MenuEntry.todo('History'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Cut'),
+      const MenuEntry.todo('Copy'),
+      const MenuEntry.todo('Paste'),
+      MenuEntry(
+          'Delete',
+          layers.isEmpty
+              ? null
+              : () {
+                  for (final l in layers) {
+                    l.delete();
+                  }
+                  ui.clearSelection();
+                  app.notifyDocumentChanged();
+                },
+          action: 'edit.delete.selection'),
+      const MenuEntry.divider(),
+      MenuEntry(
+          'Duplicate',
+          onLayer((l) {
+            l.duplicate();
+            app.notifyDocumentChanged();
+          }),
+          action: 'layer.duplicate'),
+      MenuEntry('Split layer', onComp((c) => _splitAtPlayhead(ui)),
+          action: 'layer.split'),
+      MenuEntry(
+          'Select all',
+          comp == null ? null : () => ui.setSelection(comp.getLayers()),
+          action: 'edit.select.all'),
+      MenuEntry('Deselect all', ui.clearSelection,
+          action: 'edit.deselect.all'),
+      const MenuEntry.divider(),
+      // Windows and Linux keep Preferences under Edit, which is where every
+      // application those users know puts it. macOS moves this same row into
+      // the application menu (see [platformMenusFor]), which is where every
+      // application *those* users know puts it.
+      MenuEntry('Settings…', () => showSettingsWindowFrb(context),
+          action: 'app.settings'),
+    ]),
+    (title: 'Composition', items: [
+      MenuEntry('New composition',
+          project == null ? null : () => newCompositionFrb(context, app),
+          action: 'comp.new'),
+      const MenuEntry.divider(),
+      MenuEntry('Composition settings…',
+          comp == null ? null : () => _compSettings(context, app),
+          action: 'comp.settings'),
+      const MenuEntry.todo('Trim comp to work area'),
+      const MenuEntry.todo('Crop comp to work area'),
+      const MenuEntry.divider(),
+      // "Export", never "render", for anything the user sees (glossary §9).
+      const MenuEntry.todo('Add to export queue', action: 'export.queue.add'),
+      const MenuEntry.divider(),
+      // Comp-level markers, including the beat pass, which makes them
+      // (docs/09 §10) — the layer's own markers are Layer ▸ Markers.
+      MenuEntry('Add marker at playhead', onComp((c) => _markerAtPlayhead(ui, c)),
+          action: 'marker.add'),
+      // Beat detection reads the whole comp's audio and can take seconds, so
+      // it runs off-thread; a comp with no audio does nothing rather than
+      // alarming.
+      MenuEntry(
+          'Detect beats',
+          onComp((c) => c
+              .detectBeats(sensitivityPercent: 50)
+              .then((_) {}, onError: (_) {}))),
+      MenuEntry('Clear beat markers', onComp((c) => c.clearBeatMarkers())),
+    ]),
+    (title: 'Layer', items: [
+      MenuEntry.submenu('New', [
+        MenuEntry('Solid', onComp((c) => c.addSolidLayer())),
+        MenuEntry('Text', onComp((c) => c.addTextLayer())),
+        MenuEntry('Camera', onComp((c) => c.addCameraLayer())),
+        MenuEntry('Adjustment', onComp((c) => c.addAdjustmentLayer())),
+        MenuEntry('Null', onComp((c) => c.addNullLayer())),
+        MenuEntry('Sequence', onComp((c) => c.addSequenceLayer())),
+      ]),
+      const MenuEntry.todo('Layer settings…'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Mask'),
+      const MenuEntry.todo('Mask and shape path'),
+      const MenuEntry.todo('Transform'),
+      // The selected layer's Retime (K-197). In the menu as well as on the
+      // keyboard (K-198's lesson: a command whose only route is a chord has no
+      // route the day something intercepts the chord). The command names what
+      // it will do, so a layer that already has one offers to take it away.
+      MenuEntry(_retimeLabel(layer), onLayer((l) => app.toggleRetime(l)),
+          action: 'layer.retime.enable'),
+      const MenuEntry.todo('Flow'),
+      const MenuEntry.todo('3D layer'),
+      const MenuEntry.todo('Markers'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Preserve transparency'),
+      const MenuEntry.todo('Blending mode'),
+      const MenuEntry.todo('Next blending mode'),
+      const MenuEntry.todo('Previous blending mode'),
+      const MenuEntry.todo('Track matte'),
+      const MenuEntry.todo('Layer styles'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Reveal'),
+      const MenuEntry.todo('Create'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Camera'),
+      const MenuEntry.todo('Auto-outline'),
+      // Pre-compose… is live only with a comp open and something selected in
+      // it — the menu says so by greying out rather than by failing.
+      MenuEntry(
+          'Pre-compose…',
+          comp == null || layers.isEmpty
+              ? null
+              : () => showPrecomposeDialogFrb(
+                    context: context,
+                    comp: comp,
+                    selectedLayers: layers,
+                    ui: ui,
+                    workspace: ui.workspace,
+                  ),
+          action: 'layer.precompose'),
+    ]),
+    (title: 'Effect', items: _effectMenu(app, layers)),
+    (title: 'Animation', items: const [
+      MenuEntry.todo('Save animation preset'),
+      MenuEntry.todo('Apply animation preset'),
+      MenuEntry.divider(),
+      MenuEntry.todo('Set keyframe'),
+      MenuEntry.todo('Toggle hold keyframe'),
+      MenuEntry.todo('Keyframe interpolation…'),
+      MenuEntry.todo('Keyframe velocity…'),
+      MenuEntry.divider(),
+      MenuEntry.todo('Animate text'),
+      MenuEntry.todo('Add text selector'),
+      MenuEntry.divider(),
+      MenuEntry.todo('Add expression'),
+      MenuEntry.todo('Separate dimensions'),
+      MenuEntry.todo('Track camera'),
+      MenuEntry.todo('Track motion'),
+      MenuEntry.divider(),
+      MenuEntry.todo('Reveal properties with keyframes',
+          action: 'reveal.animated'),
+      MenuEntry.todo('Reveal properties with animation'),
+      MenuEntry.todo('Reveal all modified properties'),
+    ]),
+    (title: 'View', items: const [
+      MenuEntry.todo('Zoom in', action: 'viewer.zoom.in'),
+      MenuEntry.todo('Zoom out', action: 'viewer.zoom.out'),
+      MenuEntry.todo('Fit', action: 'viewer.zoom.fit'),
+      MenuEntry.divider(),
+      MenuEntry.submenu('Resolution', [
+        MenuEntry.todo('Full', action: 'viewer.res.full'),
+        MenuEntry.todo('Half', action: 'viewer.res.half'),
+        MenuEntry.todo('Quarter', action: 'viewer.res.quarter'),
+      ]),
+      MenuEntry.divider(),
+      MenuEntry.todo('Show grid', action: 'viewer.grid.toggle'),
+      MenuEntry.todo('Show ruler', action: 'viewer.rulers.toggle'),
+      MenuEntry.todo('Show wireframe'),
+      MenuEntry.todo('Snap to grid'),
+    ]),
+    (title: 'Window', items: [
+      MenuEntry.submenu('Workspace', [
+        for (final preset in WorkspacePreset.values)
+          MenuEntry(preset.title,
+              () => ui.workspace.applyWorkspacePreset(preset),
+              checked: ui.workspace.activePreset == preset),
+        const MenuEntry.divider(),
+        MenuEntry('Reset workspace', ui.resetLayout),
+      ]),
+      MenuEntry.todo(
+          'Assign shortcut to ${ui.workspace.activePreset?.title ?? 'this'} '
+          'workspace'),
+      const MenuEntry.divider(),
+      // Every panel, ticked when it is in the arrangement. Toggling one adds
+      // or drops its pane and persists the layout, so a panel you closed stays
+      // closed across a restart.
+      for (final panel in Panel.values)
+        MenuEntry(
+          panel.title,
+          () {
+            setPanelVisible(
+                ui.split, panel, !panelVisible(ui.split, panel));
+            ui.workspace.touch();
+          },
+          checked: panelVisible(ui.split, panel),
+        ),
+      const MenuEntry.divider(),
+      MenuEntry('Command palette…', palette, action: 'palette.open'),
+    ]),
+    (title: 'Help', items: [
+      MenuEntry('About Lumit', () => showAboutWindowFrb(context)),
+      const MenuEntry.todo('Check for updates'),
+      const MenuEntry.divider(),
+      const MenuEntry.todo('Lumit help'),
+      const MenuEntry.todo('Lumit online guides'),
+      const MenuEntry.divider(),
+      MenuEntry(
+        'Enable debug panel',
+        () {
+          setPanelVisible(
+              ui.split, Panel.debug, !panelVisible(ui.split, Panel.debug));
+          ui.workspace.touch();
+        },
+        checked: panelVisible(ui.split, Panel.debug),
+      ),
+    ]),
+  ];
 }
+
+/// The Effect menu: one submenu per effect category (K-090), each applying its
+/// effect to every selected layer. Disabled outright with nothing selected —
+/// there is nowhere for an effect to go.
+List<MenuEntry> _effectMenu(LumitState app, List<LayerReference> layers) => [
+      for (final group in _effectGroups().entries)
+        MenuEntry.submenu(group.key, [
+          for (final effect in group.value)
+            MenuEntry(
+              effect.label,
+              layers.isEmpty
+                  ? null
+                  : () {
+                      for (final layer in layers) {
+                        layer.addEffect(name: effect.name);
+                      }
+                      app.notifyDocumentChanged();
+                    },
+            ),
+        ]),
+    ];
+
+/// Every built-in effect, grouped by its heading, in the engine's own order.
+///
+/// Read once: the catalogue is fixed for the run, and the menu bar rebuilds on
+/// every document change — a bridge call per rebuild is exactly the cost the
+/// hover-hot paths are budgeted against.
+Map<String, List<BridgeEffectInfo>> _effectGroups() =>
+    _effectGroupsCache ??= () {
+      final groups = <String, List<BridgeEffectInfo>>{};
+      for (final effect in listEffects()) {
+        groups.putIfAbsent(effect.categoryLabel, () => []).add(effect);
+      }
+      return groups;
+    }();
+
+Map<String, List<BridgeEffectInfo>>? _effectGroupsCache;
+
+/// What the Retime item says.
+String _retimeLabel(LayerReference? layer) {
+  if (layer == null) return 'Enable Retime';
+  try {
+    return layer.getRetimeProperty() == null
+        ? 'Enable Retime'
+        : 'Disable Retime';
+  } catch (_) {
+    return 'Enable Retime';
+  }
+}
+
+// --- The commands ---------------------------------------------------------
+//
+// Free functions, not methods, because the keyboard runs the same commands the
+// menu does (K-199 dispatch lives in main.dart) and a shortcut that took a
+// different path than its menu item would be two implementations to keep
+// honest. [saveProjectFrb] was the first of these (K-203); the rest followed
+// when the menu grew shortcuts.
+
+Future<void> openProjectFrb(LumitState app,
+    {Future<String?> Function()? picker}) async {
+  final path = await (picker ?? pickProjectToOpen)();
+  if (path == null) return;
+  app.openProject(path);
+}
+
+Future<void> importFootageFrb(LumitState app,
+        {Future<List<String>> Function()? picker}) async =>
+    app.importFootagePaths(await (picker ?? pickFootage)());
+
+/// Make a composition and front it — a comp you just made is the one you want
+/// to work on.
+Future<void> newCompositionFrb(BuildContext context, LumitState app) async {
+  final comp = await app.newComposition(context);
+  if (comp != null && context.mounted) {
+    context.read<LumitUiState>().setSelectedComp(comp);
+  }
+}
+
+Future<void> exportFrb(BuildContext context) async {
+  final comp = context.read<LumitUiState>().selectedComp;
+  if (comp == null) return;
+  await showExportDialogFrb(context: context, comp: comp);
+}
+
+void undoFrb(LumitState app) {
+  app.project?.undo();
+  app.notifyDocumentChanged();
+}
+
+void redoFrb(LumitState app) {
+  app.project?.redo();
+  app.notifyDocumentChanged();
+}
+
+/// Razor the selected layer at the playhead. Only Sequence layers hold clips,
+/// so on anything else the engine declines and nothing happens.
+void _splitAtPlayhead(LumitUiState ui) {
+  final layer = ui.selectedLayer.value;
+  if (layer == null) return;
+  try {
+    layer.cutClipAt(frame: ui.playheadFrame.value);
+  } catch (_) {}
+}
+
+void _markerAtPlayhead(LumitUiState ui, CompositionReference comp) {
+  final frame = ui.playheadFrame.value;
+  comp.setMarkers(markers: [
+    ...comp.getMarkers(),
+    BridgeMarker(
+      id: UuidValue.fromString(const Uuid().v4()),
+      time: comp.timeOfFrame(frame: frame),
+      label: '',
+    ),
+  ]);
+}
+
+Future<void> _compSettings(BuildContext context, LumitState app) async {
+  final comp = context.read<LumitUiState>().selectedComp;
+  if (comp == null) return;
+  final applied = await showCompSettingsFrb(context: context, comp: comp);
+  if (applied) app.notifyDocumentChanged();
+}
+
+/// Offer to recover work beside the open project.
+///
+/// Only meaningful once the project has a path — recovery is about a *file*,
+/// and a project that has never been saved has nothing beside it.
+Future<void> _recover(BuildContext context, LumitState app) async {
+  final path = app.project?.path();
+  if (path == null) return;
+  await showRecoveryDialogFrb(
+      context: context, state: app, projectPath: path);
+}
+
+/// Save the project, asking for a location only when there is not one already
+/// — or always, for Save as.
+///
+/// The engine refuses an empty path on a project that has never been saved, so
+/// whether to prompt is decided here from `path()` rather than by trying and
+/// handling the failure.
+///
+/// [picker] is the injectable seam a widget test needs: no plugin channel can
+/// open a real dialogue in one.
+Future<void> saveProjectFrb(
+  LumitState app, {
+  bool forcePicker = false,
+  Future<String?> Function()? picker,
+}) async {
+  final project = app.project;
+  if (project == null) return;
+
+  var target = '';
+  if (forcePicker || project.path() == null) {
+    final picked = await (picker ?? pickProjectSaveLocation)();
+    if (picked == null) return;
+    target = picked;
+  }
+  try {
+    final written = await project.save(path: target);
+    app.postNotice('Saved to $written');
+  } catch (_) {
+    // The work is still in the document and the journal; say so calmly and let
+    // the user pick somewhere writable.
+    app.postNotice('Could not save the project', error: true);
+  }
+  app.notifyDocumentChanged();
+}
+
+// --- The macOS renderer ---------------------------------------------------
+
+/// The same tree as native macOS menus.
+///
+/// Two Mac conventions are applied here and nowhere else, because they are only
+/// conventions there: the application menu leads the bar, carrying About, the
+/// system-provided Services/Hide/Quit rows and Settings — so Settings is lifted
+/// out of Edit and About out of Help on that platform alone. Ticks are drawn as
+/// a leading mark in the label, since Flutter's platform-menu API has no
+/// checked state of its own.
+///
+/// ponytail: labels carry the tick; a real checkmark needs a channel of our own.
+List<PlatformMenuItem> platformMenusFor(
+    BuildContext context, List<MenuSection> menus) {
+  final keymap = context.read<LumitUiState>().keymap;
+
+  List<PlatformMenuItem> rows(List<MenuEntry> items) {
+    final out = <PlatformMenuItem>[];
+    var group = <PlatformMenuItem>[];
+    void flush() {
+      if (group.isEmpty) return;
+      out.add(PlatformMenuItemGroup(members: group));
+      group = [];
+    }
+
+    for (final item in items) {
+      if (item.isDivider) {
+        flush();
+        continue;
+      }
+      final label = switch (item.checked) {
+        true => '✓ ${item.text}',
+        false => '  ${item.text}',
+        null => item.text,
+      };
+      if (item.children case final children?) {
+        group.add(PlatformMenu(label: label, menus: rows(children)));
+        continue;
+      }
+      final chord = item.action == null ? null : keymap.rawChordFor(item.action!);
+      group.add(PlatformMenuItem(
+        label: label,
+        // A null callback is how the platform menu draws a row disabled.
+        onSelected: item.onPressed,
+        shortcut: chord == null ? null : activatorForChord(chord),
+      ));
+    }
+    flush();
+    return out;
+  }
+
+  // Settings and About move into the application menu; the menus they came
+  // from lose exactly those rows.
+  MenuEntry? take(String title, String label) {
+    for (final menu in menus) {
+      if (menu.title != title) continue;
+      for (final item in menu.items) {
+        if (item.label == label) return item;
+      }
+    }
+    return null;
+  }
+
+  final settings = take('Edit', 'Settings…');
+  final about = take('Help', 'About Lumit');
+
+  return [
+    PlatformMenu(label: 'Lumit', menus: [
+      PlatformMenuItemGroup(members: [
+        PlatformMenuItem(
+            label: 'About Lumit', onSelected: about?.onPressed),
+      ]),
+      PlatformMenuItemGroup(members: [
+        if (settings != null)
+          PlatformMenuItem(
+            label: 'Settings…',
+            onSelected: settings.onPressed,
+            shortcut: activatorForChord(
+                keymap.rawChordFor('app.settings') ?? ''),
+          ),
+      ]),
+      const PlatformMenuItemGroup(members: [
+        PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.servicesSubmenu),
+      ]),
+      const PlatformMenuItemGroup(members: [
+        PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.hide),
+        PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.hideOtherApplications),
+        PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.showAllApplications),
+      ]),
+      const PlatformMenuItemGroup(members: [
+        PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.quit),
+      ]),
+    ]),
+    for (final menu in menus)
+      PlatformMenu(
+        label: menu.title,
+        menus: rows([
+          for (final item in menu.items)
+            if (!identical(item, settings) && !identical(item, about)) item,
+        ]),
+      ),
+  ];
+}
+
+// --- The in-app renderer --------------------------------------------------
 
 /// Watches [LumitUiState.paletteRequest] and opens the palette when the
 /// shortcut bumps it. Draws nothing; it exists only to hold the subscription,
@@ -470,7 +878,7 @@ class _PaletteHotkeyState extends State<_PaletteHotkey> {
 
 class _MenuButton extends StatelessWidget {
   final String title;
-  final List<_Item> items;
+  final List<MenuEntry> items;
   const _MenuButton({required this.title, required this.items});
 
   @override
@@ -497,20 +905,24 @@ class _MenuButton extends StatelessWidget {
 }
 
 class _MenuList extends StatelessWidget {
-  final List<_Item> items;
+  final List<MenuEntry> items;
   final VoidCallback close;
   const _MenuList({required this.items, required this.close});
 
   @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
+    final keymap = context.read<LumitUiState>().keymap;
+    // A tick column only where something in this menu is a toggle, so an
+    // ordinary menu is not indented for a mark it never shows.
+    final ticks = items.any((i) => i.checked != null);
     // A long menu on a short window would otherwise run off the bottom, where
     // the last items cannot be clicked at all — so it scrolls once it no longer
     // fits. `- 40` leaves the menu bar itself and a margin.
     final maxHeight =
         (MediaQuery.of(context).size.height - 40).clamp(80.0, 1e6);
     return FloatSurface(
-      width: 230,
+      width: 300,
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: maxHeight),
         child: SingleChildScrollView(
@@ -531,7 +943,7 @@ class _MenuList extends StatelessWidget {
                     closeParent: close,
                     submenu: (dismiss) =>
                         _MenuList(items: children, close: dismiss),
-                    child: Text(item.label ?? ''),
+                    child: _label(t, item, ticks: ticks, shortcut: null),
                   )
                 else
                   MenuRow(
@@ -541,11 +953,13 @@ class _MenuList extends StatelessWidget {
                             close();
                             item.onPressed!();
                           },
-                    child: Text(
-                      item.label ?? '',
-                      style: item.onPressed == null
-                          ? t.body.copyWith(color: t.textDisabled)
-                          : null,
+                    child: _label(
+                      t,
+                      item,
+                      ticks: ticks,
+                      shortcut: item.action == null
+                          ? null
+                          : keymap.chordFor(item.action!),
                     ),
                   ),
             ],
@@ -554,41 +968,26 @@ class _MenuList extends StatelessWidget {
       ),
     );
   }
-}
 
-/// Save the project, asking for a location only when there is not one already
-/// — or always, for Save as.
-///
-/// A free function rather than a method on the menu, because Ctrl+S is a
-/// keymap action dispatched from the shell (K-199) and a shortcut that took a
-/// different path to disk than the menu item would be two saves to keep
-/// honest. The engine refuses an empty path on a project that has never been
-/// saved, so whether to prompt is decided here from `path()` rather than by
-/// trying and handling the failure.
-///
-/// [picker] is the injectable seam a widget test needs: no plugin channel can
-/// open a real dialogue in one.
-Future<void> saveProjectFrb(
-  LumitState app, {
-  bool forcePicker = false,
-  Future<String?> Function()? picker,
-}) async {
-  final project = app.project;
-  if (project == null) return;
-
-  var target = '';
-  if (forcePicker || project.path() == null) {
-    final picked = await (picker ?? pickProjectSaveLocation)();
-    if (picked == null) return;
-    target = picked;
+  /// One row's contents: the tick column where the menu has toggles, the name,
+  /// and the chord it answers to on the right.
+  Widget _label(LumitTheme t, MenuEntry item,
+      {required bool ticks, required String? shortcut}) {
+    final style = item.enabled ? null : t.body.copyWith(color: t.textDisabled);
+    return Row(
+      children: [
+        if (ticks)
+          SizedBox(
+            width: 16,
+            child: item.checked == true ? Text('✓', style: style) : null,
+          ),
+        Expanded(child: Text(item.text, style: style)),
+        if (shortcut != null)
+          Padding(
+            padding: const EdgeInsets.only(left: 16),
+            child: Text(shortcut, style: t.small.copyWith(color: t.textMuted)),
+          ),
+      ],
+    );
   }
-  try {
-    final written = await project.save(path: target);
-    app.postNotice('Saved to $written');
-  } catch (_) {
-    // The work is still in the document and the journal; say so calmly and let
-    // the user pick somewhere writable.
-    app.postNotice('Could not save the project', error: true);
-  }
-  app.notifyDocumentChanged();
 }

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -156,6 +156,12 @@ class LumitMenuBarFrb extends StatelessWidget {
 
     return Container(
       height: 26,
+      // **Load-bearing.** The scroll view below shrink-wraps to the width of
+      // its Row, so without this the bar is only as wide as its nine headings
+      // — and the Column above it, centring by default, puts that stub in the
+      // middle of the window with the backdrop showing either side. The bar is
+      // chrome: it spans the window, one colour, headings from the left edge.
+      width: double.infinity,
       color: t.surface2,
       // Nine menu names do not fit a narrow window, and a menu you cannot
       // reach is worse than one you have to scroll to — so the bar scrolls

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -196,12 +196,8 @@ class _SettingsWindowState extends State<_SettingsWindow> {
             ),
           ),
         ]),
-        _section(t, 'About', [
-          _row(t, 'Version', 'This build of Lumit.',
-              Text(_version(), style: t.small)),
-          for (final line in bootLog().skip(1))
-            _row(t, line, '', const SizedBox.shrink()),
-        ]),
+        // About used to sit here. It is Help ▸ About Lumit now (K-242):
+        // Settings is for what you change, and a version number is not that.
       ];
 
   List<Widget> _appearance(LumitTheme t, LumitUiState ui) => [
@@ -1005,9 +1001,6 @@ class _SettingsWindowState extends State<_SettingsWindow> {
   /// A round figure for a sentence: "32 GB", or megabytes when it is small.
   static String _gib(double mib) =>
       mib >= 1024 ? '${(mib / 1024).round()} GB' : '${mib.round()} MB';
-
-  /// The engine's own first boot-log line is the build banner.
-  static String _version() => bootLog().isEmpty ? 'unknown' : bootLog().first;
 
   static String _mib(int bytes) => (bytes / (1 << 20)).toStringAsFixed(0);
 

--- a/flutter_ui/lib/state/dock.dart
+++ b/flutter_ui/lib/state/dock.dart
@@ -243,6 +243,58 @@ List<Panel> panelsIn(DockNode node) => switch (node) {
         ],
     };
 
+/// Whether `panel` is anywhere in the tree — which is what "visible" means for
+/// a dock: a panel that is not in the arrangement is not on screen, and one
+/// that is can always be brought to the front of its group.
+bool panelVisible(DockNode node, Panel panel) => panelsIn(node).contains(panel);
+
+/// Add or drop `panel`, for the Window menu's tick list. A no-op when the tree
+/// already agrees with `visible`.
+///
+/// Showing stacks it into the first tab group, fronted — a panel you just asked
+/// for is the one you want to look at. With no tab group at all it pairs up
+/// with the first tile instead, so it never has to invent a share of the
+/// window. Hiding drops the pane and simplifies, exactly as closing a tab does.
+/// The last panel standing cannot be hidden: an empty dock has no way back.
+void setPanelVisible(DockSplit root, Panel panel, bool visible) {
+  if (panelsIn(root).contains(panel) == visible) return;
+  if (!visible) {
+    if (panelsIn(root).length <= 1) return;
+    _removePanel(root, panel);
+    simplify(root);
+    return;
+  }
+  final tabs = _firstTabs(root);
+  if (tabs != null) {
+    tabs.children.add(DockPane(panel));
+    tabs.active = tabs.children.length - 1;
+    return;
+  }
+  final first = root.children.first;
+  if (first is DockPane) {
+    root.children[0] = DockTabs([first, DockPane(panel)], active: 1);
+    return;
+  }
+  root.children.insert(0, DockPane(panel));
+  root.shares.insert(0, 0.2);
+}
+
+/// The first tab group in visit order, or null when every panel sits alone.
+DockTabs? _firstTabs(DockNode node) {
+  switch (node) {
+    case DockPane():
+      return null;
+    case DockTabs():
+      return node;
+    case DockSplit(:final children):
+      for (final child in children) {
+        final found = _firstTabs(child);
+        if (found != null) return found;
+      }
+      return null;
+  }
+}
+
 /// Bring `panel`'s tab to the front of whichever tab group holds it (the
 /// start-up "always open on Project" rule).
 void activatePanelTab(DockNode node, Panel panel) {

--- a/flutter_ui/lib/state/keymap.dart
+++ b/flutter_ui/lib/state/keymap.dart
@@ -17,6 +17,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show SingleActivator;
 import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 
 import '../src/rust/api/keymap.dart';
@@ -111,6 +112,38 @@ String? chordText(KeyEvent event) {
   ].join('+');
 }
 
+/// The logical key each keymap name stands for — [_namedKeys] read backwards.
+/// Where two keys share a name (`Enter` is both), the first declared wins, so
+/// the main-row key is the one a menu shows.
+final Map<String, LogicalKeyboardKey> _keysByName = {
+  for (final e in _namedKeys.entries.toList().reversed) e.value: e.key,
+};
+
+/// A chord as macOS's own menu bar wants it: a [SingleActivator] for the native
+/// `PlatformMenuItem` to draw beside its row (K-242).
+///
+/// Only the native menu needs this — everywhere else the keyboard is the
+/// engine's business and a chord is text. `Mod` becomes Cmd, because macOS is
+/// the only place this is asked. Null when the chord names a key we cannot
+/// spell as a logical key, so a row shows no shortcut rather than the wrong one.
+SingleActivator? activatorForChord(String chord) {
+  if (chord.isEmpty) return null;
+  // `Mod++` would split into an empty last part; the trailing `+` *is* the key.
+  final keyText = chord.endsWith('+') ? '+' : chord.split('+').last;
+  final mods = chord.substring(0, chord.length - keyText.length).split('+');
+  final key = _keysByName[keyText] ??
+      (keyText.length == 1
+          ? LogicalKeyboardKey(keyText.toLowerCase().codeUnitAt(0))
+          : null);
+  if (key == null) return null;
+  return SingleActivator(
+    key,
+    meta: mods.contains('Mod'),
+    alt: mods.contains('Alt'),
+    shift: mods.contains('Shift'),
+  );
+}
+
 /// How a chord is *shown* on this machine: `Mod` becomes the symbol or word the
 /// platform's own menus use, so a Windows user reads Ctrl and a Mac user reads
 /// ⌘. The stored form never changes — only the reading of it.
@@ -195,10 +228,18 @@ class KeymapState extends ChangeNotifier {
   /// hover: this is drawn on every tooltip and the answer only changes when a
   /// rebind lands, which is exactly when [_adopt] refreshes it.
   String? chordFor(String action) {
+    final raw = rawChordFor(action);
+    return raw == null ? null : chordLabel(raw);
+  }
+
+  /// The same binding in the engine's own spelling (`Mod+Shift+Z`), for the one
+  /// caller that needs the parts rather than the reading: the macOS native menu,
+  /// which wants a [SingleActivator].
+  String? rawChordFor(String action) {
     for (final group in _groups) {
       for (final binding in group.bindings) {
         if (binding.action == action && binding.chord.isNotEmpty) {
-          return chordLabel(binding.chord);
+          return binding.chord;
         }
       }
     }

--- a/flutter_ui/lib/state/workspace.dart
+++ b/flutter_ui/lib/state/workspace.dart
@@ -385,8 +385,24 @@ class Workspace extends ChangeNotifier {
   /// this does not notify listeners.
   void rememberProject(String path) {
     lastProjectPath = path;
+    recentProjects
+      ..remove(path)
+      ..insert(0, path);
+    if (recentProjects.length > maxRecentProjects) {
+      recentProjects.removeRange(maxRecentProjects, recentProjects.length);
+    }
     save();
   }
+
+  /// The projects opened or saved most recently, newest first — File ▸ Open
+  /// recent. Paths only: whether the file is still there is not asked until
+  /// someone picks it, because a network drive that is slow to answer must not
+  /// hold up a menu opening.
+  final List<String> recentProjects = [];
+
+  /// How many the list keeps. Ten is the length every editor settled on: long
+  /// enough to reach last week's work, short enough to read at a glance.
+  static const int maxRecentProjects = 10;
 
   /// Remember [session] for the project at [path], persisted immediately so the
   /// next open restores it. A no-op write when the session is unchanged, so the
@@ -448,6 +464,7 @@ class Workspace extends ChangeNotifier {
         'precompose_adjust_duration': precomposeAdjustDuration,
         'precompose_open_new_comp': precomposeOpenNewComp,
         'last_project_path': lastProjectPath,
+        'recent_projects': recentProjects,
         'sessions': {
           for (final e in sessions.entries) e.key: e.value.toJson(),
         },
@@ -496,6 +513,11 @@ class Workspace extends ChangeNotifier {
     lastProjectPath = j['last_project_path'] is String
         ? j['last_project_path'] as String
         : null;
+    recentProjects.clear();
+    final rawRecent = j['recent_projects'];
+    if (rawRecent is List) {
+      recentProjects.addAll(rawRecent.whereType<String>());
+    }
     sessions.clear();
     final rawSessions = j['sessions'];
     if (rawSessions is Map) {

--- a/flutter_ui/test/dock_test.dart
+++ b/flutter_ui/test/dock_test.dart
@@ -69,4 +69,49 @@ void main() {
     expect(Panel.effectControls.title, 'Effect controls');
     expect(Panel.effectsAndPresets.title, 'Effects & presets');
   });
+
+  group('panel visibility (the Window menu tick list)', () {
+    test('hiding drops the panel and showing puts it back, fronted', () {
+      final root = defaultLayout();
+      expect(panelVisible(root, Panel.scopes), isTrue);
+
+      setPanelVisible(root, Panel.scopes, false);
+      expect(panelVisible(root, Panel.scopes), isFalse);
+      expect(panelsIn(root).toSet().length, panelsIn(root).length,
+          reason: 'no panel appears twice after a removal');
+
+      setPanelVisible(root, Panel.scopes, true);
+      expect(panelVisible(root, Panel.scopes), isTrue);
+      // It went into a tab group, fronted — a panel you just asked for is the
+      // one you want to look at.
+      final tabs = panelsIn(root);
+      expect(tabs.where((p) => p == Panel.scopes), hasLength(1));
+    });
+
+    test('asking for what is already so changes nothing', () {
+      final root = defaultLayout();
+      final before = root.toJson();
+      setPanelVisible(root, Panel.viewer, true);
+      setPanelVisible(root, Panel.debug, true);
+      expect(root.toJson(), before);
+    });
+
+    test('the last panel standing cannot be hidden', () {
+      final root = DockSplit(DockAxis.vertical, [DockPane(Panel.viewer)], [1.0]);
+      setPanelVisible(root, Panel.viewer, false);
+      expect(panelsIn(root), [Panel.viewer],
+          reason: 'an empty dock has no way back');
+    });
+
+    test('a tree of bare panes still finds somewhere to put one', () {
+      final root = DockSplit(
+        DockAxis.vertical,
+        [DockPane(Panel.viewer), DockPane(Panel.timeline)],
+        [0.5, 0.5],
+      );
+      setPanelVisible(root, Panel.scopes, true);
+      expect(panelVisible(root, Panel.scopes), isTrue);
+      expect(root.shares.length, root.children.length);
+    });
+  });
 }

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -127,16 +127,19 @@ void main() {
       await tester.pump();
 
       for (final item in [
-        'New project',
+        'New',
         'Open project…',
+        'Open recent',
         'Save',
         'Save as…',
-        'Import footage…',
+        'Import…',
+        'Export…',
+        'Close project (Not implemented)',
       ]) {
         expect(find.text(item), findsOneWidget, reason: 'File ▸ $item');
       }
       await dismiss(tester);
-      expect(find.text('New project'), findsNothing,
+      expect(find.text('New'), findsNothing,
           reason: 'the barrier closes the menu without choosing anything');
     });
 
@@ -197,7 +200,7 @@ void main() {
         footagePicker: () async => ['C:/clips/a.mov', 'C:/clips/b.mov'],
       );
 
-      await choose(tester, 'File', 'Import footage…');
+      await choose(tester, 'File', 'Import…');
       await tester.pump();
 
       final names = allItems(p.state)
@@ -214,7 +217,7 @@ void main() {
         savePicker: () async => null,
       );
 
-      await choose(tester, 'File', 'Import footage…');
+      await choose(tester, 'File', 'Import…');
       await tester.pump();
       expect(p.state.project!.getItems(), isEmpty);
 
@@ -320,7 +323,7 @@ void main() {
         footagePicker: () async => ['C:/clips/hero.mov'],
       );
       await makeComp(tester);
-      await choose(tester, 'File', 'Import footage…');
+      await choose(tester, 'File', 'Import…');
       await tester.pump();
       await choose(tester, 'File', 'Save');
       await settleFrb(tester, until: () => File(path).existsSync());
@@ -328,7 +331,7 @@ void main() {
           reason: 'nothing to open otherwise');
 
       // A new, empty project, then open the saved one over the top of it.
-      await choose(tester, 'File', 'New project');
+      await choose(tester, 'File', 'New');
       await tester.pump();
       expect(p.state.project!.getItems(), isEmpty);
 
@@ -345,20 +348,20 @@ void main() {
     /// The port shipped a menu with three items per menu where the previous
     /// frontend had layer creation, clip and marker commands, beat detection
     /// and a Window menu. Each of these reaches the document.
-    testWidgets('Composition creates every kind of layer', (tester) async {
+    testWidgets('Layer ▸ New creates every kind of layer', (tester) async {
       final p = await mount(tester);
       await makeComp(tester);
       final comp = p.uiState.selectedComp!;
 
       for (final item in [
-        'Add solid layer',
-        'Add text layer',
-        'Add camera layer',
-        'Add adjustment layer',
-        'Add sequence layer',
+        'Solid',
+        'Text',
+        'Camera',
+        'Adjustment',
+        'Sequence',
       ]) {
         final before = comp.getLayers().length;
-        await choose(tester, 'Composition', item);
+        await choose(tester, 'Layer', item, under: 'New');
         await tester.pump();
         expect(comp.getLayers(), hasLength(before + 1),
             reason: '$item added one');
@@ -372,7 +375,7 @@ void main() {
 
       // Pressing it must be a no-op rather than a crash — a disabled row that
       // throws when clicked is worse than one that is simply absent.
-      await choose(tester, 'Composition', 'Add solid layer');
+      await choose(tester, 'Layer', 'Solid', under: 'New');
       await tester.pump();
       expect(p.uiState.selectedComp, isNull);
     });
@@ -480,7 +483,7 @@ void main() {
       final p = await mount(tester);
 
       // The presets live under their own heading now (K-194).
-      await choose(tester, 'Window', 'Effects', under: 'Workspaces');
+      await choose(tester, 'Window', 'Effects', under: 'Workspace');
       await tester.pump();
       expect(panelsIn(p.uiState.split),
           panelsIn(presetLayout(WorkspacePreset.effects)));
@@ -488,13 +491,13 @@ void main() {
           isNot(presetLayout(WorkspacePreset.colour).toJson()),
           reason: 'the presets are genuinely different arrangements');
 
-      await choose(tester, 'Window', 'Audio', under: 'Workspaces');
+      await choose(tester, 'Window', 'Audio', under: 'Workspace');
       await tester.pump();
       expect(p.uiState.split.toJson(),
           presetLayout(WorkspacePreset.audio).toJson());
 
       // Reset still means the default (Edit) arrangement.
-      await choose(tester, 'Window', 'Reset workspace', under: 'Workspaces');
+      await choose(tester, 'Window', 'Reset workspace', under: 'Workspace');
       await tester.pump();
       expect(panelsIn(p.uiState.split), panelsIn(defaultLayout()));
     });
@@ -506,10 +509,10 @@ void main() {
       await tester.tap(find.byKey(const ValueKey<String>('menu-Window')));
       await tester.pump();
       expect(find.text('Command palette…'), findsOneWidget);
-      expect(find.text('Settings…'), findsOneWidget);
-      // The arrangements sit behind their own heading now (K-194), so the
-      // Window menu is four rows rather than eight.
-      expect(find.text('Workspaces'), findsOneWidget);
+      // The arrangements sit behind their own heading (K-194), and Settings
+      // moved to Edit where every Windows application keeps it (K-242).
+      expect(find.text('Workspace'), findsOneWidget);
+      expect(find.text('Settings…'), findsNothing);
       expect(find.text('Reset workspace'), findsNothing,
           reason: 'reset lives with the arrangements it undoes');
       await dismiss(tester);
@@ -520,10 +523,136 @@ void main() {
         [DockPane(Panel.viewer), DockPane(Panel.timeline)],
         [0.5, 0.5],
       );
-      await choose(tester, 'Window', 'Reset workspace', under: 'Workspaces');
+      await choose(tester, 'Window', 'Reset workspace', under: 'Workspace');
       await tester.pump();
       expect(panelsIn(p.uiState.split), panelsIn(defaultLayout()),
           reason: 'the default arrangement is back');
+    });
+
+    /// The bar is the shape of the finished application, not of today's build
+    /// (K-242): a command that is specified and unbuilt is still listed, marked
+    /// and disabled, so nobody has to guess whether it is missing or broken.
+    testWidgets('unbuilt commands are listed, marked and disabled',
+        (tester) async {
+      await mount(tester);
+      final t = LumitTheme.forScheme(LumitColorScheme.dark, ThemeShape.sharp);
+
+      await tester.tap(find.byKey(const ValueKey<String>('menu-Animation')));
+      await tester.pump();
+      expect(find.text('Keyframe velocity… (Not implemented)'), findsOneWidget);
+      expect(
+        tester
+            .widget<Text>(find.text('Keyframe velocity… (Not implemented)'))
+            .style
+            ?.color,
+        t.textDisabled,
+      );
+      await dismiss(tester);
+
+      // Every menu the specification names is on the bar, in its order.
+      for (final title in [
+        'File',
+        'Edit',
+        'Composition',
+        'Layer',
+        'Effect',
+        'Animation',
+        'View',
+        'Window',
+        'Help',
+      ]) {
+        expect(find.byKey(ValueKey<String>('menu-$title')), findsOneWidget,
+            reason: '$title is on the bar');
+      }
+    });
+
+    /// Shortcuts are the engine's (K-199): a row shows whatever the keymap
+    /// currently binds to its action, so a rebind changes the menus too.
+    testWidgets('a row teaches the chord its action answers to', (tester) async {
+      final p = await mount(tester);
+
+      await tester.tap(find.byKey(const ValueKey<String>('menu-File')));
+      await tester.pump();
+      expect(find.text('Ctrl+S'), findsOneWidget, reason: 'Save');
+      expect(find.text('Ctrl+Shift+S'), findsOneWidget, reason: 'Save as');
+      expect(find.text('Ctrl+Alt+N'), findsOneWidget, reason: 'New');
+      await dismiss(tester);
+
+      // The row reads the live keymap rather than a chord of its own: the
+      // engine is the only place a binding is written down (K-199).
+      expect(p.uiState.keymap.chordFor('file.save'), 'Ctrl+S');
+      expect(p.uiState.keymap.rawChordFor('file.save'), 'Mod+S');
+    });
+
+    /// The Window menu's panel list: ticked when the panel is in the
+    /// arrangement, and clicking one adds or drops it. Persistence comes free
+    /// — what is stored is the arrangement, and this changes the arrangement.
+    testWidgets('the Window menu ticks the panels and toggles them',
+        (tester) async {
+      final p = await mount(tester);
+      expect(panelsIn(p.uiState.split), contains(Panel.scopes));
+
+      await choose(tester, 'Window', Panel.scopes.title);
+      await tester.pump();
+      expect(panelsIn(p.uiState.split), isNot(contains(Panel.scopes)),
+          reason: 'the tick came off and the panel went with it');
+      expect(p.uiState.workspace.toJson()['dock'].toString(),
+          isNot(contains(Panel.scopes.name)),
+          reason: 'the stored arrangement is what persists it');
+
+      await choose(tester, 'Window', Panel.scopes.title);
+      await tester.pump();
+      expect(panelsIn(p.uiState.split), contains(Panel.scopes),
+          reason: 'and back again');
+    });
+
+    testWidgets('Help ▸ About Lumit opens the About window', (tester) async {
+      await mount(tester);
+      await choose(tester, 'Help', 'About Lumit');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('about-close')), findsOneWidget);
+      // What Settings ▸ General used to say, said here instead (K-242).
+      expect(find.textContaining('lumit-bridge'), findsOneWidget);
+    });
+
+    /// The Effect menu is the browser as a menu: a submenu per category, each
+    /// effect applying to *every* selected layer, and the whole thing dead with
+    /// nothing selected.
+    testWidgets('the Effect menu applies to every selected layer',
+        (tester) async {
+      final p = await mount(tester);
+      await makeComp(tester);
+      final comp = p.uiState.selectedComp!;
+
+      // Nothing selected: the rows are there and do nothing.
+      await choose(tester, 'Effect', 'Gaussian blur', under: 'Blur & sharpen');
+      await tester.pump();
+      expect(comp.getLayers(), isEmpty);
+
+      final a = comp.addSolidLayer();
+      final b = comp.addSolidLayer();
+      p.uiState.setSelection([a, b]);
+      await tester.pump();
+
+      await choose(tester, 'Effect', 'Gaussian blur', under: 'Blur & sharpen');
+      await tester.pump();
+      expect(a.getEffects().single.name(), 'blur');
+      expect(b.getEffects().single.name(), 'blur',
+          reason: 'every selected layer, not just the primary (K-217)');
+    });
+
+    testWidgets('Open recent lists what the workspace remembers',
+        (tester) async {
+      final p = await mount(tester);
+      p.uiState.workspace.rememberProject('C:/projects/yesterday.lum');
+      p.state.notifyDocumentChanged();
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey<String>('menu-File')));
+      await tester.pump();
+      await tester.tap(find.text('Open recent'));
+      await tester.pump();
+      expect(find.text('C:/projects/yesterday.lum'), findsOneWidget);
     });
   }, skip: !engineAvailable);
 }

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -606,6 +606,50 @@ void main() {
           reason: 'and back again');
     });
 
+    /// **The bar is chrome: it spans the window, one colour, from the left.**
+    ///
+    /// Making it scroll sideways (so nine headings cannot overflow a narrow
+    /// window) made it shrink-wrap to the width of those headings, and the
+    /// shell's Column then centred that stub with the backdrop showing either
+    /// side. Both symptoms, one cause.
+    ///
+    /// **The window has to be wider than the headings for this to be visible
+    /// at all.** The nine of them come to a little over 800px, so on the
+    /// default 800×600 test surface a shrink-wrapped bar is clamped to the full
+    /// width and looks perfect — which is exactly how the fault shipped. It is
+    /// pumped here at a real window size, in the Column `_LumitAppViewState`
+    /// puts it in — that Column is the whole mechanism, because a Column gives
+    /// its children *loose* cross-axis constraints, which is what lets a
+    /// shrink-wrapping child stay narrow and be centred. (`hostPanel` alone
+    /// puts the bar in an Overlay, which forces full width and hides the
+    /// fault; the whole `LumitAppNew` reproduces it too, but drags in an
+    /// unrelated Debug-panel overflow at this size.)
+    testWidgets('the bar spans the window, from the left edge', (tester) async {
+      tester.view.physicalSize = const Size(1280, 720);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final p = freshProject();
+      await tester.pumpWidget(hostPanel(
+        child: Builder(builder: (context) {
+          final state = context.watch<LumitState>();
+          context.watch<LumitUiState>();
+          return Column(children: [LumitMenuBarFrb(app: state)]);
+        }),
+        state: p.state,
+        uiState: p.uiState,
+      ));
+      await tester.pump();
+
+      final bar = tester.getRect(find.byType(LumitMenuBarFrb));
+      expect(bar.left, 0, reason: 'flush to the left edge, not centred');
+      expect(bar.width, 1280,
+          reason: 'the full width of the window, so one colour spans it');
+      expect(tester.getTopLeft(find.byKey(const ValueKey<String>('menu-File'))).dx,
+          lessThan(20),
+          reason: 'File is the first heading, at the left');
+    });
+
     testWidgets('Help ▸ About Lumit opens the About window', (tester) async {
       await mount(tester);
       await choose(tester, 'Help', 'About Lumit');

--- a/flutter_ui/test/frb/shell_frb_test.dart
+++ b/flutter_ui/test/frb/shell_frb_test.dart
@@ -69,8 +69,12 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('open-settings')));
       await tester.pumpAndSettle();
 
-      // General opens first, and states facts about this build.
-      expect(find.textContaining('lumit-bridge'), findsOneWidget);
+      // General opens first. What this build *is* is no longer stated here —
+      // that is Help ▸ About Lumit now (K-242); Settings is for what you
+      // change, and a version number is not that.
+      expect(find.textContaining('lumit-bridge'), findsNothing);
+      expect(find.byKey(const ValueKey('settings-reset-workspace')),
+          findsOneWidget);
 
       // The engine's own readouts and buttons live on Performance (K-193).
       await tester.tap(find.byKey(const ValueKey('settings-page-performance')));

--- a/flutter_ui/test/keymap_test.dart
+++ b/flutter_ui/test/keymap_test.dart
@@ -132,4 +132,34 @@ void main() {
       expect(chordLabel(''), '');
     });
   });
+
+  group('chords as macOS menu activators', () {
+    test('the modifiers and the key come back out again', () {
+      final a = activatorForChord('Mod+Shift+Z')!;
+      expect(a.trigger, LogicalKeyboardKey.keyZ);
+      expect(a.meta, isTrue, reason: 'Mod is Cmd on the only platform asking');
+      expect(a.shift, isTrue);
+      expect(a.alt, isFalse);
+
+      final b = activatorForChord('Mod+Alt+;')!;
+      expect(b.trigger, LogicalKeyboardKey.semicolon);
+      expect(b.alt, isTrue);
+    });
+
+    test('the named keys and the awkward ones survive', () {
+      expect(activatorForChord('Space')!.trigger, LogicalKeyboardKey.space);
+      expect(activatorForChord('Shift+PageDown')!.trigger,
+          LogicalKeyboardKey.pageDown);
+      // A chord whose key *is* the separator must not split into nothing. It
+      // is the numpad key, as `*` is for markers — the main row's `+` is
+      // Shift+= and a different chord.
+      expect(activatorForChord('Mod++')!.trigger, LogicalKeyboardKey.numpadAdd);
+    });
+
+    test('a chord we cannot spell shows nothing rather than the wrong thing',
+        () {
+      expect(activatorForChord(''), isNull);
+      expect(activatorForChord('Mod+NotAKey'), isNull);
+    });
+  });
 }


### PR DESCRIPTION
The menu bar was three menus and a Window heading — what the Flutter port had time for. It is now the nine After Effects menus (**File, Edit, Composition, Layer, Effect, Animation, View, Window, Help**) carrying the commands each will hold, whether or not they are built yet.

## Why list what does not work

A command that is specified and unbuilt is still listed, marked **"(Not implemented)"** and drawn disabled. Two reasons, both about testing: the shape of the finished application is visible while it is being built, so a tester knows whether a command is missing or broken rather than guessing; and every unbuilt command has a row waiting for it, so building one is filling a row in rather than re-arguing where it goes.

A command whose preconditions are absent (no project, no comp, no selected layer) greys out rather than failing when pressed.

## One tree, two renderers

`lumitMenus` returns the bar as data — labels, keymap action ids, enablement, ticks. Windows and Linux draw it in the window; macOS hands the same tree to `PlatformMenuBar`, so the menus sit in the Mac menu bar like every other Mac app's, with About and Settings lifted into a leading **Lumit** menu alongside the system Services/Hide/Quit rows. Neither renderer holds a list of its own, which is the only arrangement in which the two cannot drift apart. iOS/Android are not targets (K-174 is a desktop decision), so there is no third case.

**Reviewer note:** the macOS path is written but unverified — it was built on Windows and nothing here can exercise `PlatformMenuBar`. Worth a look from anyone with a Mac.

## Shortcuts are the engine's

A row names an action id and shows whatever chord `lumit-keymap` currently binds to it (K-199), so a rebind in Settings ▸ Keymap changes the menus too and a menu can never teach a chord that does nothing. Nine new actions joined the shipped table for commands that already worked and had none:

| Command | Chord |
|---|---|
| File ▸ New | `Ctrl+Alt+N` |
| Composition ▸ New composition | `Ctrl+N` |
| Open project | `Ctrl+O` |
| Save as | `Ctrl+Shift+S` |
| Import | `Ctrl+I` |
| Export | `Ctrl+Alt+M` (`Ctrl+M` is already add-to-export-queue) |
| Select all / Deselect all | `Ctrl+A` / `Ctrl+Shift+A` |
| Settings | `Ctrl+Alt+;` |

`Ctrl+N` makes a composition and `Ctrl+Alt+N` a project, which is the pair anyone arriving from AE has in their fingers. Each is dispatched in the shell through the very function its menu row calls, so a shortcut and its menu item cannot become two implementations (the K-203 rule applied to the rest of the bar). The default keymap stays conflict-free — the existing test proves it.

## Also here

- **Window lists every panel with a tick.** Toggling one adds or drops its pane in the dock, which is also what persists it — the arrangement is already saved, so no new state was invented. The last panel standing cannot be hidden.
- **About left Settings ▸ General** for its own Help ▸ About Lumit window. Settings is for what you change; a version number is not that.
- **File ▸ Open recent**, backed by a ten-deep list in the workspace store.
- **Composition ▸ "Add to export queue"**, never "render queue" — *render* is a banned user-facing term (glossary §9).
- Settings sits under Edit on Windows/Linux (where every application those users know puts Preferences) and in the application menu on macOS.

## Two defects found on the way

- Nine menu names overflowed an 800px window by 2px. The bar scrolls sideways now rather than clipping Help away.
- The bar never rebuilt on a selection change, so Effect, Delete, Duplicate, Pre-compose and Retime could sit greyed out with a layer plainly selected. It listens to the selection now.

## Deviations from the requested list, deliberate

- **File** keeps `Recover…` at the end — the one command whose absence costs a day's work.
- **Composition** keeps the marker and beat-detection rows; they are comp-level and they work. Layer ▸ Markers stays a stub for per-layer markers.
- **Window** keeps `Command palette…` at the end.

## Docs and tests

`docs/07-UI-SPEC.md` §1.8 specifies the bar; K-242 records the decision; `docs/GUIDE.md` has the plain-English section; `docs/TODO.md` lists every "(Not implemented)" row as backlog with suggested chords.

Tests: 702 pass. New coverage for the marked-and-disabled rows, the chord a row teaches, the panel tick list (unit + integration), the About window, the Effect menu applying to *every* selected layer, Open recent, `setPanelVisible`, and chord→`SingleActivator` conversion. The six remaining failures are all in `viewer_panel_frb_test.dart` — pre-existing GPU/audio frame-delivery failures on this machine, verified by stashing this branch and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)