### PR TITLE
make-dmg.sh forces the machine's architecture past Flutter's universal default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
       # pkg-config override (K-204).
       - name: Install FFmpeg 7.1 and dylibbundler
         run: |
-          brew install ffmpeg@7 dylibbundler
+          brew install ffmpeg@7 dylibbundler create-dmg
           echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
       - uses: subosito/flutter-action@v2

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -33,6 +33,16 @@ ffprefix="$(brew --prefix ffmpeg@7 2>/dev/null)" || {
     exit 1
 }
 
+# Flutter forces a universal build on the xcodebuild command line
+# (ARCHS="arm64 x86_64", ONLY_ACTIVE_ARCH=NO), which out-ranks every project
+# and Podfile setting — cargokit then cross-compiles the bridge for the
+# architecture Homebrew has no FFmpeg for, and rusty_ffmpeg's pkg-config
+# probe dies. FLUTTER_XCODE_* variables are Flutter's own escape hatch:
+# they are appended as build settings AFTER Flutter's, and the last ARCHS
+# wins. One architecture per machine until K-033 takes on universal builds.
+FLUTTER_XCODE_ARCHS="$arch"
+export FLUTTER_XCODE_ARCHS
+
 (cd "$root/flutter_ui" && flutter build macos --release)
 
 app="$root/flutter_ui/build/macos/Build/Products/Release/lumit_flutter.app"

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -6,7 +6,9 @@
 #
 #   packaging/macos/make-dmg.sh [version]
 #
-# Needs: flutter, rust, and `brew install ffmpeg@7 dylibbundler`.
+# Needs: flutter, rust, and `brew install ffmpeg@7 dylibbundler create-dmg`
+# (create-dmg optional - without it the image has no drag-to-Applications
+# window dressing).
 #
 # The bundling is the same move the Windows installer makes with the FFmpeg
 # DLLs: the bridge links the shared FFmpeg, so the libraries must travel with
@@ -52,9 +54,11 @@ app="$root/flutter_ui/build/macos/Build/Products/Release/lumit_flutter.app"
 # dylibbundler. The bridge dylib is the expected hit; the loop rather than a
 # hardcoded path so a renamed framework cannot silently ship keg links.
 fixups=""
+fixlist=""
 for bin in $(find "$app/Contents" -type f ! -name "*.png" ! -name "*.json" ! -name "*.plist"); do
     if otool -L "$bin" 2>/dev/null | tail -n +2 | grep -Eq '/opt/homebrew/|/usr/local/(opt|Cellar)/'; then
         fixups="$fixups -x $bin"
+        fixlist="$fixlist $bin"
     fi
 done
 if [ -n "$fixups" ]; then
@@ -70,6 +74,18 @@ else
     echo "warning: nothing in the app links Homebrew - is the media feature on?" >&2
 fi
 
+# dyld (macOS 15+) refuses to launch a binary carrying duplicate LC_RPATH
+# entries, and dylibbundler adds its -p path as an rpath on each binary it
+# fixes — on top of Xcode's default '@executable_path/../Frameworks'. Drop
+# the slashed twin outright, then collapse any exact duplicates to one.
+for bin in "$app/Contents/MacOS/lumit_flutter" $fixlist; do
+    while install_name_tool -delete_rpath "@executable_path/../Frameworks/" "$bin" 2>/dev/null; do :; done
+    for rp in $(otool -l "$bin" | awk '$1=="path"{print $2}' | sort | uniq -d); do
+        while install_name_tool -delete_rpath "$rp" "$bin" 2>/dev/null; do :; done
+        install_name_tool -add_rpath "$rp" "$bin"
+    done
+done
+
 # Re-sign everything ad hoc; the install-name rewrites invalidated the
 # existing signatures.
 codesign --force --deep --sign - "$app"
@@ -77,10 +93,20 @@ codesign --force --deep --sign - "$app"
 stage="$(mktemp -d)"
 trap 'rm -rf "$stage"' EXIT
 cp -R "$app" "$stage/Lumit.app"
-ln -s /Applications "$stage/Applications"
 
 mkdir -p "$here/dist"
 out="$here/dist/lumit-$version-macos-$arch.dmg"
 rm -f "$out"
-hdiutil create -volname "Lumit" -srcfolder "$stage" -ov -format UDZO "$out"
+if command -v create-dmg >/dev/null; then
+    # The proper drag-into-Applications window (brew install create-dmg).
+    create-dmg --volname "Lumit" \
+        --window-size 540 380 --icon-size 128 \
+        --icon "Lumit.app" 140 185 --app-drop-link 400 185 \
+        --hide-extension "Lumit.app" \
+        "$out" "$stage"
+else
+    # Plain image: app + Applications shortcut, no window dressing.
+    ln -s /Applications "$stage/Applications"
+    hdiutil create -volname "Lumit" -srcfolder "$stage" -ov -format UDZO "$out"
+fi
 echo "Wrote $out"

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -75,33 +75,42 @@ else
     echo "warning: nothing in the app links Homebrew - is the media feature on?" >&2
 fi
 
