### PR TITLE
The release DMG carries its own FFmpeg — experimental macOS job (K-252)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@
 # (same FFmpeg 7.1 shared build, same LLVM 18 pin, same Flutter 3.44.7); when
 # one changes, change the other.
 #
-# No macOS job yet, deliberately: the built app would link Homebrew's ffmpeg@7
-# at its keg path and the Metal Viewer is unverified on real hardware — a DMG
-# would only pretend to work. It lands with the macOS pass (K-033,
-# docs/TODO.md); until then packaging/macos/make-dmg.sh builds one locally for
-# experiments.
+# The macOS job is EXPERIMENTAL (continue-on-error): make-dmg.sh bundles the
+# Homebrew FFmpeg dylibs into the .app and re-signs ad hoc, so the DMG runs
+# without Homebrew — but it is unsigned (Gatekeeper warns) and the Metal
+# Viewer is unverified on real hardware. Signing and notarisation land with
+# the macOS pass (K-033, docs/TODO.md); a release still publishes if this job
+# fails, just without the DMG.
 
 name: release
 
@@ -140,9 +141,38 @@ jobs:
           path: lumit-*-linux-x64.tar.gz
           if-no-files-found: error
 
+  macos-dmg:
+    name: macOS disk image (experimental)
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      # Mirrors ci.yml's `check` job: keg-only ffmpeg@7 found via the explicit
+      # pkg-config override (K-204).
+      - name: Install FFmpeg 7.1 and dylibbundler
+        run: |
+          brew install ffmpeg@7 dylibbundler
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.7
+          channel: stable
+          cache: true
+      - name: Build the disk image
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          packaging/macos/make-dmg.sh "${version:-0.0.0}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: packaging/macos/dist/*.dmg
+          if-no-files-found: error
+
   publish:
     name: GitHub release
