### PR TITLE
feat(timeline): comp tabs reorder, drops land where aimed, and a button zoom holds the middle

### DIFF
--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -1159,6 +1159,19 @@ class LumitUiState extends ChangeNotifier {
     }
   }
 
+  /// Drop a comp's tab where [target]'s tab sits. The strip is drawn in this
+  /// list's order, so moving the entry is the whole reorder — and it rides
+  /// along in the session, like the rest of the tab strip.
+  void moveComp(UuidValue id, UuidValue target) {
+    final from = openComps.indexOf(id);
+    final to = openComps.indexOf(target);
+    if (from < 0 || to < 0 || from == to) return;
+    openComps.removeAt(from);
+    openComps.insert(to, id);
+    rememberSession();
+    notifyListeners();
+  }
+
   /// Close a comp's Timeline tab. When the closed tab was fronted, [fallback]
   /// — the tab bar's nearest remaining neighbour — fronts instead.
   void closeComp(UuidValue id, {CompositionReference? fallback}) {

--- a/flutter_ui/lib/panels/timeline_extras_frb.dart
+++ b/flutter_ui/lib/panels/timeline_extras_frb.dart
@@ -18,6 +18,7 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../icons/icons.dart';
+import '../shell/comp_settings_frb.dart';
 import '../state/comp_time.dart';
 import '../state/timeline_columns.dart';
 import '../theme/theme.dart';
@@ -38,12 +39,21 @@ class CompTabsFrb extends StatelessWidget {
     // re-read when the engine says it changed shape. Filtered to the tabs the
     // user has opened, so a deleted comp's tab also simply stops matching.
     final selected = uiState.selectedComp?.internalid;
+    // In the tab strip's own order, not the project's: the strip is dragged
+    // into whatever order suits the work, and `openComps` is where that order
+    // lives (and what the session writes down).
+    final byId = {for (final entry in state.comps()) entry.$1.internalid: entry};
     final comps = [
-      for (final entry in state.comps())
-        if (uiState.openComps.contains(entry.$1.internalid) ||
-            entry.$1.internalid == selected)
-          entry,
+      for (final id in uiState.openComps)
+        if (byId[id] != null) byId[id]!,
     ];
+    // A fronted comp always joins `openComps`, so this only catches a comp
+    // fronted from somewhere that has not been through `setSelectedComp` yet.
+    if (selected != null &&
+        !uiState.openComps.contains(selected) &&
+        byId[selected] != null) {
+      comps.add(byId[selected]!);
+    }
     if (comps.isEmpty) return const SizedBox.shrink();
 
     return Container(
@@ -53,19 +63,41 @@ class CompTabsFrb extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         children: [
           for (var i = 0; i < comps.length; i++)
-            _CompTab(
-              key: ValueKey<String>('tl-tab-${comps[i].$1.internalid}'),
-              name: comps[i].$2,
-              active: selected == comps[i].$1.internalid,
-              onTap: () => uiState.setSelectedComp(comps[i].$1),
-              closeKey:
-                  ValueKey<String>('tl-tab-close-${comps[i].$1.internalid}'),
-              onClose: () => uiState.closeComp(
-                comps[i].$1.internalid,
-                // The nearest remaining neighbour fronts: the one to the
-                // left, or the next one when the first tab closes.
-                fallback:
-                    comps.length == 1 ? null : comps[i == 0 ? 1 : i - 1].$1,
+            DragTarget<UuidValue>(
+              onWillAcceptWithDetails: (d) => d.data != comps[i].$1.internalid,
+              onAcceptWithDetails: (d) =>
+                  uiState.moveComp(d.data, comps[i].$1.internalid),
+              builder: (context, candidate, _) => Draggable<UuidValue>(
+                data: comps[i].$1.internalid,
+                feedback: Container(
+                  height: 22,
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  color: t.surface2,
+                  child: Center(child: Text(comps[i].$2, style: t.small)),
+                ),
+                childWhenDragging: const SizedBox.shrink(),
+                child: _CompTab(
+                  key: ValueKey<String>('tl-tab-${comps[i].$1.internalid}'),
+                  name: comps[i].$2,
+                  active: selected == comps[i].$1.internalid,
+                  dropping: candidate.isNotEmpty,
+                  onTap: () => uiState.setSelectedComp(comps[i].$1),
+                  onMenu: (position) => showCompTabMenuFrb(
+                    context: context,
+                    comp: comps[i].$1,
+                    position: position,
+                    onChanged: uiState.model.refresh,
+                  ),
+                  closeKey:
+                      ValueKey<String>('tl-tab-close-${comps[i].$1.internalid}'),
+                  onClose: () => uiState.closeComp(
+                    comps[i].$1.internalid,
+                    // The nearest remaining neighbour fronts: the one to the
+                    // left, or the next one when the first tab closes.
+                    fallback:
+                        comps.length == 1 ? null : comps[i == 0 ? 1 : i - 1].$1,
+                  ),
+                ),
               ),
             ),
         ],
@@ -74,17 +106,49 @@ class CompTabsFrb extends StatelessWidget {
   }
 }
 
+/// A comp tab's context menu. Only one entry so far — the same Composition
+/// settings dialog the Project panel's menu opens, reached from the comp the
+/// user is actually working in rather than by hunting for its project row.
+Future<void> showCompTabMenuFrb({
+  required BuildContext context,
+  required CompositionReference comp,
+  required Offset position,
+  required VoidCallback onChanged,
+}) async {
+  final open = await showLumitPopup<bool>(
+    context: context,
+    position: position,
+    builder: (close) => FloatSurface(
+      width: 210,
+      child: MenuRow(
+        key: const ValueKey('tl-tab-menu-settings'),
+        onPressed: () => close(true),
+        child: const Text('Composition settings…'),
+      ),
+    ),
+  );
+  if (open != true || !context.mounted) return;
+  if (await showCompSettingsFrb(context: context, comp: comp)) onChanged();
+}
+
 class _CompTab extends StatelessWidget {
   final String name;
   final bool active;
+
+  /// A tab being dragged is hovering over this one, which is where it would
+  /// land — lit so the drop is visible before it is taken.
+  final bool dropping;
   final VoidCallback onTap;
+  final ValueChanged<Offset> onMenu;
   final Key closeKey;
   final VoidCallback onClose;
   const _CompTab({
     super.key,
     required this.name,
     required this.active,
+    required this.dropping,
     required this.onTap,
+    required this.onMenu,
     required this.closeKey,
     required this.onClose,
   });
@@ -95,10 +159,13 @@ class _CompTab extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
+      onSecondaryTapUp: (d) => onMenu(d.globalPosition),
       child: Container(
         padding: const EdgeInsets.only(left: 10, right: 4),
         decoration: BoxDecoration(
-          color: active ? t.surface0 : null,
+          color: dropping
+              ? t.accent.withValues(alpha: 0.18)
+              : (active ? t.surface0 : null),
           border: Border(
             bottom: BorderSide(
               color: active ? t.accent : const Color(0x00000000),

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -222,6 +222,22 @@ int layerDragTarget(List<double> heights, int from, double travel) {
   return to;
 }
 
+/// Which slot footage dropped from the Project panel takes, from how far down
+/// the stack it landed.
+///
+/// [y] is measured from the top of the first block, so the caller subtracts the
+/// pinned toolbar and header and adds the scroll. A drop in a block's top half
+/// goes above it and one in its bottom half below, the same midpoint rule a
+/// layer drag uses — and a drop past the last block lands at the bottom.
+int layerDropSlot(List<double> heights, double y) {
+  var top = 0.0;
+  for (var i = 0; i < heights.length; i++) {
+    if (y < top + heights[i] / 2) return i;
+    top += heights[i];
+  }
+  return heights.length;
+}
+
 /// One layer's block, slid out of a dragged layer's way.
 ///
 /// A transform, not a layout change: the rows keep their places, so a drag
@@ -935,6 +951,10 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
   /// Ctrl+wheel zooms about the pointer.
   double _zoom = 1;
 
+  /// The body the Project panel drops onto, so a drop can be measured against
+  /// it: where in the stack the pointer let go is where the footage lands.
+  final GlobalKey _dropArea = GlobalKey();
+
   /// Whether a dragged keyframe sticks to whole frames (docs/07 §4.5). On by
   /// default: landing between frames is the deliberate exception.
   bool _magnet = true;
@@ -1329,6 +1349,40 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
     }
   }
 
+  /// Zoom from somewhere other than the pointer — the bottom bar's − / + —
+  /// holding the middle of the visible lanes still. Zooming about the left
+  /// edge instead threw whatever was being looked at off the right of the
+  /// panel with every press. Same-turn jump, for the reason [_wheel] gives.
+  void _setZoom(double z) {
+    final next = z.clamp(1.0, 64.0);
+    if (next == _zoom) return;
+    final half =
+        _hLane.hasClients ? _hLane.position.viewportDimension / 2 : 0.0;
+    final centre = (_hLane.hasClients ? _hLane.offset : 0.0) + half;
+    final grew = next / _zoom;
+    setState(() => _zoom = next);
+    if (_hLane.hasClients) _hLane.jumpTo(max(0.0, centre * grew - half));
+  }
+
+  /// Which layer index a Project-panel drop landed on. The stack starts below
+  /// the pinned toolbar and column header and scrolls under them, so the drop
+  /// is measured in stack space; the slot is then read back as an index into
+  /// the whole comp, because the rows on screen may be a filtered subset.
+  int _dropIndex(LumitUiState ui, List<BridgeLayerEntry> layers,
+      List<double> heights, Offset global) {
+    final box = _dropArea.currentContext?.findRenderObject();
+    if (box is! RenderBox) return 0;
+    final y = box.globalToLocal(global).dy -
+        (_toolbarHeight + _headerHeight) +
+        (_vLane.hasClients ? _vLane.offset : 0);
+    final slot = layerDropSlot(heights, y);
+    if (slot >= layers.length) return ui.model.layers.length;
+    final id = layers[slot].layer.internallayerId;
+    final at = ui.model.layers
+        .indexWhere((e) => e.layer.internallayerId == id);
+    return at < 0 ? 0 : at;
+  }
+
   /// The gutter down the right of a scrollable half: a block level with that
   /// half's header (After Effects keeps the same reserved corner), then the
   /// scrollbar itself. Reserved whether or not a thumb shows, so the columns
@@ -1444,6 +1498,10 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
             onWillAcceptWithDetails: (details) =>
                 details.data is FootageDragData || details.data is CompDragData,
             onAcceptWithDetails: (details) {
+              // Where the pointer let go, not the top of the stack: dropping
+              // between two layers means "here", and a stack that ignores it
+              // has to be re-sorted by hand after every drop.
+              final at = _dropIndex(ui, layers, blockHeights, details.offset);
               switch (details.data) {
                 case FootageDragData(:final footage):
                   // Bottom-up, so a multi-item drop stacks in the order the
@@ -1452,16 +1510,31 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                     comp.addFootageLayer(
                         footage: f, asSequence: _videoAsSequence(context));
                   }
+                  ui.model.refresh();
+                  // They went on at the top; walk them down to the drop, the
+                  // bottom-most first so each one's slot is free when it moves.
+                  // ponytail: one undo step per layer — a drop-at-index on the
+                  // engine side would make it one, if that ever grates.
+                  final fresh = [
+                    for (var i = 0; i < footage.length; i++)
+                      ui.model.layers[i].layer,
+                  ];
+                  for (var i = fresh.length - 1; i >= 0; i--) {
+                    fresh[i].reorder(newIndex: BigInt.from(at + i));
+                  }
                 case CompDragData(comp: final dropped):
                   // A comp cannot nest into itself; the engine refuses and
                   // the drop simply does nothing.
                   try {
-                    comp.addPrecompLayer(comp: dropped);
+                    comp.addPrecompLayer(comp: dropped).reorder(
+                          newIndex: BigInt.from(at),
+                        );
                   } catch (_) {}
               }
               ui.model.refresh();
             },
             builder: (context, candidate, _) => Container(
+              key: _dropArea,
               // A live outline while something is over it, so the drop is
               // visibly going to land rather than being taken on faith.
               foregroundDecoration: candidate.isEmpty
@@ -1879,8 +1952,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                       magnet: _magnet,
                                       onToggleMagnet: () =>
                                           setState(() => _magnet = !_magnet),
-                                      onZoom: (z) => setState(
-                                          () => _zoom = z.clamp(1.0, 64.0)),
+                                      onZoom: _setZoom,
                                       lens: _graphLens,
                                       onLens: (lens) =>
                                           setState(() => _graphLens = lens),
@@ -2046,8 +2118,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                       magnet: _magnet,
                                       onToggleMagnet: () =>
                                           setState(() => _magnet = !_magnet),
-                                      onZoom: (z) => setState(
-                                          () => _zoom = z.clamp(1.0, 64.0)),
+                                      onZoom: _setZoom,
                                     ),
                                   ],
                                 ),

--- a/flutter_ui/test/frb/timeline_extras_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_extras_frb_test.dart
@@ -106,6 +106,59 @@ void main() {
       expect(find.textContaining('Open a composition'), findsOneWidget);
     });
 
+    /// The strip is the user's order, not the project's: a tab dragged onto
+    /// another takes its place, and the fronted comp comes along unchanged.
+    testWidgets('dragging a comp tab reorders the strip', (tester) async {
+      final p = withComp();
+      final second = p.state.project!.newComposition(name: 'Titles');
+      p.uiState.setSelectedComp(second);
+      await mount(tester, p);
+
+      final first = find.byKey(ValueKey<String>('tl-tab-${p.comp.internalid}'));
+      expect(tester.getCenter(first).dx,
+          lessThan(tester.getCenter(
+              find.byKey(ValueKey<String>('tl-tab-${second.internalid}'))).dx));
+
+      // Onto the tab to its left, which is where it lands.
+      await tester.drag(
+          find.byKey(ValueKey<String>('tl-tab-${second.internalid}')),
+          tester.getCenter(first) -
+              tester.getCenter(
+                  find.byKey(ValueKey<String>('tl-tab-${second.internalid}'))));
+      await tester.pumpAndSettle();
+
+      expect(p.uiState.openComps,
+          [second.internalid, p.comp.internalid]);
+      expect(p.uiState.selectedComp?.internalid, second.internalid,
+          reason: 'reordering the strip fronts nothing new');
+      expect(
+          tester.getCenter(
+                  find.byKey(ValueKey<String>('tl-tab-${second.internalid}')))
+              .dx,
+          lessThan(tester.getCenter(first).dx),
+          reason: 'and the strip is drawn in the new order');
+    });
+
+    /// Right-clicking a tab reaches the comp's settings, so the comp being
+    /// worked in can be edited without going back to the Project panel.
+    testWidgets('a comp tab offers Composition settings on right click',
+        (tester) async {
+      final p = withComp();
+      await mount(tester, p);
+
+      await tester.tap(
+          find.byKey(ValueKey<String>('tl-tab-${p.comp.internalid}')),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('tl-tab-menu-settings')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('tl-tab-menu-settings')));
+      await tester.pumpAndSettle();
+      expect(find.text('Composition settings'), findsOneWidget,
+          reason: 'the dialog the Project panel opens, from the tab');
+      expect(tester.takeException(), isNull);
+    });
+
     /// **The bridge error where the Timeline should be.** Pre-compose, step
     /// into the new comp, undo: the layers come back and the comp they were
     /// packed into stops existing — with the Timeline still fronting it, every

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1812,15 +1812,24 @@ void main() {
               find.byKey(ValueKey<String>('tl-bar-${layer.internallayerId}')))
           .width;
 
+      final centreBefore = tester
+          .getRect(
+              find.byKey(ValueKey<String>('tl-bar-${layer.internallayerId}')))
+          .center
+          .dx;
+
       await tester.tap(find.byKey(const ValueKey('tl-zoom-in')));
       await tester.pumpAndSettle();
       expect(find.text('150%'), findsOneWidget);
-      final zoomed = tester
-          .getRect(
-              find.byKey(ValueKey<String>('tl-bar-${layer.internallayerId}')))
-          .width;
-      expect(zoomed, greaterThan(before),
+      final bar = tester.getRect(
+          find.byKey(ValueKey<String>('tl-bar-${layer.internallayerId}')));
+      expect(bar.width, greaterThan(before),
           reason: 'the comp takes more pixels when zoomed in');
+      // A button zoom has no pointer to zoom about, so it holds the middle of
+      // the visible lanes still — zooming about the left edge instead pushed
+      // whatever was being looked at off the right of the panel.
+      expect(bar.center.dx, moreOrLessEquals(centreBefore, epsilon: 1),
+          reason: 'the middle of the view stayed where it was');
 
       await tester.tap(find.byKey(const ValueKey('tl-zoom-fit')));
       await tester.pumpAndSettle();
@@ -2372,6 +2381,57 @@ void main() {
       expect(p.comp.getLayers(), hasLength(1),
           reason: 'the drop reached the document');
       expect(p.comp.getLayers().single.getName(), contains('shot'));
+    });
+
+    /// **A drop used to ignore where it was aimed.** Footage always went on at
+    /// the top of the stack, so building an order meant dragging every clip in
+    /// and then re-sorting it by hand.
+    testWidgets('footage lands where it was dropped, not at the top',
+        (tester) async {
+      final p = withComp();
+      // Three solids to drop between, added bottom-up so the stack reads
+      // Top, Middle, Bottom down the screen. The drop aims at the middle one.
+      for (final name in ['Bottom', 'Middle', 'Top']) {
+        p.comp.addSolidLayer().rename(name: name);
+      }
+      final footage = p.state.project!.importFootage(path: 'C:/clips/shot.mov');
+
+      await tester.pumpWidget(hostPanel(
+        child: const Row(
+          children: [
+            SizedBox(width: 300, child: ProjectPanelFrb()),
+            Expanded(child: TimelinePanelFrb()),
+          ],
+        ),
+        state: p.state,
+        uiState: p.uiState,
+        size: const Size(1400, 700),
+      ));
+      await tester.pump();
+
+      final middle = p.comp.getLayers()[1];
+      final row =
+          find.byKey(ValueKey<String>('tl-row-${middle.internallayerId}'));
+      // The upper half of the row: a drop there goes above it, and the centre
+      // is the midpoint the rule flips on.
+      final target = tester.getTopLeft(row) +
+          Offset(tester.getSize(row).width / 2, 5);
+      final from = tester.getCenter(
+          find.byKey(ValueKey<String>('project-row-${footage.internalid}')));
+
+      final gesture = await tester.startGesture(from);
+      await tester.pump(const Duration(milliseconds: 200));
+      // Stepped, for the same arena reason as the drop test above.
+      for (var i = 1; i <= 10; i++) {
+        await gesture.moveTo(Offset.lerp(from, target, i / 10)!);
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect([for (final l in p.comp.getLayers()) l.getName()],
+          ['Top', 'shot.mov', 'Middle', 'Bottom'],
+          reason: 'it went in above the row it was dropped on');
     });
 
     /// Comps nest by the same gesture: drag one from the Project panel onto

--- a/flutter_ui/test/timeline_drag_test.dart
+++ b/flutter_ui/test/timeline_drag_test.dart
@@ -87,4 +87,22 @@ void main() {
       expect(layerDragTarget(heights, -1, 100), -1);
     });
   });