-# libavdevice exists to talk to capture/playback devices, which the engine
-# never does (decode and encode go through avformat/avcodec) — yet it drags
-# in sdl2-compat, whose libSDL2 dlopens SDL3 at load time: a dependency no
-# bundler can see, so a shipped app dies with "failed loading SDL3 library".
-# The bridge imports zero avdevice symbols (guarded below), so its load
-# command is repointed at libavutil — already loaded, nothing missed — and
-# avdevice leaves the bundle with the SDL/X11 tail nothing else references.
-bridge="$app/Contents/Frameworks/lumit_bridge.framework/Versions/A/lumit_bridge"
-if [ -f "$bridge" ] && ! nm -u "$bridge" 2>/dev/null | grep -qi avdevice; then
-    avdev="$(otool -L "$bridge" | awk '/libavdevice/{print $1}')"
-    avutil="$(otool -L "$bridge" | awk '/libavutil/{print $1}')"
-    if [ -n "$avdev" ] && [ -n "$avutil" ]; then
-        install_name_tool -change "$avdev" "$avutil" "$bridge"
-        rm -f "$app/Contents/Frameworks/libavdevice."*
-        for cand in "$app/Contents/Frameworks"/libSDL2* \
-                    "$app/Contents/Frameworks"/libxcb* \
-                    "$app/Contents/Frameworks"/libX11* \
-                    "$app/Contents/Frameworks"/libXau* \
-                    "$app/Contents/Frameworks"/libXdmcp*; do
-            [ -e "$cand" ] || continue
-            base="$(basename "$cand")"
-            if ! find "$app/Contents" -type f ! -path "$cand" -exec otool -L {} + 2>/dev/null \
-                    | grep -q "/$base "; then
-                rm -f "$cand"
-            fi
-        done
+# Homebrew's libSDL2 is the sdl2-compat shim: its module initializer dlopens
+# SDL3, and when that fails the process aborts before main() ever runs — and
+# a dlopen is invisible to otool, so no bundler can ship its target. Nothing
+# in Lumit calls SDL; it rides in through libavdevice's output devices, and
+# libavdevice cannot leave (the bridge imports its version symbols). So the
+# bundled libSDL2 is replaced with a generated stub: a dylib exporting no-op
+# versions of exactly the symbols the other bundled binaries import from it.
+# No initializer, no SDL3, no abort.
+sdl="$(find "$app/Contents/Frameworks" -maxdepth 1 -name 'libSDL2*.dylib' | head -1)"
+if [ -n "$sdl" ]; then
+    sdlbase="$(basename "$sdl")"
+    stub="$(mktemp -d)"
+    # nm -m names the source library of every undefined symbol under the
+    # two-level namespace, so this is the exact import list to satisfy.
+    find "$app/Contents/Frameworks" -maxdepth 1 -type f ! -name "$sdlbase" \
+        -exec nm -m {} + 2>/dev/null \
+        | awk '/from libSDL2/{print $(NF-2)}' | sort -u > "$stub/syms"
+    if [ -s "$stub/syms" ]; then
+        while read -r s; do
+            printf 'void %s(void) {}\n' "${s#_}"
+        done < "$stub/syms" > "$stub/stub.c"
+        # dyld checks the compatibility version the importers were linked
+        # against; carry the real library's numbers over to the stub.
+        line="$(otool -L "$app/Contents/Frameworks/"libavdevice.*.dylib 2>/dev/null | grep "$sdlbase" | head -1)"
+        compat="$(printf '%s' "$line" | sed -n 's/.*compatibility version \([0-9.]*\).*/\1/p')"
+        curr="$(printf '%s' "$line" | sed -n 's/.*current version \([0-9.]*\).*/\1/p')"
+        cc -dynamiclib -o "$sdl" "$stub/stub.c" \
+            -install_name "@executable_path/../Frameworks/$sdlbase" \
+            -compatibility_version "${compat:-1.0}" \
+            -current_version "${curr:-1.0}"
+        echo "Stubbed $sdlbase ($(wc -l < "$stub/syms" | tr -d ' ') symbols)"
+    else
+        # nothing imports from it: it has no reason to ship at all
+        rm -f "$sdl"
     fi