-    needs: [windows-installer, linux-bundle]
+    needs: [windows-installer, linux-bundle, macos-dmg]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5472,6 +5472,8 @@ machine builds a run-anywhere bundle (FFmpeg's libraries ride inside it), and
 both land attached to a GitHub Release under that tag. Flutter cannot
 cross-build — a Windows machine can only make the Windows app — which is why
 the answer to "can I release everything from Windows" is "yes, by letting the
-tag do it". There is no macOS artifact yet, deliberately: the app it would
-build only runs on a machine with the same Homebrew FFmpeg installed, so it
-waits for the proper macOS pass in the TODO.
+tag do it". A macOS disk image builds too, marked experimental: the FFmpeg
+libraries are folded into the app itself (so it runs without Homebrew), but
+it carries no paid Apple signature yet, so macOS warns before first launch —
+the proper signing lands with the macOS pass in the TODO, and a release still
+publishes even if this job fails.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -431,9 +431,10 @@ list, not a re-statement of the roadmap.
     notarisation (K-033); it also owes `application:openFile:` (a double-clicked
     `.lum` opening, K-252) and adding `packaging/macos/*.icns` to the bundle's
     resources. The Metal/IOSurface Viewer path is unverified on real hardware.
-    The release workflow gains a macOS job when that pass lands (today it
-    builds Windows + Linux only — a DMG linking Homebrew keg paths would not
-    run elsewhere); signing the Windows installer; Linux distro packages
+    The release workflow's macOS job stays `continue-on-error` until the pass
+    verifies the Metal Viewer on real hardware and adds signing/notarisation
+    (the DMG bundles its FFmpeg dylibs but is ad-hoc signed, so Gatekeeper
+    warns); signing the Windows installer; Linux distro packages
     (deb/rpm/Flatpak) beyond `install.sh` and the release tarball.
 - **Phase 2 - Retime.** Flow interpolation policies; automatic beat snapping
     across edit/retime points ([04-RETIMING.md](04-RETIMING.md),

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -1,21 +1,65 @@
 #!/bin/sh
-# Builds the macOS disk image (K-252): a release build, then a compressed DMG
-# holding the .app and an Applications shortcut. macOS only (hdiutil).
+# Builds the macOS disk image (K-252): a release build, the Homebrew FFmpeg
+# dylibs bundled INTO the .app (so the image runs on machines without
+# Homebrew), an ad-hoc re-sign, then a compressed DMG with an Applications
+# shortcut. macOS only.
 #
-#   packaging/macos/make-dmg.sh
+#   packaging/macos/make-dmg.sh [version]
 #
-# Unsigned and un-notarised for now — that work is the macOS pass (K-033,
-# docs/TODO.md). Gatekeeper will warn accordingly.
+# Needs: flutter, rust, and `brew install ffmpeg@7 dylibbundler`.
+#
+# The bundling is the same move the Windows installer makes with the FFmpeg
+# DLLs: the bridge links the shared FFmpeg, so the libraries must travel with
+# the app. dylibbundler copies every Homebrew-linked dylib (transitive deps
+# included) into Contents/Frameworks and rewrites the install names; the
+# ad-hoc codesign afterwards is mandatory - macOS kills a process whose
+# binaries changed after signing.
+#
+# Ad-hoc means unsigned in Gatekeeper's eyes: a downloaded copy still warns
+# until the notarisation work in the macOS pass (K-033, docs/TODO.md).
 set -eu
 
 here="$(cd "$(dirname "$0")" && pwd)"
 root="$here/../.."
-version="$(sed -n 's/^version: *\([0-9.]*\).*/\1/p' "$root/flutter_ui/pubspec.yaml")"
+version="${1:-$(sed -n 's/^version: *\([0-9.]*\).*/\1/p' "$root/flutter_ui/pubspec.yaml")}"
+arch="$(uname -m)"
+
+command -v dylibbundler >/dev/null || {
+    echo "dylibbundler not found - brew install dylibbundler" >&2
+    exit 1
+}
+ffprefix="$(brew --prefix ffmpeg@7 2>/dev/null)" || {
+    echo "ffmpeg@7 not found - brew install ffmpeg@7" >&2
+    exit 1
+}
 
 (cd "$root/flutter_ui" && flutter build macos --release)
 
 app="$root/flutter_ui/build/macos/Build/Products/Release/lumit_flutter.app"
 [ -d "$app" ] || { echo "No app at $app" >&2; exit 1; }
+
+# Every Mach-O in the app that still links a Homebrew path gets handed to
+# dylibbundler. The bridge dylib is the expected hit; the loop rather than a
+# hardcoded path so a renamed framework cannot silently ship keg links.
+fixups=""
+for bin in $(find "$app/Contents" -type f ! -name "*.png" ! -name "*.json" ! -name "*.plist"); do
+    if otool -L "$bin" 2>/dev/null | tail -n +2 | grep -Eq '/opt/homebrew/|/usr/local/(opt|Cellar)/'; then
+        fixups="$fixups -x $bin"
+    fi
+done
+if [ -n "$fixups" ]; then
+    # shellcheck disable=SC2086 # word-splitting the -x list is the point
+    dylibbundler -od -b $fixups \
+        -d "$app/Contents/Frameworks/" \
+        -p "@executable_path/../Frameworks/" \
+        -s "$ffprefix/lib"
+else
+    echo "warning: nothing in the app links Homebrew - is the media feature on?" >&2
+fi
+
+# Re-sign everything ad hoc; the install-name rewrites invalidated the
+# existing signatures.
+codesign --force --deep --sign - "$app"
 
 stage="$(mktemp -d)"
 trap 'rm -rf "$stage"' EXIT
@@ -23,7 +67,7 @@ cp -R "$app" "$stage/Lumit.app"
 ln -s /Applications "$stage/Applications"
 
 mkdir -p "$here/dist"
-out="$here/dist/lumit-$version-macos.dmg"
+out="$here/dist/lumit-$version-macos-$arch.dmg"
 rm -f "$out"
 hdiutil create -volname "Lumit" -srcfolder "$stage" -ov -format UDZO "$out"
 echo "Wrote $out"


### PR DESCRIPTION
## What changed

- **`packaging/macos/make-dmg.sh`** — after `flutter build macos`, every Mach-O in the app still linking a Homebrew path goes through `dylibbundler`: FFmpeg dylibs (transitive deps included) are copied into `Contents/Frameworks`, install names rewritten, then the app is re-signed ad hoc (mandatory — macOS kills processes whose binaries changed after signing). The DMG now runs on machines without Homebrew, same move as the Windows installer's DLL bundling.
- **`.github/workflows/release.yml`** — new `macos-dmg` job mirroring ci.yml's `check` toolchain (ffmpeg@7 keg + K-204 pkg-config override), `continue-on-error` so a release still publishes without the DMG if it fails.
- Docs: GUIDE and TODO updated to match (ad-hoc signature ⇒ Gatekeeper warning; real signing/notarisation stays with the macOS pass, K-033).

## For the reviewer

- The DMG is **experimental**: unsigned in Gatekeeper's eyes, and the Metal Viewer is still unverified on real hardware. The owner is testing `make-dmg.sh` locally on a Mac.
- Releases remain tag-only (`v*`) — nothing fires on pushes to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)