+
+  group('where a Project-panel drop lands', () {
+    test('the top half of a block goes above it, the bottom half below', () {
+      expect(layerDropSlot(heights, 0), 0);
+      expect(layerDropSlot(heights, 10), 0, reason: 'top half of block 0');
+      expect(layerDropSlot(heights, 12), 1, reason: 'bottom half of block 0');
+      expect(layerDropSlot(heights, 40), 1, reason: 'top half of block 1');
+      expect(layerDropSlot(heights, 60), 2, reason: 'bottom half of block 1');
+    });
+
+    test('a drop past the last block lands at the bottom of the stack', () {
+      expect(layerDropSlot(heights, 10000), heights.length);
+    });
+
+    test('an empty stack takes the drop at nought', () {
+      expect(layerDropSlot(const [], 500), 0);
+    });
+  });
 }


### PR DESCRIPTION
Three places the Timeline ignored where the user pointed.

## What changed

**The comp tab strip is the user's order.** It was drawn in the project's order, so it could not be arranged at all. It now follows `openComps`, and a tab dragged onto another takes its place — the order rides along in the session, like the rest of the strip. Right-clicking a tab opens **Composition settings…** for that comp: the same dialog the Project panel's context menu opens, reached from the comp actually being worked in.

**Footage dropped from the Project panel lands where it was dropped.** It always went on at the top of the stack, so building an order meant dragging every clip in and then re-sorting by hand. The drop point is measured against the stack by the same midpoint rule a layer drag uses (new pure `layerDropSlot`), and the new layers walk down to that slot. A drop past the last layer lands at the bottom. A dropped comp nests at the drop point too.

**A button zoom holds the middle of the visible lanes still.** `Ctrl`+wheel already zoomed about the pointer, but the bottom bar's − / + zoomed about the left edge, which pushed whatever was being looked at off the right of the panel with every press.

## Tests

- `layerDropSlot` unit tests, beside the existing drag maths (pure, no engine).
- A tab-reorder and a tab-context-menu widget test.
- A drop-position test driven through the real Project-panel drag: three named solids, drop aimed at the middle row, assert the resulting stack order.
- A centre-held assertion added to the existing zoom-button test — it fails under the old left-anchored behaviour.

`flutter analyze` clean; the affected test files pass (93 + 36).

## For the reviewer

- **The spec text lives in #32, not here.** docs/07 §4, §4.6 and §4.7 were updated for all three behaviours, but those paragraphs got swept into the docs truth-audit commit on `claude/docs-truth-audit` while this was being written. Duplicating them here would guarantee a conflict, so this branch carries the code alone. If #32 is dropped or rebased, the paragraphs need re-adding here.
- A multi-item footage drop is one `reorder` per layer, so one undo step per layer. Marked with a `ponytail:` comment; an engine-side add-at-index would collapse it to one if that ever grates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