+    rm -rf "$stub"
 fi
 
 # dyld (macOS 15+) refuses to launch a binary carrying duplicate LC_RPATH

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -62,11 +62,12 @@ for bin in $(find "$app/Contents" -type f ! -name "*.png" ! -name "*.json" ! -na
     fi
 done
 if [ -n "$fixups" ]; then
-    # -cd creates the destination if missing; NEVER -od here — that flag
-    # OVERWRITES the directory, i.e. deletes Contents/Frameworks and every
-    # framework already embedded in it.
+    # -cd creates the destination if missing; -of overwrites dylibs a
+    # previous run already copied, so reruns are idempotent. NEVER -od here —
+    # that flag OVERWRITES the directory, i.e. deletes Contents/Frameworks
+    # and every framework already embedded in it.
     # shellcheck disable=SC2086 # word-splitting the -x list is the point
-    dylibbundler -cd -b $fixups \
+    dylibbundler -cd -of -b $fixups \
         -d "$app/Contents/Frameworks/" \
         -p "@executable_path/../Frameworks/" \
         -s "$ffprefix/lib"

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -75,13 +75,44 @@ else
     echo "warning: nothing in the app links Homebrew - is the media feature on?" >&2
 fi
 
+# libavdevice exists to talk to capture/playback devices, which the engine
+# never does (decode and encode go through avformat/avcodec) — yet it drags
+# in sdl2-compat, whose libSDL2 dlopens SDL3 at load time: a dependency no
+# bundler can see, so a shipped app dies with "failed loading SDL3 library".
+# The bridge imports zero avdevice symbols (guarded below), so its load
+# command is repointed at libavutil — already loaded, nothing missed — and
+# avdevice leaves the bundle with the SDL/X11 tail nothing else references.
+bridge="$app/Contents/Frameworks/lumit_bridge.framework/Versions/A/lumit_bridge"
+if [ -f "$bridge" ] && ! nm -u "$bridge" 2>/dev/null | grep -qi avdevice; then
+    avdev="$(otool -L "$bridge" | awk '/libavdevice/{print $1}')"
+    avutil="$(otool -L "$bridge" | awk '/libavutil/{print $1}')"
+    if [ -n "$avdev" ] && [ -n "$avutil" ]; then
+        install_name_tool -change "$avdev" "$avutil" "$bridge"
+        rm -f "$app/Contents/Frameworks/libavdevice."*
+        for cand in "$app/Contents/Frameworks"/libSDL2* \
+                    "$app/Contents/Frameworks"/libxcb* \
+                    "$app/Contents/Frameworks"/libX11* \
+                    "$app/Contents/Frameworks"/libXau* \
+                    "$app/Contents/Frameworks"/libXdmcp*; do
+            [ -e "$cand" ] || continue
+            base="$(basename "$cand")"
+            if ! find "$app/Contents" -type f ! -path "$cand" -exec otool -L {} + 2>/dev/null \
+                    | grep -q "/$base "; then
+                rm -f "$cand"
+            fi
+        done
+    fi
+fi
+
 # dyld (macOS 15+) refuses to launch a binary carrying duplicate LC_RPATH
 # entries, and dylibbundler adds its -p path as an rpath on each binary it
-# fixes — on top of Xcode's default '@executable_path/../Frameworks'. Drop
-# the slashed twin outright, then collapse any exact duplicates to one.
-for bin in "$app/Contents/MacOS/lumit_flutter" $fixlist; do
+# fixes — on top of Xcode's default '@executable_path/../Frameworks'. Every
+# binary in the app gets the sweep (a rerun of this script must clean marks
+# the previous run left, so the set cannot be limited to freshly-fixed
+# files): drop the slashed twin outright, collapse exact duplicates to one.
+for bin in "$app/Contents/MacOS/lumit_flutter" $(find "$app/Contents/Frameworks" -type f); do
     while install_name_tool -delete_rpath "@executable_path/../Frameworks/" "$bin" 2>/dev/null; do :; done
-    for rp in $(otool -l "$bin" | awk '$1=="path"{print $2}' | sort | uniq -d); do
+    for rp in $(otool -l "$bin" 2>/dev/null | awk '$1=="path"{print $2}' | sort | uniq -d); do
         while install_name_tool -delete_rpath "$rp" "$bin" 2>/dev/null; do :; done
         install_name_tool -add_rpath "$rp" "$bin"
     done

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -58,8 +58,11 @@ for bin in $(find "$app/Contents" -type f ! -name "*.png" ! -name "*.json" ! -na
     fi
 done
 if [ -n "$fixups" ]; then
+    # -cd creates the destination if missing; NEVER -od here — that flag
+    # OVERWRITES the directory, i.e. deletes Contents/Frameworks and every
+    # framework already embedded in it.
     # shellcheck disable=SC2086 # word-splitting the -x list is the point
-    dylibbundler -od -b $fixups \
+    dylibbundler -cd -b $fixups \
         -d "$app/Contents/Frameworks/" \
         -p "@executable_path/../Frameworks/" \
         -s "$ffprefix/lib"


### PR DESCRIPTION
The Podfile ONLY_ACTIVE_ARCH fix (PR #36) never had a chance: flutter passes
ARCHS="arm64 x86_64" and ONLY_ACTIVE_ARCH=NO on the xcodebuild command line
for release builds, which out-ranks every project and Podfile setting, and
cargokit's build_pod.sh forwards that raw ARCHS to the bridge build - so it
still cross-compiled for the architecture Homebrew has no FFmpeg for.

FLUTTER_XCODE_ARCHS is Flutter's own escape hatch: FLUTTER_XCODE_* variables
are appended as build settings after Flutter's own, and the last ARCHS wins.
make-dmg.sh now exports it as uname -m (arm64 on Apple silicon, x86_64 on
Intel), which is also what the CI macos-dmg job runs through.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
