### PR TITLE
macOS release builds one architecture, so the bridge can link FFmpeg

### DIFF
--- a/flutter_ui/macos/Podfile
+++ b/flutter_ui/macos/Podfile
@@ -38,5 +38,13 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
+    # Release builds default to a universal (arm64 + x86_64) binary, which
+    # makes cargokit cross-compile the bridge for the other architecture —
+    # where Homebrew's FFmpeg does not exist, so the build dies in
+    # rusty_ffmpeg's pkg-config probe. One architecture per machine until the
+    # macOS pass takes on universal binaries properly (K-033, docs/TODO.md).
+    target.build_configurations.each do |config|
+      config.build_settings['ONLY_ACTIVE_ARCH'] = 'YES'
+    end
   end
 end

--- a/flutter_ui/macos/Runner/Configs/Release.xcconfig
+++ b/flutter_ui/macos/Runner/Configs/Release.xcconfig
@@ -1,2 +1,6 @@
 #include "../../Flutter/Flutter-Release.xcconfig"
 #include "Warnings.xcconfig"
+
+// One architecture per machine (see the Podfile post_install note): a
+// universal Runner cannot embed the single-arch bridge framework anyway.
+ONLY_ACTIVE_ARCH = YES


### PR DESCRIPTION
A release build defaulted to a universal (arm64 + x86_64) binary, which made
cargokit cross-compile the bridge for the architecture the machine is not -
where Homebrew's FFmpeg does not exist, so rusty_ffmpeg's pkg-config probe
panicked and flutter build macos --release died. Debug builds only ever
compile the active arch, which is why CI's runner-build job never saw it.

ONLY_ACTIVE_ARCH=YES in the Podfile post_install (the Pods project is where
cargokit reads ARCHS) and in Runner's Release.xcconfig (a universal Runner
could not embed the single-arch framework anyway). Universal binaries are
macOS-pass work (K-033).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
