### PR TITLE
The playhead returns on stop, and markers are flags you can drag (K-254)

### DIFF
--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -32,6 +32,37 @@ pub struct BridgeMarker {
     pub label: String,
 }
 
+/// A core marker as the bridge carries it. One conversion each way, shared by
+/// the composition's list and by every layer's own (K-254) — two copies of this
+/// mapping is two chances for a marker to mean something different depending on
+/// which row it is drawn on.
+#[frb(ignore)]
+pub(crate) fn bridge_marker(m: &lumit_core::markers::Marker) -> BridgeMarker {
+    BridgeMarker {
+        id: m.id,
+        time: BridgeRational {
+            num: m.time.0.num(),
+            den: m.time.0.den(),
+        },
+        label: m.label.clone(),
+    }
+}
+
+#[frb(ignore)]
+pub(crate) fn core_marker(m: BridgeMarker) -> Result<lumit_core::markers::Marker, BridgeError> {
+    use lumit_core::time::{CompTime, Rational};
+    Ok(lumit_core::markers::Marker {
+        id: m.id,
+        time: CompTime(
+            Rational::new(m.time.num, m.time.den).map_err(|_| BridgeError::InvalidTime)?,
+        ),
+        duration: None,
+        label: m.label,
+        kind: lumit_core::markers::MarkerKind::default(),
+        extra: serde_json::Map::new(),
+    })
+}
+
 /// Every blend mode, in the order the Timeline's dropdown shows them. The index
 /// into this list is what `LayerReference::get_blend`/`set_blend` speak, so the
 /// two cannot disagree about what "3" means.
@@ -412,7 +443,7 @@ impl CompositionReference {
         let inner = comp.composition()?;
         let outer = self.composition()?;
 
-        let layer = crate::edits::base_layer(
+        let mut layer = crate::edits::base_layer(
             inner.name.clone(),
             lumit_core::model::LayerKind::Precomp { comp: inner.id },
             outer.duration.0,
@@ -423,6 +454,19 @@ impl CompositionReference {
                 outer.height,
             ),
         );
+        // The comp's own markers come with it as the layer's (K-254): a
+        // composition dropped into another is a piece of material, and its
+        // beats are part of what you are placing. Copied, not referenced —
+        // from here they are this layer's, and editing them never reaches back
+        // into the composition they came from. New ids for the same reason.
+        layer.markers = inner
+            .markers
+            .iter()
+            .map(|m| lumit_core::markers::Marker {
+                id: Uuid::now_v7(),
+                ..m.clone()
+            })
+            .collect();
         self.add_at_top(layer)
     }
 
@@ -588,7 +632,26 @@ impl CompositionReference {
             background: comp.background,
             work_area: None,
             layers: inner_layers,
-            markers: Vec::new(),
+            // The comp's markers go in with the layers (K-254). They are part
+            // of how the work is laid out, and a packed section that loses its
+            // cues has lost the map to itself. Shifted with everything else
+            // when `adjust_duration` moves time back to zero, and any that fall
+            // outside the new comp's span are left behind rather than parked
+            // where nothing can reach them.
+            markers: comp
+                .markers
+                .iter()
+                .filter_map(|m| {
+                    let time = shift_back(m.time).ok()?;
+                    (!time.0.is_negative() && time.0 <= duration.0).then(|| {
+                        lumit_core::markers::Marker {
+                            id: Uuid::now_v7(),
+                            time,
+                            ..m.clone()
+                        }
+                    })
+                })
+                .collect(),
             motion_blur: MotionBlur::default(),
             extra: serde_json::Map::new(),
         };
@@ -903,14 +966,7 @@ impl CompositionReference {
             .composition()?
             .markers
             .iter()
-            .map(|m| BridgeMarker {
-                id: m.id,
-                time: BridgeRational {
-                    num: m.time.0.num(),
-                    den: m.time.0.den(),
-                },
-                label: m.label.clone(),
-            })
+            .map(bridge_marker)
             .collect())
     }
 
@@ -918,24 +974,9 @@ impl CompositionReference {
     /// also how beat detection commits a regenerated set.
     #[frb(sync)]
     pub fn set_markers(&self, markers: Vec<BridgeMarker>) -> Result<(), BridgeError> {
-        use lumit_core::markers::Marker;
-        use lumit_core::time::{CompTime, Rational};
-
         let markers = markers
             .into_iter()
-            .map(|m| {
-                Ok(Marker {
-                    id: m.id,
-                    time: CompTime(
-                        Rational::new(m.time.num, m.time.den)
-                            .map_err(|_| BridgeError::InvalidTime)?,
-                    ),
-                    duration: None,
-                    label: m.label,
-                    kind: lumit_core::markers::MarkerKind::default(),
-                    extra: serde_json::Map::new(),
-                })
-            })
+            .map(core_marker)
             .collect::<Result<Vec<_>, BridgeError>>()?;
 
         self.commit(lumit_core::Op::SetCompMarkers {

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -7,6 +7,7 @@ use lumit_core::time::{CompTime, Duration, Rational, SourceTime};
 use uuid::Uuid;
 
 use crate::api::{
+    composition::{bridge_marker, core_marker, BridgeMarker},
     effect::{BridgeEffectInstance, BridgeRational, BridgeScalar},
     project_item::ItemReference,
     state::{LumitBridgeState, PROJECTS},
@@ -454,6 +455,21 @@ pub struct BridgeLayerInfo {
     /// Carried for the same reason again — and for one more: the art *is* the
     /// layer's size, so the Viewer's wireframe reads it here.
     pub shape_contents: Vec<BridgeShapeItem>,
+    /// The layer's own markers (K-254), and the comp frame each falls on — the
+    /// marker's layer-local time carried out by the layer's start offset — so
+    /// the bar needs no time↔frame trip to draw one. In the read model because the
+    /// Timeline draws them on every rebuild, which is the cost K-184 exists to
+    /// remove.
+    pub markers: Vec<BridgeLayerMarker>,
+}
+
+/// One marker on a layer's bar: the marker itself plus where it lands at the
+/// comp's rate, worked out here so drawing costs nothing across the seam.
+#[frb(non_opaque)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgeLayerMarker {
+    pub marker: BridgeMarker,
+    pub frame: i64,
 }
 
 /// Build one layer's [`BridgeLayerInfo`] from an already-fetched composition —
@@ -572,6 +588,24 @@ pub(crate) fn read_layer_info(
             .map(|r| BridgeScalar::read_at(r, layer.start_offset.0)),
         masks: layer.masks.iter().map(BridgeMask::read).collect(),
         paint: layer.paint.iter().map(BridgeStroke::read).collect(),
+        markers: layer
+            .markers
+            .iter()
+            .map(|m| BridgeLayerMarker {
+                marker: bridge_marker(m),
+                // A layer marker's time is the layer's own, so where it lands
+                // on the comp is that time carried out by the layer's start
+                // offset — exactly as a Sequence clip's is. That is what makes
+                // markers travel when the layer is dragged along the timeline.
+                frame: comp.frame_rate.frame_at(CompTime(
+                    layer
+                        .start_offset
+                        .0
+                        .checked_add(m.time.0)
+                        .unwrap_or(m.time.0),
+                )),
+            })
+            .collect(),
         shape_contents: match &layer.kind {
             lumit_core::model::LayerKind::Shape { contents } => {
                 contents.iter().map(BridgeShapeItem::read).collect()
@@ -1940,6 +1974,33 @@ impl LayerReference {
     pub fn set_label(&self, label: u8) -> Result<(), BridgeError> {
         let (comp, layer) = (self.comp_id, self.layer_id);
         self.commit(lumit_core::Op::SetLayerLabel { comp, layer, label })
+    }
+
+    /// This layer's own markers (docs/03 §11), drawn on its bar rather than on
+    /// the comp's ruler.
+    ///
+    /// The layer's, not the source composition's: a comp dropped into another
+    /// brings a **copy** along, and from then on the two lists are unrelated
+    /// (K-254). Deleting one here never reaches into another composition.
+    #[frb(sync)]
+    pub fn get_markers(&self) -> Result<Vec<BridgeMarker>, BridgeError> {
+        Ok(self.item()?.markers.iter().map(bridge_marker).collect())
+    }
+
+    /// Replace this layer's whole marker list — one op, trivially invertible,
+    /// the same shape as the composition's.
+    #[frb(sync)]
+    pub fn set_markers(&self, markers: Vec<BridgeMarker>) -> Result<(), BridgeError> {
+        let markers = markers
+            .into_iter()
+            .map(core_marker)
+            .collect::<Result<Vec<_>, BridgeError>>()?;
+        let (comp, layer) = (self.comp_id, self.layer_id);
+        self.commit(lumit_core::Op::SetLayerMarkers {
+            comp,
+            layer,
+            markers,
+        })
     }
 
     /// Where this layer sits on the comp timeline.

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -457,9 +457,9 @@ pub struct BridgeLayerInfo {
     pub shape_contents: Vec<BridgeShapeItem>,
     /// The layer's own markers (K-254), and the comp frame each falls on — the
     /// marker's layer-local time carried out by the layer's start offset — so
-    /// the bar needs no time↔frame trip to draw one. In the read model because the
-    /// Timeline draws them on every rebuild, which is the cost K-184 exists to
-    /// remove.
+    /// the bar needs no time↔frame trip to draw one. In the read model because
+    /// the Timeline draws them on every rebuild, which is the cost K-184 exists
+    /// to remove.
     pub markers: Vec<BridgeLayerMarker>,
 }
 

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -285,6 +285,7 @@ pub(crate) fn op_scope(op: &lumit_core::Op) -> (Option<Uuid>, Option<Uuid>, bool
 
         // One layer's own contents.
         Op::SetLayerSpan { comp, layer, .. }
+        | Op::SetLayerMarkers { comp, layer, .. }
         | Op::RenameLayer { comp, layer, .. }
         | Op::SetLayerMasks { comp, layer, .. }
         | Op::SetLayerPaint { comp, layer, .. }

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -3740,6 +3740,84 @@ fn clearing_beats_keeps_the_markers_a_person_made() {
     assert_eq!(comp.get_markers().expect("markers").len(), 1);
 }
 
+/// A composition dropped into another brings its markers with it as the
+/// layer's own — **copies**, so editing them never reaches back into the
+/// composition they came from, or into anywhere else it is used (K-254).
+#[test]
+fn dropping_a_comp_in_copies_its_markers_onto_the_layer() {
+    use crate::api::composition::BridgeMarker;
+    use crate::api::effect::BridgeRational;
+
+    let (project, layer) = project_with_layer();
+    let outer = CompositionReference::new(project.id, layer.comp_id());
+    let source = project
+        .new_composition("Beats".into(), None)
+        .expect("a comp to drop in");
+    let seeded = Uuid::now_v7();
+    source
+        .set_markers(vec![BridgeMarker {
+            id: seeded,
+            time: BridgeRational { num: 1, den: 2 },
+            label: "Drop".into(),
+        }])
+        .expect("marked");
+
+    let placed = outer.add_precomp_layer(&source).expect("placed");
+    let on_layer = placed.get_markers().expect("layer markers");
+    assert_eq!(on_layer.len(), 1, "the marker came along");
+    assert_eq!(on_layer[0].label, "Drop");
+    assert_ne!(on_layer[0].id, seeded, "a copy, with an id of its own");
+
+    // Independent from here: clearing the layer's leaves the comp's alone.
+    placed.set_markers(vec![]).expect("cleared");
+    assert!(placed.get_markers().expect("layer markers").is_empty());
+    assert_eq!(
+        source.get_markers().expect("comp markers").len(),
+        1,
+        "the composition it came from is untouched"
+    );
+}
+
+/// Pre-composing carries the comp's markers into the new comp and leaves the
+/// Precomp layer bare: the same cues are on the ruler above it, and drawing
+/// them again on the layer would say it twice (K-254).
+#[test]
+fn precompose_carries_markers_in_and_leaves_the_layer_bare() {
+    use crate::api::composition::BridgeMarker;
+    use crate::api::effect::BridgeRational;
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    comp.set_markers(vec![BridgeMarker {
+        id: Uuid::now_v7(),
+        time: BridgeRational { num: 1, den: 2 },
+        label: "Chorus".into(),
+    }])
+    .expect("marked");
+
+    let precomp = comp
+        .precompose(vec![layer.layer_id], "Packed".into(), false, false)
+        .expect("packed");
+    assert!(
+        precomp.get_markers().expect("layer markers").is_empty(),
+        "the Precomp layer draws none of its own"
+    );
+    assert_eq!(
+        comp.get_markers().expect("outer markers").len(),
+        1,
+        "the outer comp keeps its own"
+    );
+
+    let inner = match precomp.get_source_item().expect("source") {
+        Some(crate::api::project_item::ItemReference::Composition(c)) => c,
+        _ => panic!("a Precomp layer's source is a composition"),
+    };
+    let packed = inner.get_markers().expect("packed markers");
+    assert_eq!(packed.len(), 1, "and the packed comp got a copy");
+    assert_eq!(packed[0].label, "Chorus");
+    assert_eq!(packed[0].time.num * 2, packed[0].time.den, "still at 0.5 s");
+}
+
 /// A row's stopwatch keys every axis it covers, and that has to be ONE undo
 /// step — two ops for one click is exactly what the whole-value shape exists to
 /// avoid everywhere else.

--- a/crates/lumit-bridge/src/edits.rs
+++ b/crates/lumit-bridge/src/edits.rs
@@ -65,6 +65,7 @@ pub(crate) fn base_layer(
         LayerKind::Shape { .. } => 9,
     };
     Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name,
         kind,

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 848570327;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1235708917;
 
 // Section: executor
 
@@ -4025,6 +4025,36 @@ fn wire__crate__api__layer__layer_reference_get_label_impl(
         },
     )
 }
+fn wire__crate__api__layer__layer_reference_get_markers_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "layer_reference_get_markers",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::layer::LayerReference>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::layer::LayerReference::get_markers(&api_that)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__layer__layer_reference_get_masks_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -5087,6 +5117,39 @@ fn wire__crate__api__layer__layer_reference_set_label_impl(
             deserializer.end();
             transform_result_sse::<_, BridgeError>((move || {
                 let output_ok = crate::api::layer::LayerReference::set_label(&api_that, api_label)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__layer__layer_reference_set_markers_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "layer_reference_set_markers",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::layer::LayerReference>::sse_decode(&mut deserializer);
+            let api_markers =
+                <Vec<crate::api::composition::BridgeMarker>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok =
+                    crate::api::layer::LayerReference::set_markers(&api_that, api_markers)?;
                 Ok(output_ok)
             })())
         },
@@ -7485,6 +7548,7 @@ impl SseDecode for crate::api::layer::BridgeLayerInfo {
         let mut var_paint = <Vec<crate::api::layer::BridgeStroke>>::sse_decode(deserializer);
         let mut var_shapeContents =
             <Vec<crate::api::layer::BridgeShapeItem>>::sse_decode(deserializer);
+        let mut var_markers = <Vec<crate::api::layer::BridgeLayerMarker>>::sse_decode(deserializer);
         return crate::api::layer::BridgeLayerInfo {
             name: var_name,
             kind: var_kind,
@@ -7505,6 +7569,7 @@ impl SseDecode for crate::api::layer::BridgeLayerInfo {
             masks: var_masks,
             paint: var_paint,
             shape_contents: var_shapeContents,
+            markers: var_markers,
         };
     }
 }
@@ -7524,6 +7589,18 @@ impl SseDecode for crate::api::layer::BridgeLayerKind {
             7 => crate::api::layer::BridgeLayerKind::Adjustment,
             8 => crate::api::layer::BridgeLayerKind::NullLayer,
             _ => unreachable!("Invalid variant for BridgeLayerKind: {}", inner),
+        };
+    }
+}
+
+impl SseDecode for crate::api::layer::BridgeLayerMarker {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_marker = <crate::api::composition::BridgeMarker>::sse_decode(deserializer);
+        let mut var_frame = <i64>::sse_decode(deserializer);
+        return crate::api::layer::BridgeLayerMarker {
+            marker: var_marker,
+            frame: var_frame,
         };
     }
 }
@@ -8477,6 +8554,20 @@ impl SseDecode for Vec<crate::api::composition::BridgeLayerEntry> {
     }
 }
 
+impl SseDecode for Vec<crate::api::layer::BridgeLayerMarker> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::layer::BridgeLayerMarker>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::composition::BridgeMarker> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -9096,13 +9187,13 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        131 => wire__crate__api__layer__layer_reference_has_audio_impl(
+        132 => wire__crate__api__layer__layer_reference_has_audio_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        185 => wire__crate__api__project__project_reference_save_impl(
+        187 => wire__crate__api__project__project_reference_save_impl(
             port,
             ptr,
             rust_vec_len,
@@ -9226,91 +9317,93 @@ fn pde_ffi_dispatcher_sync_impl(
 115 => wire__crate__api__layer__layer_reference_get_interpolation_impl(ptr, rust_vec_len, data_len),
 116 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
 117 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
-118 => wire__crate__api__layer__layer_reference_get_masks_impl(ptr, rust_vec_len, data_len),
-119 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
-120 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
-121 => wire__crate__api__layer__layer_reference_get_paint_impl(ptr, rust_vec_len, data_len),
-122 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
-123 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
-124 => wire__crate__api__layer__layer_reference_get_shape_contents_impl(ptr, rust_vec_len, data_len),
-125 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
-126 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
-127 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
-128 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
-129 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
-130 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
-132 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
-133 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
-134 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
-135 => wire__crate__api__layer__layer_reference_paste_sequence_shape_impl(ptr, rust_vec_len, data_len),
-136 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
-137 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
-138 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
-139 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
-140 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
-141 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
-142 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
-143 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
-144 => wire__crate__api__layer__layer_reference_set_clip_retime_impl(ptr, rust_vec_len, data_len),
-145 => wire__crate__api__layer__layer_reference_set_clip_speed_impl(ptr, rust_vec_len, data_len),
-146 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
-147 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
-148 => wire__crate__api__layer__layer_reference_set_interpolation_impl(ptr, rust_vec_len, data_len),
-149 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
-150 => wire__crate__api__layer__layer_reference_set_mask_impl(ptr, rust_vec_len, data_len),
-151 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
-152 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
-153 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
-154 => wire__crate__api__layer__layer_reference_set_shape_contents_impl(ptr, rust_vec_len, data_len),
-155 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
-156 => wire__crate__api__layer__layer_reference_set_stroke_impl(ptr, rust_vec_len, data_len),
-157 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
-158 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
-159 => wire__crate__api__layer__layer_reference_set_text_placed_impl(ptr, rust_vec_len, data_len),
-160 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
-161 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
-162 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
-163 => wire__crate__api__layer__layer_reference_slide_clip_impl(ptr, rust_vec_len, data_len),
-164 => wire__crate__api__layer__layer_reference_split_at_impl(ptr, rust_vec_len, data_len),
-165 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
-166 => wire__crate__api__layer__layer_reference_trim_clip_impl(ptr, rust_vec_len, data_len),
-167 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
-168 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
-169 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
-170 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
-171 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
-172 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
-173 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
-174 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
-175 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
-176 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
-177 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
-178 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
-179 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
-180 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
-181 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
-182 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
-183 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
-184 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
-186 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
-187 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
-188 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
-189 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
-190 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
-191 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
-192 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
-193 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
-194 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
-195 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
-196 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
-197 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
-198 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
-199 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
-200 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
-201 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
-202 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
-203 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
-204 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
+118 => wire__crate__api__layer__layer_reference_get_markers_impl(ptr, rust_vec_len, data_len),
+119 => wire__crate__api__layer__layer_reference_get_masks_impl(ptr, rust_vec_len, data_len),
+120 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
+121 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
+122 => wire__crate__api__layer__layer_reference_get_paint_impl(ptr, rust_vec_len, data_len),
+123 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
+124 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
+125 => wire__crate__api__layer__layer_reference_get_shape_contents_impl(ptr, rust_vec_len, data_len),
+126 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
+127 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
+128 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
+129 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
+130 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
+131 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
+133 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
+134 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
+135 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
+136 => wire__crate__api__layer__layer_reference_paste_sequence_shape_impl(ptr, rust_vec_len, data_len),
+137 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
+138 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
+139 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
+140 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
+141 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
+142 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
+143 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
+144 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
+145 => wire__crate__api__layer__layer_reference_set_clip_retime_impl(ptr, rust_vec_len, data_len),
+146 => wire__crate__api__layer__layer_reference_set_clip_speed_impl(ptr, rust_vec_len, data_len),
+147 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
+148 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
+149 => wire__crate__api__layer__layer_reference_set_interpolation_impl(ptr, rust_vec_len, data_len),
+150 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
+151 => wire__crate__api__layer__layer_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+152 => wire__crate__api__layer__layer_reference_set_mask_impl(ptr, rust_vec_len, data_len),
+153 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
+154 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
+155 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
+156 => wire__crate__api__layer__layer_reference_set_shape_contents_impl(ptr, rust_vec_len, data_len),
+157 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
+158 => wire__crate__api__layer__layer_reference_set_stroke_impl(ptr, rust_vec_len, data_len),
+159 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
+160 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
+161 => wire__crate__api__layer__layer_reference_set_text_placed_impl(ptr, rust_vec_len, data_len),
+162 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
+163 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
+164 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
+165 => wire__crate__api__layer__layer_reference_slide_clip_impl(ptr, rust_vec_len, data_len),
+166 => wire__crate__api__layer__layer_reference_split_at_impl(ptr, rust_vec_len, data_len),
+167 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
+168 => wire__crate__api__layer__layer_reference_trim_clip_impl(ptr, rust_vec_len, data_len),
+169 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
+170 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
+171 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
+172 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
+173 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
+174 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
+175 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
+176 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
+177 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
+178 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
+179 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
+180 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
+181 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
+182 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
+183 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
+184 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
+185 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
+186 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
+188 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
+189 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
+190 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
+191 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
+192 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
+193 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
+194 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
+195 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
+196 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
+197 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
+198 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
+199 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
+200 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
+201 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
+202 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
+203 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
+204 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
+205 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
+206 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -10067,6 +10160,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::layer::BridgeLayerInfo {
             self.masks.into_into_dart().into_dart(),
             self.paint.into_into_dart().into_dart(),
             self.shape_contents.into_into_dart().into_dart(),
+            self.markers.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -10107,6 +10201,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::layer::BridgeLayerKind>
     for crate::api::layer::BridgeLayerKind
 {
     fn into_into_dart(self) -> crate::api::layer::BridgeLayerKind {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::layer::BridgeLayerMarker {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.marker.into_into_dart().into_dart(),
+            self.frame.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::layer::BridgeLayerMarker
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::layer::BridgeLayerMarker>
+    for crate::api::layer::BridgeLayerMarker
+{
+    fn into_into_dart(self) -> crate::api::layer::BridgeLayerMarker {
         self
     }
 }
@@ -11767,6 +11882,7 @@ impl SseEncode for crate::api::layer::BridgeLayerInfo {
         <Vec<crate::api::layer::BridgeMask>>::sse_encode(self.masks, serializer);
         <Vec<crate::api::layer::BridgeStroke>>::sse_encode(self.paint, serializer);
         <Vec<crate::api::layer::BridgeShapeItem>>::sse_encode(self.shape_contents, serializer);
+        <Vec<crate::api::layer::BridgeLayerMarker>>::sse_encode(self.markers, serializer);
     }
 }
 
@@ -11790,6 +11906,14 @@ impl SseEncode for crate::api::layer::BridgeLayerKind {
             },
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::layer::BridgeLayerMarker {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <crate::api::composition::BridgeMarker>::sse_encode(self.marker, serializer);
+        <i64>::sse_encode(self.frame, serializer);
     }
 }
 
@@ -12520,6 +12644,16 @@ impl SseEncode for Vec<crate::api::composition::BridgeLayerEntry> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::composition::BridgeLayerEntry>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::layer::BridgeLayerMarker> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::layer::BridgeLayerMarker>::sse_encode(item, serializer);
         }
     }
 }

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -97,6 +97,7 @@ fn posterize_sample_times_snap_covered_layers_to_the_grid() {
     use crate::time::{CompTime, Rational};
     let secs = |n: i64, d: i64| CompTime(Rational::new(n, d).unwrap());
     let layer = |kind: LayerKind, effects: Vec<EffectInstance>| Layer {
+        markers: Vec::new(),
         id: uuid::Uuid::now_v7(),
         name: "l".into(),
         kind,
@@ -4108,6 +4109,7 @@ fn marker_rig(
         extra: serde_json::Map::new(),
     };
     let layer = Layer {
+        markers: Vec::new(),
         id: uuid::Uuid::now_v7(),
         name: "l".into(),
         kind: LayerKind::Adjustment,

--- a/crates/lumit-core/src/model.rs
+++ b/crates/lumit-core/src/model.rs
@@ -1022,6 +1022,21 @@ pub struct Layer {
     /// organisational — never rendered into the picture.
     #[serde(default)]
     pub label: u8,
+    /// The layer's own markers (docs/03 §11): cues drawn on its bar rather than
+    /// on the comp's ruler.
+    ///
+    /// **A copy, not a view.** Dropping a composition into another one brings
+    /// that comp's markers along as the layer's, so its beats are visible where
+    /// the layer sits — but they are this layer's from then on, and deleting
+    /// one here never reaches into the composition it came from. The alternative
+    /// (drawing the source comp's live list) makes a delete on one row change a
+    /// different comp, and every other place that comp is used.
+    ///
+    /// Pre-composing deliberately leaves this empty: the markers it copies into
+    /// the new comp are the ones already on the ruler above, and drawing them
+    /// again on the Precomp layer would say the same thing twice.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub markers: Vec<crate::markers::Marker>,
     /// Per-layer audio volume in dB (docs/09 §6): 0 = unity, boostable to
     /// +50; −100 and below reads as −∞ (exact silence). Animatable like any
     /// property — fades are volume keyframes. Only heard on layers whose
@@ -1734,6 +1749,7 @@ mod tests {
             extra: serde_json::Map::new(),
         };
         let cam = |name: &str, zoom: f64, z_pos: f64, visible: bool, in_s: i64, out_s: i64| Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: name.into(),
             kind: LayerKind::Camera {

--- a/crates/lumit-core/src/ops.rs
+++ b/crates/lumit-core/src/ops.rs
@@ -205,6 +205,13 @@ pub enum Op {
         comp: Uuid,
         markers: Vec<crate::markers::Marker>,
     },
+    /// Replace a layer's own marker list (docs/03 §11) — coarse-grained and
+    /// trivially invertible, exactly like [`Op::SetCompMarkers`].
+    SetLayerMarkers {
+        comp: Uuid,
+        layer: Uuid,
+        markers: Vec<crate::markers::Marker>,
+    },
     SetLayerBlend {
         comp: Uuid,
         layer: Uuid,
@@ -770,6 +777,24 @@ pub fn apply(doc: &mut Document, op: &Op) -> Result<Op, OpError> {
             let previous = std::mem::replace(&mut c.markers, markers.clone());
             Ok(Op::SetCompMarkers {
                 comp: *comp,
+                markers: previous,
+            })
+        }
+        Op::SetLayerMarkers {
+            comp,
+            layer,
+            markers,
+        } => {
+            let c = doc.comp_mut(*comp).ok_or(OpError::UnknownComp)?;
+            let l = c
+                .layers
+                .iter_mut()
+                .find(|l| l.id == *layer)
+                .ok_or(OpError::UnknownLayer)?;
+            let previous = std::mem::replace(&mut l.markers, markers.clone());
+            Ok(Op::SetLayerMarkers {
+                comp: *comp,
+                layer: *layer,
                 markers: previous,
             })
         }

--- a/crates/lumit-core/src/store.rs
+++ b/crates/lumit-core/src/store.rs
@@ -340,6 +340,7 @@ mod tests {
 
     fn test_layer(item: Uuid) -> Layer {
         Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "clip.mp4".into(),
             kind: LayerKind::Footage { item },
@@ -763,6 +764,7 @@ mod tests {
                 comp: comp_id,
                 index: 0,
                 layer: Box::new(Layer {
+                    markers: Vec::new(),
                     id: seq_id,
                     name: "Seq".into(),
                     kind: LayerKind::Sequence {
@@ -948,6 +950,7 @@ mod tests {
                 comp: comp_id,
                 index: 0,
                 layer: Box::new(Layer {
+                    markers: Vec::new(),
                     id: cam_id,
                     name: "Camera".into(),
                     kind: LayerKind::Camera {

--- a/crates/lumit-eval/src/graph.rs
+++ b/crates/lumit-eval/src/graph.rs
@@ -232,6 +232,7 @@ mod tests {
 
     fn layer(kind: LayerKind, masks: Vec<Mask>) -> lumit_core::model::Layer {
         lumit_core::model::Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "l".into(),
             kind,

--- a/crates/lumit-eval/src/lib.rs
+++ b/crates/lumit-eval/src/lib.rs
@@ -919,6 +919,7 @@ mod tests {
 
     fn text_layer(text: &str, in_s: f64, out_s: f64, offset_s: f64) -> Layer {
         Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "t".into(),
             kind: LayerKind::Text {

--- a/crates/lumit-keymap/src/lib.rs
+++ b/crates/lumit-keymap/src/lib.rs
@@ -652,12 +652,12 @@ pub fn default_keymap() -> Keymap {
             bindings.push(b);
         }
     }
-    // Numbered markers (K-254): `Ctrl+N` drops marker *N* at the playhead and
-    // the bare digit jumps back to it. The pairing is the point — the key that
-    // sets a cue is the key that returns to it, with the modifier as the only
-    // difference — and it is what every NLE with numbered markers does.
+    // Numbered markers (K-254): `Shift+N` drops marker *N* at the playhead and
+    // the bare digit jumps back to it — After Effects' own pairing. The pairing
+    // is the point: the key that sets a cue is the key that returns to it, with
+    // the modifier as the only difference.
     for d in 0..=9u8 {
-        if let Some(b) = row(Global, &format!("Mod+{d}"), &format!("marker.add.{d}")) {
+        if let Some(b) = row(Global, &format!("Shift+{d}"), &format!("marker.add.{d}")) {
             bindings.push(b);
         }
         if let Some(b) = row(Global, &format!("{d}"), &format!("marker.goto.{d}")) {
@@ -839,7 +839,7 @@ mod tests {
         }
     }
 
-    /// The numbered markers (K-254). `Ctrl+N` sets and the bare `N` returns, for
+    /// The numbered markers (K-254). `Shift+N` sets and the bare `N` returns, for
     /// all ten digits including zero — and `M` must still reveal Masks in the
     /// Timeline, which is the whole reason the marker key is `Shift+M`.
     #[test]
@@ -847,9 +847,9 @@ mod tests {
         let km = default_keymap();
         for d in 0..=9u8 {
             assert_eq!(
-                km.lookup(KeyContext::Global, &chord(&format!("Mod+{d}"))),
+                km.lookup(KeyContext::Global, &chord(&format!("Shift+{d}"))),
                 Some(&ActionId(format!("marker.add.{d}"))),
-                "Ctrl+{d} should set marker {d}"
+                "Shift+{d} should set marker {d}"
             );
             assert_eq!(
                 km.lookup(KeyContext::Global, &chord(&format!("{d}"))),

--- a/crates/lumit-keymap/src/lib.rs
+++ b/crates/lumit-keymap/src/lib.rs
@@ -51,6 +51,15 @@ impl ActionId {
         if let Some(n) = self.0.strip_prefix("workspace.switch.") {
             return format!("Switch to workspace {n}");
         }
+        // The numbered markers (K-254). Twenty actions, so they are described by
+        // their shape rather than listed one by one below — a table of twenty
+        // near-identical rows is exactly what this prefix form is for.
+        if let Some(n) = self.0.strip_prefix("marker.add.") {
+            return format!("Add marker {n} at the playhead");
+        }
+        if let Some(n) = self.0.strip_prefix("marker.goto.") {
+            return format!("Go to marker {n}");
+        }
         let known = match self.0.as_str() {
             // Transport and navigation.
             "playback.toggle" => "Play or pause",
@@ -531,6 +540,12 @@ pub fn default_keymap() -> Keymap {
         row(Global, "B", "workarea.set.start"),
         row(Global, "N", "workarea.set.end"),
         row(Global, "*", "marker.add"),
+        // `Shift+M` is the second way in (K-254). Premiere and Vegas both drop a
+        // marker on `M`, which is the habit the owner arrives with — but `M`
+        // reveals Masks in the Timeline and that is After Effects' oldest
+        // reflex, so the letter stays where it is and the marker takes Shift.
+        // Two chords for one action is not a clash; `*` still works.
+        row(Global, "Shift+M", "marker.add"),
         // Delete-removes-the-selection was missing from the §15 table
         // entirely (TF-6, first outside tester): keyframes when any are
         // selected, else the selected layer. Backspace is its usual sibling.
@@ -634,6 +649,18 @@ pub fn default_keymap() -> Keymap {
             &format!("Alt+Shift+{d}"),
             &format!("workspace.switch.{d}"),
         ) {
+            bindings.push(b);
+        }
+    }
+    // Numbered markers (K-254): `Ctrl+N` drops marker *N* at the playhead and
+    // the bare digit jumps back to it. The pairing is the point — the key that
+    // sets a cue is the key that returns to it, with the modifier as the only
+    // difference — and it is what every NLE with numbered markers does.
+    for d in 0..=9u8 {
+        if let Some(b) = row(Global, &format!("Mod+{d}"), &format!("marker.add.{d}")) {
+            bindings.push(b);
+        }
+        if let Some(b) = row(Global, &format!("{d}"), &format!("marker.goto.{d}")) {
             bindings.push(b);
         }
     }
@@ -810,6 +837,34 @@ mod tests {
                 .iter()
                 .any(|b| b.context == KeyContext::Global));
         }
+    }
+
+    /// The numbered markers (K-254). `Ctrl+N` sets and the bare `N` returns, for
+    /// all ten digits including zero — and `M` must still reveal Masks in the
+    /// Timeline, which is the whole reason the marker key is `Shift+M`.
+    #[test]
+    fn numbered_markers_bind_set_and_return_for_every_digit() {
+        let km = default_keymap();
+        for d in 0..=9u8 {
+            assert_eq!(
+                km.lookup(KeyContext::Global, &chord(&format!("Mod+{d}"))),
+                Some(&ActionId(format!("marker.add.{d}"))),
+                "Ctrl+{d} should set marker {d}"
+            );
+            assert_eq!(
+                km.lookup(KeyContext::Global, &chord(&format!("{d}"))),
+                Some(&ActionId(format!("marker.goto.{d}"))),
+                "{d} should return to marker {d}"
+            );
+        }
+        assert_eq!(
+            km.lookup(KeyContext::Global, &chord("Shift+M")),
+            Some(&"marker.add".into())
+        );
+        assert_eq!(
+            km.lookup(KeyContext::Timeline, &chord("M")),
+            Some(&"reveal.masks".into())
+        );
     }
 
     #[test]

--- a/crates/lumit-project/src/fixtures.rs
+++ b/crates/lumit-project/src/fixtures.rs
@@ -155,6 +155,7 @@ pub fn stress_document(p: &StressParams) -> Document {
                 footage_ids[layer_index % footage_ids.len()]
             };
             layers.push(Layer {
+                markers: Vec::new(),
                 id: uid(3, layer_index),
                 name: format!("layer {layer_index}"),
                 kind: LayerKind::Footage { item },

--- a/crates/lumit-render/examples/perf_probe.rs
+++ b/crates/lumit-render/examples/perf_probe.rs
@@ -21,6 +21,7 @@ const N: u64 = 90;
 
 fn layer(kind: LayerKind, name: &str) -> lumit_core::model::Layer {
     lumit_core::model::Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: name.into(),
         kind,

--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -1105,6 +1105,7 @@ mod parent_placement_tests {
 
     fn layer(px: f64, py: f64, parent: Option<uuid::Uuid>) -> Layer {
         Layer {
+            markers: Vec::new(),
             id: uuid::Uuid::now_v7(),
             name: "l".into(),
             kind: LayerKind::Solid {
@@ -1212,6 +1213,7 @@ mod render_below_at_tests {
 
     fn text_layer(x: f64) -> Layer {
         Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "t".into(),
             kind: LayerKind::Text {
@@ -1351,6 +1353,7 @@ mod render_below_at_tests {
             }
         }
         Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "posterize".into(),
             kind: LayerKind::Adjustment,
@@ -1634,6 +1637,7 @@ mod render_below_at_tests {
             }
         }
         Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "accumulation".into(),
             kind: LayerKind::Adjustment,

--- a/crates/lumit-render/src/build/build_tests.rs
+++ b/crates/lumit-render/src/build/build_tests.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 fn footage_geometry_uses_native_size_not_decoded_size() {
     let item = Uuid::now_v7();
     let layer = Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: "clip".into(),
         kind: LayerKind::Footage { item },
@@ -91,6 +92,7 @@ fn footage_geometry_uses_native_size_not_decoded_size() {
 fn collapsed_precomp_splices_inner_draws_with_parent_placement() {
     use lumit_core::model::{ProjectItem, TextDocument};
     let text_layer = || Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: "inner".into(),
         kind: LayerKind::Text {
@@ -219,6 +221,7 @@ fn patch_layer_prop_overrides_the_previewed_value() {
     use lumit_core::model::TransformProp;
     let item = Uuid::now_v7();
     let layer = Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: "clip".into(),
         kind: LayerKind::Footage { item },
@@ -286,6 +289,7 @@ fn patch_layer_prop_overrides_the_previewed_value() {
 fn a_live_adjustment_layer_emits_a_staging_draw() {
     let solid_def = Uuid::now_v7();
     let base = Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: "under".into(),
         kind: LayerKind::Solid { def: solid_def },
@@ -379,6 +383,7 @@ fn a_live_adjustment_layer_emits_a_staging_draw() {
 fn a_paint_stroke_reaches_the_layers_pixels() {
     let solid_id = Uuid::now_v7();
     let mut layer = Layer {
+        markers: Vec::new(),
         id: Uuid::now_v7(),
         name: "solid".into(),
         kind: LayerKind::Solid { def: solid_id },

--- a/crates/lumit-render/src/cache.rs
+++ b/crates/lumit-render/src/cache.rs
@@ -234,6 +234,7 @@ mod tests {
             background: LinearColour::BLACK,
             work_area: None,
             layers: vec![Layer {
+                markers: Vec::new(),
                 id: Uuid::now_v7(),
                 name: "clip".into(),
                 kind: LayerKind::Footage { item },

--- a/crates/lumit-render/src/export.rs
+++ b/crates/lumit-render/src/export.rs
@@ -710,6 +710,7 @@ mod tests {
             background: LinearColour::BLACK,
             work_area: None,
             layers: vec![lumit_core::model::Layer {
+                markers: Vec::new(),
                 id: Uuid::now_v7(),
                 name: "Solid".into(),
                 kind: LayerKind::Solid { def: solid_id },

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -1784,6 +1784,7 @@ mod tests {
         }));
         let comp_id = Uuid::now_v7();
         let layer = lumit_core::model::Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: "Solid".into(),
             kind: LayerKind::Solid { def: solid_id },
@@ -2067,6 +2068,7 @@ mod tests {
             .find(|i| matches!(i, ProjectItem::Composition(_)))
         {
             c.layers.push(lumit_core::model::Layer {
+                markers: Vec::new(),
                 id: Uuid::now_v7(),
                 name: "gone.mp4".into(),
                 kind: LayerKind::Footage { item: item_id },
@@ -2654,6 +2656,7 @@ mod tests {
     /// own natural size, everything else the model's defaults.
     fn matrix_layer(name: &str, kind: LayerKind, w: u32, h: u32) -> lumit_core::model::Layer {
         lumit_core::model::Layer {
+            markers: Vec::new(),
             id: Uuid::now_v7(),
             name: name.into(),
             kind,

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5040,9 +5040,12 @@ for them; what was missing was the ruler. Comp markers are now small flags with 
 point is what carries the meaning, *this* frame and not the one next door, so a shape hung
 off to one side was marking the wrong thing. They hang into the ruler's lower row beside
 the work-area band, drawn last so a flag wins the pointer over a work-area handle it sits
-on. What a marker says rides in a box of the same colour flush against the flag rather than
-as loose text over the ticks, where it crossed the ruler and the work-area wash and read as
-neither. Colour is a `marker` token of its own — a plain grey, light on dark and dark on
+on. What a marker says rides in a box of the same colour flying from the flag's **centre
+point** — the pole is the marker's centre line and the cloth hangs off it — rather than as
+loose text over the ticks, where it crossed the ruler and the work-area wash and read as
+neither. Both carry a hairline outline in the darkest surface and sit on the floor of the
+ruler: a pale flag on the pale work-area band lost its silhouette, and the point was the
+first part to go. Colour is a `marker` token of its own — a plain grey, light on dark and dark on
 light, editable like any other role — because a marker says *here*, not *good* or
 *careful*, and the accent is already spent on the work area.
 
@@ -5063,8 +5066,9 @@ an edit can change. `bridge_call_budget_test` pins both: nothing per rebuild, ex
 
 **Right-click** offers *Edit marker…* and *Delete marker*.
 
-The keyboard is the numbered pair every NLE has: **`Ctrl+0…9`** sets marker *N* at the
-playhead and the **bare digit** returns to it. Setting a numbered marker that already
+The keyboard is the numbered pair every NLE has: **`Shift+0…9`** sets marker *N* at the
+playhead and the **bare digit** returns to it — `Shift`+digit rather than `Ctrl`+digit,
+which is the chord After Effects itself uses. Setting a numbered marker that already
 exists *moves* it rather than adding a second — a digit has to name one place. A digit
 with no marker behind it is left unhandled, not swallowed. The plain marker key is
 **`Shift+M`** alongside AE's numpad `*`: Premiere and Vegas both use `M`, but `M` reveals

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5035,13 +5035,33 @@ returning playhead (real Vegas returns its cursor too), so there is nothing for 
 question to decide, and K-246's pair stays a pair.
 
 *Markers.* The engine has had markers since docs/03 §11 and the ⋯ menu has had a dialogue
-for them; what was missing was the ruler. Comp markers are now After Effects' bookmark
-flags — a square with its bottom corners cut to a point, its **left edge** on the moment
-it marks — drawn in the ruler's lower row beside the work-area band, and drawn last so a
-flag wins the pointer over a work-area handle it sits on. They **drag** along the ruler
-(committed per frame crossed, like the work-area edges, and holding the grab offset so the
-flag does not flinch to the pointer), and **right-click** offers *Edit marker…* and
-*Delete marker*.
+for them; what was missing was the ruler. Comp markers are now small flags with the
+**point at the top**, **centred on the frame** so the point sits on the playhead — the
+point is what carries the meaning, *this* frame and not the one next door, so a shape hung
+off to one side was marking the wrong thing. They hang into the ruler's lower row beside
+the work-area band, drawn last so a flag wins the pointer over a work-area handle it sits
+on. What a marker says rides in a box of the same colour flush against the flag rather than
+as loose text over the ticks, where it crossed the ruler and the work-area wash and read as
+neither. Colour is a `marker` token of its own — a plain grey, light on dark and dark on
+light, editable like any other role — because a marker says *here*, not *good* or
+*careful*, and the accent is already spent on the work area.
+
+**Markers do not stack.** Adding one where a marker already sits replaces it, and so does
+dragging one on top of another; both go through one `markersWithFrb`, so the shortcut and
+the drag cannot drift into different ideas of what placing a marker means. Two flags on one
+frame are two things to click and one place, and the second hides the first exactly.
+
+A drag **writes once, on release**. Committing per frame crossed — what the work-area edges
+do — cost a document write, a cache flush and a panel rebuild for every frame of travel,
+which is what made the drag feel heavy; the work-area edge can afford it because the
+Viewer's preview range changes as it moves, and a marker has nothing to show until it
+lands. In the same vein the marker list is now remembered in Dart (`markersOf`, beside the
+frame/time memo, cleared by the same committed-change hook) rather than fetched across the
+bridge on every ruler rebuild — sixty times a second while playback runs, for a list only
+an edit can change. `bridge_call_budget_test` pins both: nothing per rebuild, exactly one
+`set_markers` per drag.
+
+**Right-click** offers *Edit marker…* and *Delete marker*.
 
 The keyboard is the numbered pair every NLE has: **`Ctrl+0…9`** sets marker *N* at the
 playhead and the **bare digit** returns to it. Setting a numbered marker that already

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5076,6 +5076,21 @@ Masks in the Timeline and that reflex is older, so the letter stays put and the 
 takes Shift. Twenty new action ids, described by prefix (`marker.add.N`, `marker.goto.N`)
 the way `workspace.switch.N` already is, and the shipped keymap stays conflict-free.
 
+**Markers travel with the material (2026-08-03).** A layer carries its own marker list
+(`Layer::markers`, docs/03 §11, drawn on its bar and moving with it), and two moments fill
+it. Dropping a composition into another **copies** that comp's markers onto the layer: a
+comp placed in a comp is a piece of material and its beats are part of what you are
+placing. Copies with fresh ids, not a live view of the source list — the alternative makes
+deleting one flag on one row change a different composition, and every other place that
+composition is used, which is spooky action at a distance for a right-click menu.
+**Pre-composing** copies the comp's markers into the new composition (shifted by the same
+amount `adjust_duration` shifts the layers, and dropped if they fall outside the new span
+rather than parked where nothing can reach them) and gives the Precomp layer **none**: the
+cues are on the ruler above it already, and drawing them on the layer too would say it
+twice. `BridgeLayerInfo` carries the list with each marker's comp frame precomputed —
+layer-local time plus the layer's start offset, exactly as a Sequence clip's is — so the
+bar draws them with no bridge call, and dragging the layer moves them.
+
 Two things this leaves: §10's *`8` during playback = beat tap* now wants a key of its own
 or a modal reading, since the bare digits are spoken for; and `set_markers` still flattens
 every marker to `MarkerKind::User`, so dragging a marker turns detected beats into ordinary

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5009,3 +5009,52 @@ Flutter Linux embedder needs GTK 3, which only the GNOME runtime ships. Sandbox 
 (`--filesystem=host`, dri, pulseaudio) carry over from the old manifest's reasoning
 verbatim. Published as a single-file `.flatpak` on the GitHub Release; Flathub submission,
 if ever, is a separate decision.
+
+**K-254 · PROPOSED · The playhead returns when playback stops, a scrub takes it off the
+transport, and markers are flags you can drag, name and jump to by number.**
+Three things the owner asked for on 2026-08-03, all about the playhead.
+
+*Scrubbing during playback.* The engine chooses frames and hands each one back, and
+`_arrived` moves the playhead to follow the picture (K-181). A drag on the ruler was
+therefore unwinnable — every tick put the playhead back where the transport wanted it.
+Taking hold of the playhead now **takes it off the transport**: every ruler and lane seek
+goes through one new `LumitUiState.scrubTo`, which stops playback first. One funnel rather
+than a guard per call site, because the three `onSeek` closures were three copies of
+`playheadFrame.value = …` and a fourth would have been written without the guard.
+
+*Returning on stop.* Stopping now puts the playhead back where `play` was asked for —
+including when the composition simply runs out, since where you are when the transport
+stops should not depend on why it stopped. This realises §9's long-standing
+"stop-to-start toggle behaviour as a setting" line. The default is the returning one:
+playback is a preview of the moment being worked on. Settings ▸ Interface ▸ Editing ▸
+*Playhead stays where playback stopped* restores the older After Effects behaviour, and
+unlike the K-246 pair it does **not** defer to a settings file's silence — an install
+written before the field adopts the new default rather than being pinned to the old
+behaviour by omission. The first-run screen does not touch it: both answers want the
+returning playhead (real Vegas returns its cursor too), so there is nothing for the
+question to decide, and K-246's pair stays a pair.
+
+*Markers.* The engine has had markers since docs/03 §11 and the ⋯ menu has had a dialogue
+for them; what was missing was the ruler. Comp markers are now After Effects' bookmark
+flags — a square with its bottom corners cut to a point, its **left edge** on the moment
+it marks — drawn in the ruler's lower row beside the work-area band, and drawn last so a
+flag wins the pointer over a work-area handle it sits on. They **drag** along the ruler
+(committed per frame crossed, like the work-area edges, and holding the grab offset so the
+flag does not flinch to the pointer), and **right-click** offers *Edit marker…* and
+*Delete marker*.
+
+The keyboard is the numbered pair every NLE has: **`Ctrl+0…9`** sets marker *N* at the
+playhead and the **bare digit** returns to it. Setting a numbered marker that already
+exists *moves* it rather than adding a second — a digit has to name one place. A digit
+with no marker behind it is left unhandled, not swallowed. The plain marker key is
+**`Shift+M`** alongside AE's numpad `*`: Premiere and Vegas both use `M`, but `M` reveals
+Masks in the Timeline and that reflex is older, so the letter stays put and the marker
+takes Shift. Twenty new action ids, described by prefix (`marker.add.N`, `marker.goto.N`)
+the way `workspace.switch.N` already is, and the shipped keymap stays conflict-free.
+
+Two things this leaves: §10's *`8` during playback = beat tap* now wants a key of its own
+or a modal reading, since the bare digits are spoken for; and `set_markers` still flattens
+every marker to `MarkerKind::User`, so dragging a marker turns detected beats into ordinary
+cues and *Clear beat markers* stops finding them. That was already true of the dialogue's
+remove button and is not made worse here, but it is now much easier to hit — it wants a
+kind carried across the bridge.

--- a/docs/03-DATA-MODEL.md
+++ b/docs/03-DATA-MODEL.md
@@ -159,9 +159,13 @@ struct Layer {
     retime: Option<Property>,          // K-197: Retime as an ordinary keyframable property —
                                        // layer-local time → source time, in seconds. None = not
                                        // retimed (no row, no map). Ctrl+Alt+T installs the identity.
+    markers: Vec<Marker>,              // §11, K-254: the layer's OWN cues, drawn on its bar.
+                                       // Times are layer-local. A comp dropped into another
+                                       // brings a copy of its markers here; the two lists are
+                                       // unrelated from then on.
     switches: Switches,
 }
-// Future (not in v1): `stretch` (uniform rate multiplier) and per-layer `markers`.
+// Future (not in v1): `stretch` (uniform rate multiplier).
 // Mute stays the `audible` switch, and audio comes only from a footage layer's own
 // stream (§5.2, docs/09); the once-sketched `audio: AudioProps` grouping collapsed
 // to the single `volume_db` property when it shipped (K-172) — fades are its
@@ -493,6 +497,14 @@ struct Marker {
 
 Beat markers are ordinary markers with provenance; regenerating beats replaces only
 `Beat`-kind markers ([09-AUDIO.md](09-AUDIO.md)).
+
+**Two owners (K-254).** A composition holds markers on its ruler; a layer holds markers of
+its own on its bar, in `Layer::markers`, timed in the layer's own time so they move with it.
+A layer's list is always a **copy**, never a view: dropping a composition into another
+copies that comp's markers onto the layer with fresh ids, and editing either list afterwards
+leaves the other alone. Pre-composing copies the comp's markers into the new composition and
+leaves the Precomp layer's list empty — the cues are on the ruler above it already. One
+marker per frame per owner: placing one where a marker already sits replaces it.
 
 ## 12. Schema evolution
 

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -727,8 +727,12 @@ frame readout `f72`, the layer search, the master motion-blur button, the shy fi
 Lane and Graph view buttons, and a ⋯ menu with the layer / razor / work-area / marker /
 beat commands) and the **column-group header** (§4.2). The lane side gives those two
 rows' height to a taller, labelled time ruler — a bigger playhead grab — with the cache
-bar tucked under it. Markers currently draw on the ruler itself; the separate ribbon,
-double-click-to-create and marker dragging are still to come.
+bar tucked under it. Markers draw on the ruler itself rather than in a ribbon of their
+own — as After Effects' bookmark flags, in the ruler's lower row beside the work-area
+band, with a one- or two-character label inside the flag and a longer one beside it. They
+can be **dragged** along the ruler, and **right-clicking** one offers *Edit marker…* and
+*Delete marker* (K-254). The separate ribbon, span markers and double-click-to-create are
+still to come.
 
 ### 4.2 Layer outline columns
 
@@ -943,7 +947,10 @@ edit point near a beat marker lands exactly on it.
 - `=`/`-` zoom time in/out; `Shift+=` zooms to the work area; `\` toggles between full-comp
   zoom and the previous zoom (AE-compatible).
 - Dragging in the ruler scrubs the playhead. Scrubbing previews video always; holding
-  `Ctrl` while scrubbing also scrubs audio.
+  `Ctrl` while scrubbing also scrubs audio. **Scrubbing while playing stops playback**
+  (K-254) and the playhead stays where the drag left it: the engine hands back a frame
+  every tick, so a scrub fought against playback could never win, and a playhead that
+  returned to where play started would undo the very gesture that stopped it.
 - The playhead MUST stay visible during playback via edge-follow scrolling (page-flip or
   smooth per user setting); the timeline MUST NOT recentre while the user is dragging
   anything.
@@ -1314,7 +1321,12 @@ the T14 viewfinder), and the on-Viewer crosshair handle for point parameters.
 A slim transport strip is docked beneath the Viewer bar by default; the same controls exist
 as the dockable **Preview panel**.
 
-- **Play/pause** (Space), stop-to-start toggle behaviour as a setting.
+- **Play/pause** (Space). **Stopping returns the playhead to where play started** — the
+  default, because playback is a preview of the moment being worked on and coming back to
+  a different frame means finding your place again after every space bar. This holds
+  however playback ends, the composition running out included. Settings ▸ Interface ▸
+  Editing ▸ *Playhead stays where playback stopped* puts the older behaviour back (K-254).
+  The exception is a ruler scrub, which stops playback in order to move the playhead (§4.6).
 - **Loop modes**: loop work area (default) / play once / ping-pong.
 - **Cache status**: a readout of how much of the work area is preview-ready (backed by the
   cache bar), plus a *fill cache* action that renders the work area ahead of playback while
@@ -1668,7 +1680,9 @@ them away the day dispatch started going through the keymap.
 | Global | `,` / `.` | Previous / next keyframe on revealed properties |
 | Global | `Ctrl+,` / `Ctrl+.` | Previous / next edit point or layer boundary |
 | Global | `B` / `N` | Set work area start / end at playhead |
-| Global | `*` (numpad or `Shift+8`) | Add marker at playhead (`8` during playback: beat tap, §10) |
+| Global | `*` (numpad or `Shift+8`) / `Shift+M` | Add marker at playhead. `M` keeps Reveal Masks, so the letter form takes Shift (K-254) |
+| Global | `Ctrl+0…9` | Set numbered marker at playhead — pressing it again *moves* that marker (K-254) |
+| Global | `0…9` | Go to that numbered marker; nothing happens until one has been set (K-254) |
 | Global | `Delete` / `Backspace` | Delete the selection — keyframes when any are selected, else the layer (TF-6) |
 | Global | `Ctrl+Shift+P` | Command palette |
 | Global | `Ctrl+M` | Add active comp to export queue |

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -740,7 +740,19 @@ dragging one on top of another. Two flags on one moment are two things to click 
 place, and the second hides the first exactly. A flag can be **dragged** along the ruler —
 the document hears about the move once, on release, not per frame crossed — and
 **right-clicking** one offers *Edit marker…* and *Delete marker*. The separate ribbon, span
-markers, layer markers and double-click-to-create are still to come.
+markers and double-click-to-create are still to come.
+
+**Layer markers (K-254)** draw on the layer's own bar, in the same flags, and travel with
+it when it is moved. A layer's markers are **its own copy**: dropping a composition into
+another brings that comp's markers along as the layer's, and from then on the two lists are
+unrelated — deleting one on a layer never reaches into the composition it came from, or
+into anywhere else that composition is used. Right-clicking a flag on a bar offers *Edit
+marker…*, *Delete marker* and *Delete all markers*; the layer's own row menu carries
+*Delete all markers* too, and only when there are some. Pre-composing copies the comp's
+markers **into the new composition** (shifted with everything else when the dialogue's
+*Adjust duration* moves time back to zero, and any falling outside the new span are left
+behind) and leaves the Precomp layer with none — those cues are on the ruler above it
+already, and drawing them on the layer as well would say the same thing twice.
 
 ### 4.2 Layer outline columns
 

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -728,11 +728,18 @@ Lane and Graph view buttons, and a ⋯ menu with the layer / razor / work-area /
 beat commands) and the **column-group header** (§4.2). The lane side gives those two
 rows' height to a taller, labelled time ruler — a bigger playhead grab — with the cache
 bar tucked under it. Markers draw on the ruler itself rather than in a ribbon of their
-own — as After Effects' bookmark flags, in the ruler's lower row beside the work-area
-band, with a one- or two-character label inside the flag and a longer one beside it. They
-can be **dragged** along the ruler, and **right-clicking** one offers *Edit marker…* and
-*Delete marker* (K-254). The separate ribbon, span markers and double-click-to-create are
-still to come.
+own (K-254): a small flag with its **point at the top**, centred on the frame it marks so
+the point sits on the playhead, hanging into the ruler's lower row beside the work-area
+band. What a marker says rides in a box of the same colour flush against the flag's right,
+not as loose text over the ticks. Styling — a grey `marker` token, editable like any other
+— is in [15-DESIGN.md](15-DESIGN.md) §6.4.
+
+**One marker per frame**: adding one where a marker already sits replaces it, and so does
+dragging one on top of another. Two flags on one moment are two things to click and one
+place, and the second hides the first exactly. A flag can be **dragged** along the ruler —
+the document hears about the move once, on release, not per frame crossed — and
+**right-clicking** one offers *Edit marker…* and *Delete marker*. The separate ribbon, span
+markers, layer markers and double-click-to-create are still to come.
 
 ### 4.2 Layer outline columns
 
@@ -1681,7 +1688,7 @@ them away the day dispatch started going through the keymap.
 | Global | `Ctrl+,` / `Ctrl+.` | Previous / next edit point or layer boundary |
 | Global | `B` / `N` | Set work area start / end at playhead |
 | Global | `*` (numpad or `Shift+8`) / `Shift+M` | Add marker at playhead. `M` keeps Reveal Masks, so the letter form takes Shift (K-254) |
-| Global | `Ctrl+0…9` | Set numbered marker at playhead — pressing it again *moves* that marker (K-254) |
+| Global | `Ctrl+0…9` | Set numbered marker at playhead — pressing it again *moves* that marker, and it replaces whatever is on that frame (K-254) |
 | Global | `0…9` | Go to that numbered marker; nothing happens until one has been set (K-254) |
 | Global | `Delete` / `Backspace` | Delete the selection — keyframes when any are selected, else the layer (TF-6) |
 | Global | `Ctrl+Shift+P` | Command palette |

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -730,8 +730,9 @@ rows' height to a taller, labelled time ruler — a bigger playhead grab — wit
 bar tucked under it. Markers draw on the ruler itself rather than in a ribbon of their
 own (K-254): a small flag with its **point at the top**, centred on the frame it marks so
 the point sits on the playhead, hanging into the ruler's lower row beside the work-area
-band. What a marker says rides in a box of the same colour flush against the flag's right,
-not as loose text over the ticks. Styling — a grey `marker` token, editable like any other
+band. What a marker says rides in a box of the same colour flying from the flag's **centre
+point**, like a flag from a pole, not as loose text over the ticks; both carry a hairline
+outline, and both sit on the floor of the ruler. Styling — a grey `marker` token, editable like any other
 — is in [15-DESIGN.md](15-DESIGN.md) §6.4.
 
 **One marker per frame**: adding one where a marker already sits replaces it, and so does
@@ -1688,7 +1689,7 @@ them away the day dispatch started going through the keymap.
 | Global | `Ctrl+,` / `Ctrl+.` | Previous / next edit point or layer boundary |
 | Global | `B` / `N` | Set work area start / end at playhead |
 | Global | `*` (numpad or `Shift+8`) / `Shift+M` | Add marker at playhead. `M` keeps Reveal Masks, so the letter form takes Shift (K-254) |
-| Global | `Ctrl+0…9` | Set numbered marker at playhead — pressing it again *moves* that marker, and it replaces whatever is on that frame (K-254) |
+| Global | `Shift+0…9` | Set numbered marker at playhead — pressing it again *moves* that marker, and it replaces whatever is on that frame (K-254) |
 | Global | `0…9` | Go to that numbered marker; nothing happens until one has been set (K-254) |
 | Global | `Delete` / `Backspace` | Delete the selection — keyframes when any are selected, else the layer (TF-6) |
 | Global | `Ctrl+Shift+P` | Command palette |

--- a/docs/15-DESIGN.md
+++ b/docs/15-DESIGN.md
@@ -422,9 +422,11 @@ failure.
   *careful*, and the ruler already spends the accent on the work area. The flag is an 11×12
   shape with its **point at the top**, centred on the frame it marks so the point sits on the
   playhead, hanging into the ruler's lower row. What it says rides in a box of the same
-  colour flush against its right, `caption` weight 400 in `surface_0`, rather than as loose
-  text over the ticks. **One marker per frame** — a second dropped on an occupied frame
-  replaces the first, since two flags on one moment are two things to click and one place.
+  colour flying from the flag's **centre point**, `caption` weight 400 in `surface_0`,
+  rather than as loose text over the ticks. Flag and box both carry a 1px `surface_0`
+  outline and sit flush with the floor of the ruler. **One marker per frame** — a second
+  dropped on an occupied frame replaces the first, since two flags on one moment are two
+  things to click and one place.
 - **Beat markers**: `marker.beat` = `#aef3e7` (mint) 1px ticks in the ruler with a small
   triangular head — still to come, and it needs a token of its own beside `marker`. Span
   markers draw a hairline-bounded band.

--- a/docs/15-DESIGN.md
+++ b/docs/15-DESIGN.md
@@ -245,10 +245,11 @@ on a light scheme means going *darker* while the surfaces go lighter).
 (`flutter_ui/lib/theme/theme.dart`) carries the structural roles — the surfaces, text, hairlines,
 `accent`/`accent_hover`, `success`/`warning`/`error`, the `curve[4]` ramp, `layer`
 (`LayerColours`, §6.1) — plus two the code has split out that this listing does not yet name:
-`scope` (`ScopeColours`, the four scope-chrome accents) and `cache_disk` (the disk tier of the
-cache bar, §6.3). Not yet split into their own tokens, and derived ad-hoc from existing roles in
+`scope` (`ScopeColours`, the four scope-chrome accents), `cache_disk` (the disk tier of the
+cache bar, §6.3) and `marker` (comp markers on the time ruler, §6.4 — the first of the
+`marker` grouping to be split out, K-254; the beat variant still waits). Not yet split into their own tokens, and derived ad-hoc from existing roles in
 v1: `disabled` and `fill_tonal` (the `cloud`/`oat` mappings below are reserved, not present);
-the `keyframe`, `marker`, `overrun_hatch`, `waveform` and `selection` groupings (widgets reach
+the `keyframe`, `overrun_hatch`, `waveform` and `selection` groupings (widgets reach
 for `text_secondary`, `accent`, `warning`, etc. directly); and `shadow_float`. Splitting each
 into a named token — so no widget derives a semantic colour itself — is the standing direction,
 done as each area is next touched; the no-hex rule already holds regardless.
@@ -415,9 +416,18 @@ failure.
   marks the exact exhaustion point, and hovering the span says what it means ("Source ends
   here — holding the last frame"). Warning, not error: the render is well-defined
   (boundary-frame hold), the editor just needs to see it.
+- **Comp markers (shipped, K-254)**: a `marker` token of its own — a plain grey, `#c4c4c4`
+  on a dark scheme and `#565656` on a light one, editable in the theme editor like any other
+  role. Grey rather than a role colour on purpose: a marker says *here*, not *good* or
+  *careful*, and the ruler already spends the accent on the work area. The flag is an 11×12
+  shape with its **point at the top**, centred on the frame it marks so the point sits on the
+  playhead, hanging into the ruler's lower row. What it says rides in a box of the same
+  colour flush against its right, `caption` weight 400 in `surface_0`, rather than as loose
+  text over the ticks. **One marker per frame** — a second dropped on an occupied frame
+  replaces the first, since two flags on one moment are two things to click and one place.
 - **Beat markers**: `marker.beat` = `#aef3e7` (mint) 1px ticks in the ruler with a small
-  triangular head. Manual markers: `marker.manual` = `text_secondary`; span markers draw a
-  hairline-bounded band. Marker labels: mono 11px.
+  triangular head — still to come, and it needs a token of its own beside `marker`. Span
+  markers draw a hairline-bounded band.
 - **Clip waveforms**: `waveform.rest` = `#5d8a96` (muted steel-cyan) filled envelope at 80%
   opacity on `surface_2`; on selected clips the envelope brightens to `text_secondary`.
   Waveforms never render in `accent` — they are content, not state.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5445,8 +5445,29 @@ has a tick box.
 **Markers are labelled flags on the ruler.** A marker is just a moment with a name on it —
 the drop of a track, the frame a door closes, wherever you want to be able to get back to.
 Lumit has had them in the document for a long time; what it did not have was a way to
-touch them. Now they draw as small bookmark-shaped flags in the lower row of the time
-ruler, and you can drag one along, right-click it to change what it says, or delete it.
+touch them. Now they draw as small flags in the lower row of the time ruler, and you can
+drag one along, right-click it to change what it says, or delete it.
+
+The flag points *upwards*, and the point is centred on the frame it marks, so it lands on
+the playhead. That is the whole of the design: the point is the bit that means "this
+frame", and a shape sitting to one side of it would be pointing at the frame next door.
+Whatever the marker says rides in a small box stuck to the flag's right — as loose text it
+crossed the ruler's ticks and the work-area band and read as belonging to neither.
+
+Two markers can never sit on the same frame. Drop one where another already is — with the
+keyboard or by dragging — and the newcomer takes its place. Two flags on one moment would
+be two things to click and one place, and the second would hide the first exactly.
+
+**A note on cost, because it is the reason this feels smooth.** Two habits keep markers
+cheap. First, the list is *remembered*: asking the engine for a comp's markers is a trip
+across the Rust/Flutter boundary, and the ruler redraws sixty times a second while playback
+runs — so the answer is kept on the Flutter side and thrown away only when the document
+actually changes. Second, dragging a flag writes nothing until you let go. The earlier
+version saved the new position every time the flag crossed a frame, which meant a document
+write, a memory flush and a panel redraw for every few pixels of travel — the drag worked,
+but it felt like dragging something heavy. A work-area edge can afford that, because the
+Viewer's preview range genuinely changes as the edge moves; a marker has nothing to show
+until it lands.
 
 The keyboard is where they earn their keep. **Ctrl and a digit** puts a marker with that
 number at the playhead; **the digit on its own** jumps back to it. Press `Ctrl+1` again

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5451,8 +5451,10 @@ drag one along, right-click it to change what it says, or delete it.
 The flag points *upwards*, and the point is centred on the frame it marks, so it lands on
 the playhead. That is the whole of the design: the point is the bit that means "this
 frame", and a shape sitting to one side of it would be pointing at the frame next door.
-Whatever the marker says rides in a small box stuck to the flag's right — as loose text it
-crossed the ruler's ticks and the work-area band and read as belonging to neither.
+Whatever the marker says flies from the flag's centre point, like a flag from a pole — as
+loose text it crossed the ruler's ticks and the work-area band and read as belonging to
+neither. Both the flag and the box are outlined in the darkest surface, because a pale grey
+shape on the pale work-area band otherwise loses its edges.
 
 Two markers can never sit on the same frame. Drop one where another already is — with the
 keyboard or by dragging — and the newcomer takes its place. Two flags on one moment would
@@ -5469,8 +5471,8 @@ but it felt like dragging something heavy. A work-area edge can afford that, bec
 Viewer's preview range genuinely changes as the edge moves; a marker has nothing to show
 until it lands.
 
-The keyboard is where they earn their keep. **Ctrl and a digit** puts a marker with that
-number at the playhead; **the digit on its own** jumps back to it. Press `Ctrl+1` again
+The keyboard is where they earn their keep. **Shift and a digit** puts a marker with that
+number at the playhead; **the digit on its own** jumps back to it. Press `Shift+1` again
 somewhere else and marker 1 *moves* — a number names one place, so there is never a second
 marker 1 for the plain `1` to have to choose between. `Shift+M` drops an unnumbered one.
 (Why not plain `M`, which is what Premiere and Vegas use? Because `M` reveals a layer's

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5413,6 +5413,48 @@ through a side door that skips all three (`set_ui_state`), and the frontend call
 it in the one instant it is genuinely wanted — immediately before a save, when the
 arrangement it describes is the one on the screen.
 
+### The playhead, playback, and where you end up (K-254)
+
+Three small things that all turn out to be the same thing.
+
+**The playhead is not always yours.** Normally the playhead is a number the interface
+owns: you move it, and the engine is told to draw that frame. During playback it is the
+other way round. The engine picks which frame to render — it is the one watching the clock
+and the cache — and each finished frame arrives saying *this is the frame you are looking
+at*, at which point the playhead is moved to match. That is deliberate: the number under
+the timecode is the frame genuinely on screen, not the frame something hoped to show.
+
+The catch is that it made scrubbing during playback impossible. You would drag the ruler,
+the playhead would move, and about a sixtieth of a second later the next frame would
+arrive and put it straight back. Not a bug in the drag — the drag worked perfectly, sixty
+times a second, and lost every time. So taking hold of the playhead now **stops playback
+first**. Every place that moves the playhead by pointer goes through one function
+(`scrubTo`) that does exactly that, rather than each of them remembering to.
+
+**Stopping puts you back where you started.** Press play, watch ten seconds go by, press
+stop — and the playhead returns to the frame you were on when you pressed play. This is
+what playback is *for*: you are looking at one moment, you want to see it move, and then
+you want to be back at that moment to change something. The alternative — being left
+wherever the picture happened to stop — means hunting for your place after every press of
+the space bar. It works the same way when the composition simply runs out, because "where
+am I now" should not depend on why it stopped. The one exception is the scrub above: that
+gesture stops playback *in order to* go somewhere else, so putting the playhead back would
+undo the very thing you did. If you preferred the old way, Settings ▸ Interface ▸ Editing
+has a tick box.
+
+**Markers are labelled flags on the ruler.** A marker is just a moment with a name on it —
+the drop of a track, the frame a door closes, wherever you want to be able to get back to.
+Lumit has had them in the document for a long time; what it did not have was a way to
+touch them. Now they draw as small bookmark-shaped flags in the lower row of the time
+ruler, and you can drag one along, right-click it to change what it says, or delete it.
+
+The keyboard is where they earn their keep. **Ctrl and a digit** puts a marker with that
+number at the playhead; **the digit on its own** jumps back to it. Press `Ctrl+1` again
+somewhere else and marker 1 *moves* — a number names one place, so there is never a second
+marker 1 for the plain `1` to have to choose between. `Shift+M` drops an unnumbered one.
+(Why not plain `M`, which is what Premiere and Vegas use? Because `M` reveals a layer's
+masks in the Timeline, and that is a much older reflex to break.)
+
 ## 10. The app icon and the brand files
 
 The icon you see in the taskbar is not one picture — it is a small bag of

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5460,6 +5460,20 @@ Two markers can never sit on the same frame. Drop one where another already is �
 keyboard or by dragging — and the newcomer takes its place. Two flags on one moment would
 be two things to click and one place, and the second would hide the first exactly.
 
+**Markers on a layer.** A layer can carry markers of its own, drawn on its bar rather than
+on the ruler, and they slide along with the layer when you move it. There are two ways a
+layer gets them. Drop a composition into another composition and that comp's markers come
+along for the ride — a comp placed in a comp is a piece of material, and its beats are part
+of what you are placing. Or pre-compose a selection, in which case the *opposite* happens:
+the markers go into the new composition, and the Precomp layer is left bare, because those
+cues are already on the ruler right above it and showing them twice is just clutter.
+
+The important word is **copy**. A layer's markers are the layer's, not a live window onto
+the composition they came from. Delete one on a layer and it is gone from that layer only —
+the composition still has it, and so does every other place that composition is used. The
+alternative sounds tidier until you try it: a right-click on one row silently editing a
+different composition is the kind of surprise that makes people stop trusting a menu.
+
 **A note on cost, because it is the reason this feels smooth.** Two habits keep markers
 cheap. First, the list is *remembered*: asking the engine for a comp's markers is a trip
 across the Rust/Flutter boundary, and the ruler redraws sixty times a second while playback

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -260,6 +260,14 @@ colour individually; only the two Timeline tokens default from the mode.
     shared engine (audio device, render worker) across test *files*. Give those
     files a serial marker or make the engine per-file - the serial run is a
     mitigation, not the fix, and it costs wall-clock.
+- **`set_markers` flattens every marker to `MarkerKind::User`** - so dragging or
+    renaming one on the ruler turns detected beats into ordinary cues and *Clear
+    beat markers* stops finding them (`crates/lumit-bridge/src/api/composition.rs`).
+    Carry the kind across the bridge (`BridgeMarker`) and map it back. Pre-dates
+    K-254's ruler markers, which made it far easier to hit.
+- **Beat tap has no key left** - [07-UI-SPEC.md](07-UI-SPEC.md) §10 wants `8`
+    during playback to tap a beat, and K-254 gave the bare digits to the numbered
+    markers. Needs its own chord or a modal reading.
 - **The magnet snaps keyframes to frames and nothing else**
     ([07-UI-SPEC.md](07-UI-SPEC.md) §4.5 wants edit points, in/out points,
     markers, beat markers, the playhead and work-area edges, plus `Ctrl`-hold to

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -533,9 +533,19 @@ class LumitUiState extends ChangeNotifier {
             start: comp.frameAtTime(time: set.inPoint),
             end: comp.frameAtTime(time: set.outPoint)
           );
+    _playedFrom = playheadFrame.value;
     _playFrom(comp, playheadFrame.value);
     playing.value = true;
   }
+
+  /// Where the playhead stood when [play] was called, so stopping can put it
+  /// back (K-254). Null when nothing is playing.
+  ///
+  /// Held here rather than read off the comp because it is a fact about *this
+  /// run of the transport*, not about the document: it must survive the frames
+  /// arriving and moving the playhead, and it must be forgotten the moment
+  /// playback ends however it ends.
+  int? _playedFrom;
 
   /// The work area playback loops round, or null when the comp has not been
   /// narrowed — in which case playback ends at the end, as it always did.
@@ -549,10 +559,35 @@ class LumitUiState extends ChangeNotifier {
             : BridgePlaybackMode.everyFrame,
       );
 
-  void stopPlayback() {
+  /// Stop the transport, and — unless the user is taking hold of the playhead
+  /// themselves — put the playhead back where play started (K-254).
+  ///
+  /// Returning is the default because playback is a *preview*: you park the
+  /// playhead where you are working, watch it run, and expect to still be where
+  /// you were when it stops. Somebody who wants the playhead to stay where the
+  /// picture stopped ticks Settings ▸ Interface ▸ Editing.
+  ///
+  /// `restorePlayhead: false` is for the one case where returning would fight
+  /// the user: scrubbing the ruler stops playback *in order to* move the
+  /// playhead, so putting it back would undo the very gesture that stopped it.
+  void stopPlayback({bool restorePlayhead = true}) {
     playing.value = false;
     _loop = null;
     selectedComp?.stopPlayback();
+    _returnPlayhead(restore: restorePlayhead);
+  }
+
+  /// The half of stopping that moves the playhead — shared by the user's stop
+  /// and by playback running off the end on its own, because "where am I when
+  /// it stops" should not depend on *why* it stopped.
+  void _returnPlayhead({bool restore = true}) {
+    final from = _playedFrom;
+    _playedFrom = null;
+    if (!restore || from == null) return;
+    if (workspace.interface.playheadStaysOnStop) return;
+    // Setting the notifier is the whole of it: the Viewer listens and asks the
+    // engine for the frame there, exactly as it does for any other move.
+    playheadFrame.value = from;
   }
 
   /// Ask for the frame under the playhead as the document now stands.
@@ -598,6 +633,20 @@ class LumitUiState extends ChangeNotifier {
       playheadFrame.value = loop.start;
       _playFrom(comp, loop.start);
     }
+  }
+
+  /// Move the playhead because the user is taking hold of it — a drag on the
+  /// time ruler, a click in the lane area (K-254).
+  ///
+  /// Different from setting [playheadFrame] directly in one way that matters:
+  /// it **stops the transport first**. Scrubbing against running playback was
+  /// unwinnable — the engine hands back a frame every tick and each one moved
+  /// the playhead straight back off the pointer — so taking hold of it means
+  /// taking it off the transport. The playhead does *not* return to where play
+  /// started here: the point of the gesture is to end up somewhere else.
+  void scrubTo(int frame) {
+    if (playing.value) stopPlayback(restorePlayhead: false);
+    playheadFrame.value = frame;
   }
 
   /// Move the playhead by `delta` frames, clamped to the fronted composition.
@@ -921,6 +970,10 @@ class LumitUiState extends ChangeNotifier {
         // needs no message — `stopPlayback` already set the flag.
         case WorkerResponse_PlaybackEnded():
           playing.value = false;
+          // Running off the end returns the playhead too (K-254): where you are
+          // when the transport stops should not depend on whether you stopped
+          // it or the composition ran out.
+          _returnPlayhead();
         case WorkerResponse_CacheFilled():
           cacheChanged.value++;
         // The pixels under the dropper. Held rather than acted on: the
@@ -1521,6 +1574,42 @@ class _LumitAppViewState extends State<LumitAppView> {
             ),
           );
           state.notifyDocumentChanged();
+        }
+      // Markers (K-254). `Shift+M` (or AE's numpad `*`) drops a plain cue at
+      // the playhead; `Ctrl`+digit sets the numbered one and the bare digit
+      // returns to it. The numbered pair is the whole point — the key that
+      // marks a moment is the key that goes back to it.
+      case 'marker.add':
+        if (comp == null) {
+          handled = false;
+        } else {
+          addMarkerFrb(comp, frame: ui.playheadFrame.value);
+          state.notifyDocumentChanged();
+        }
+      case final id when id.startsWith('marker.add.'):
+        if (comp == null) {
+          handled = false;
+        } else {
+          addMarkerFrb(
+            comp,
+            frame: ui.playheadFrame.value,
+            label: id.substring('marker.add.'.length),
+          );
+          state.notifyDocumentChanged();
+        }
+      case final id when id.startsWith('marker.goto.'):
+        // Nothing bound to that digit yet is not a failure to report — it is a
+        // key that has not been given a meaning. Left unhandled so it still
+        // reaches whatever else wants it.
+        final at = comp == null
+            ? null
+            : markerFrameFrb(comp, id.substring('marker.goto.'.length));
+        if (at == null) {
+          handled = false;
+        } else {
+          // Through the scrub, so a digit pressed mid-playback lands where it
+          // says rather than being overwritten by the next frame that arrives.
+          ui.scrubTo(at);
         }
       case 'edit.delete.selection':
         // A panel holding a finer selection than the layer one gets the key

--- a/flutter_ui/lib/panels/timeline_extras_frb.dart
+++ b/flutter_ui/lib/panels/timeline_extras_frb.dart
@@ -1060,7 +1060,10 @@ class _TimelineRulerState extends State<TimelineRuler> {
                 // where, and a shape hung off to one side reads as marking the
                 // frame next door.
                 left: axis.xOf(_markerFrame(marker)) - MarkerFlag.width / 2,
-                bottom: 2,
+                // On the floor of the ruler, where the work-area band ends —
+                // markers and the band share the lower row, and a flag lifted
+                // off the edge read as floating over the lanes below.
+                bottom: 0,
                 child: MouseRegion(
                   cursor: SystemMouseCursors.click,
                   child: GestureDetector(
@@ -1144,31 +1147,38 @@ class MarkerFlag extends StatelessWidget {
     final flag = SizedBox(
       width: width,
       height: height,
-      child: CustomPaint(painter: _MarkerFlagPainter(fill: fill)),
+      child: CustomPaint(painter: _MarkerFlagPainter(fill: fill, edge: ink)),
     );
     if (label.isEmpty) return flag;
     return LumitTooltip(
       message: label,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
+      child: Stack(
+        alignment: Alignment.bottomLeft,
         children: [
-          flag,
-          // Flush against the flag, and only as tall as the flag's square
-          // part, so the pair reads as one object rather than a flag with a
-          // caption floating near it.
-          Container(
-            height: height * (1 - _pointDepth) + 2,
-            padding: const EdgeInsets.symmetric(horizontal: 3),
-            alignment: Alignment.center,
-            color: fill,
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: text.copyWith(color: ink, height: 1),
+          // The label flies from the point, not from the flag's right edge —
+          // the pole is the marker's centre line and the cloth hangs off it,
+          // which is what makes a long comment read as belonging to *this*
+          // moment rather than as a bar starting somewhere to its right.
+          Padding(
+            padding: const EdgeInsets.only(left: width / 2),
+            child: Container(
+              height: height,
+              padding: const EdgeInsets.only(left: width / 2 + 2, right: 3),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: fill,
+                border: Border.all(color: ink, width: 1),
+              ),
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: text.copyWith(color: ink, height: 1),
+              ),
             ),
           ),
+          // Over the cloth, so the point stays the shape you aim at.
+          flag,
         ],
       ),
     );
@@ -1177,27 +1187,42 @@ class MarkerFlag extends StatelessWidget {
 
 class _MarkerFlagPainter extends CustomPainter {
   final Color fill;
-  const _MarkerFlagPainter({required this.fill});
+
+  /// The hairline round the shape. Without it a pale flag sitting on the pale
+  /// work-area band lost its silhouette, and the point — the part that says
+  /// which frame — was the first thing to go.
+  final Color edge;
+  const _MarkerFlagPainter({required this.fill, required this.edge});
 
   @override
   void paint(Canvas canvas, Size size) {
     // A point at the top opening out to shoulders, then square to the bottom:
     // the shape hangs *from* the frame it marks.
     final shoulder = size.height * MarkerFlag._pointDepth;
-    canvas.drawPath(
-      Path()
-        ..moveTo(size.width / 2, 0)
-        ..lineTo(size.width, shoulder)
-        ..lineTo(size.width, size.height)
-        ..lineTo(0, size.height)
-        ..lineTo(0, shoulder)
-        ..close(),
-      Paint()..color = fill,
-    );
+    // Inset by half the stroke, so the outline lands inside the box rather
+    // than straddling its edge and going soft on a fractional pixel ratio.
+    const half = 0.5;
+    final path = Path()
+      ..moveTo(size.width / 2, half)
+      ..lineTo(size.width - half, shoulder)
+      ..lineTo(size.width - half, size.height - half)
+      ..lineTo(half, size.height - half)
+      ..lineTo(half, shoulder)
+      ..close();
+    canvas
+      ..drawPath(path, Paint()..color = fill)
+      ..drawPath(
+        path,
+        Paint()
+          ..color = edge
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1,
+      );
   }
 
   @override
-  bool shouldRepaint(_MarkerFlagPainter old) => old.fill != fill;
+  bool shouldRepaint(_MarkerFlagPainter old) =>
+      old.fill != fill || old.edge != edge;
 }
 
 /// Ask for what a marker says. Returns the new label, or null when the user

--- a/flutter_ui/lib/panels/timeline_extras_frb.dart
+++ b/flutter_ui/lib/panels/timeline_extras_frb.dart
@@ -480,7 +480,7 @@ class _MarkerEditorState extends State<_MarkerEditor> {
   @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
-    final markers = widget.comp.getMarkers();
+    final markers = markersOf(widget.comp);
 
     return FloatSurface(
       width: 340,
@@ -516,12 +516,10 @@ class _MarkerEditorState extends State<_MarkerEditor> {
                     small: true,
                     frameless: true,
                     onPressed: () {
-                      widget.comp.setMarkers(
-                        markers: [
-                          for (final m in markers)
-                            if (m.id != marker.id) m,
-                        ],
-                      );
+                      writeMarkers(widget.comp, [
+                        for (final m in markers)
+                          if (m.id != marker.id) m,
+                      ]);
                       setState(() {});
                     },
                     child:
@@ -552,17 +550,8 @@ class _MarkerEditorState extends State<_MarkerEditor> {
                   key: const ValueKey('marker-add'),
                   small: true,
                   onPressed: () {
-                    widget.comp.setMarkers(
-                      markers: [
-                        ...markers,
-                        BridgeMarker(
-                          id: UuidValue.fromString(const Uuid().v4()),
-                          time: widget.comp
-                              .timeOfFrame(frame: widget.playheadFrame),
-                          label: _label.text,
-                        ),
-                      ],
-                    );
+                    addMarkerFrb(widget.comp,
+                        frame: widget.playheadFrame, label: _label.text);
                     _label.clear();
                     setState(() {});
                   },
@@ -834,31 +823,44 @@ class _TimelineRulerState extends State<TimelineRuler> {
           ? _dragMarkerFrame!
           : frameAtTime(widget.comp, marker.time);
 
+  /// The last frame of the comp, read once when a drag starts. Asking per
+  /// pointer move was a bridge call per pixel of travel.
+  int _dragMarkerLast = 0;
+
   /// Write a whole marker list and tell the panel. Every marker edit on the
   /// ruler goes through here, so there is one place that knows a marker change
   /// is a document change.
   void _writeMarkers(List<BridgeMarker> markers) {
-    widget.comp.setMarkers(markers: markers);
+    writeMarkers(widget.comp, markers);
     widget.onMarkersChanged?.call();
     if (mounted) setState(() {});
   }
 
-  /// Drag a marker to `frame`, committing only when the drag actually crosses
-  /// one — a pointer emits many moves per frame of travel and each commit is a
-  /// document write.
-  void _dragMarkerTo(BridgeMarker marker, int frame) {
-    final comp = widget.comp;
-    final last = comp.durationFrames() - 1;
-    final to = frame.clamp(0, last < 0 ? 0 : last);
+  /// Follow the pointer. **Nothing is written while the button is down**: the
+  /// flag draws from [_dragMarkerFrame] and the document hears about the move
+  /// once, on release. Committing per frame crossed — the way the work-area
+  /// edges do — cost a document write, a cache flush and a panel rebuild for
+  /// every frame of travel, which is what made the drag feel heavy. A
+  /// work-area edge can afford it because the Viewer preview range changes as
+  /// it moves; a marker has nothing to show until it lands.
+  void _dragMarkerTo(int frame) {
+    final to = frame.clamp(0, _dragMarkerLast < 0 ? 0 : _dragMarkerLast);
     if (to == _dragMarkerFrame) return;
     setState(() => _dragMarkerFrame = to);
-    _writeMarkers([
-      for (final m in comp.getMarkers())
-        if (m.id == marker.id)
-          BridgeMarker(id: m.id, time: timeOfFrame(comp, to), label: m.label)
-        else
-          m,
-    ]);
+  }
+
+  /// The drag ended: write where the flag has been sitting, once.
+  void _dropMarker(BridgeMarker marker) {
+    final to = _dragMarkerFrame;
+    setState(() {
+      _dragMarker = null;
+      _dragMarkerFrame = null;
+    });
+    if (to == null) return;
+    // The same placement rule adding a marker follows, so a flag dropped onto
+    // another behaves exactly as `Ctrl`+digit aimed at an occupied frame does.
+    _writeMarkers(markersWithFrb(widget.comp,
+        frame: to, label: marker.label, id: marker.id));
   }
 
   /// The right-click menu on a flag: change what it says, or take it away.
@@ -885,7 +887,7 @@ class _TimelineRulerState extends State<TimelineRuler> {
                 onPressed: () {
                   close(null);
                   _writeMarkers([
-                    for (final m in widget.comp.getMarkers())
+                    for (final m in markersOf(widget.comp))
                       if (m.id != marker.id) m,
                   ]);
                 },
@@ -903,7 +905,7 @@ class _TimelineRulerState extends State<TimelineRuler> {
         await showMarkerLabelDialogFrb(context: context, initial: marker.label);
     if (label == null || !mounted) return;
     _writeMarkers([
-      for (final m in widget.comp.getMarkers())
+      for (final m in markersOf(widget.comp))
         if (m.id == marker.id)
           BridgeMarker(id: m.id, time: m.time, label: label)
         else
@@ -933,7 +935,7 @@ class _TimelineRulerState extends State<TimelineRuler> {
     final comp = widget.comp;
     final axis = widget.axis;
     final work = _work;
-    final markers = comp.getMarkers();
+    final markers = markersOf(comp);
 
     return GestureDetector(
       key: const ValueKey('tl-ruler'),
@@ -1053,7 +1055,11 @@ class _TimelineRulerState extends State<TimelineRuler> {
             // edge could not be picked up at all.
             for (final marker in markers)
               Positioned(
-                left: axis.xOf(_markerFrame(marker)),
+                // Centred on the frame, so the flag's point sits *on* the
+                // playhead rather than beside it — the point is what says
+                // where, and a shape hung off to one side reads as marking the
+                // frame next door.
+                left: axis.xOf(_markerFrame(marker)) - MarkerFlag.width / 2,
                 bottom: 2,
                 child: MouseRegion(
                   cursor: SystemMouseCursors.click,
@@ -1065,26 +1071,26 @@ class _TimelineRulerState extends State<TimelineRuler> {
                     onHorizontalDragStart: (d) => setState(() {
                       _dragMarker = marker.id;
                       _dragMarkerFrame = null;
-                      _dragMarkerGrab = d.localPosition.dx;
+                      // Measured from the point, not the flag's left edge,
+                      // because the point is what the frame means.
+                      _dragMarkerGrab =
+                          d.localPosition.dx - MarkerFlag.width / 2;
+                      _dragMarkerLast = comp.durationFrames() - 1;
                     }),
-                    onHorizontalDragUpdate: (d) => _dragMarkerTo(
-                        marker,
-                        axis.frameAt(d.globalPosition.dx -
+                    onHorizontalDragUpdate: (d) => _dragMarkerTo(axis.frameAt(
+                        d.globalPosition.dx -
                             _originX(context) -
                             _dragMarkerGrab)),
-                    onHorizontalDragEnd: (_) => setState(() {
-                      _dragMarker = null;
-                      _dragMarkerFrame = null;
-                    }),
+                    onHorizontalDragEnd: (_) => _dropMarker(marker),
                     onHorizontalDragCancel: () => setState(() {
                       _dragMarker = null;
                       _dragMarkerFrame = null;
                     }),
                     child: MarkerFlag(
                       label: marker.label,
-                      fill: t.warning,
+                      fill: t.marker,
                       ink: t.surface0,
-                      text: t.small,
+                      text: t.caption.copyWith(fontWeight: FontWeight.w400),
                     ),
                   ),
                 ),
@@ -1100,25 +1106,30 @@ class _TimelineRulerState extends State<TimelineRuler> {
 /// handle is catchable without the mark being heavy.
 const double _workHandleWidth = 10;
 
-/// A comp marker on the time ruler: After Effects' bookmark flag — a small
-/// square with its bottom corners cut away to a point, its **left edge** on the
-/// moment it marks (docs/07 §4.1, K-254).
+/// A comp marker on the time ruler: a small flag with its **point at the top**,
+/// centred on the moment it marks, and what it says in a box hung off its right
+/// (docs/07 §4.1, K-254).
 ///
-/// A short label (the numbered markers, `1`–`0`) is drawn inside the flag, the
-/// way every editor shows a numbered cue. Anything longer sits beside it:
-/// a flag stretched to fit a sentence stops reading as a point in time.
+/// The point is the whole of the design. It is what carries the meaning — this
+/// frame, not the one next door — so it sits on the playhead and the body of
+/// the flag hangs below it, out of the way of the ticks. The label rides in a
+/// box of the same colour rather than as loose text over the ruler, where it
+/// crossed the ticks and the work-area band and read as neither.
 class MarkerFlag extends StatelessWidget {
   final String label;
   final Color fill;
 
-  /// What is drawn *on* the flag — the darkest surface, so a number reads as
-  /// cut out of the flag rather than printed over it. The same trick the
-  /// playhead's notch uses.
+  /// What is drawn *on* the flag and in its label box — the darkest surface, so
+  /// the writing reads as cut out of the marker rather than printed over it.
+  /// The same trick the playhead's notch uses.
   final Color ink;
   final TextStyle text;
 
   static const double width = 11;
   static const double height = 12;
+
+  /// How far down the point reaches before the flag squares off.
+  static const double _pointDepth = 0.42;
 
   const MarkerFlag({
     super.key,
@@ -1128,36 +1139,36 @@ class MarkerFlag extends StatelessWidget {
     required this.text,
   });
 
-  bool get _inside => label.isNotEmpty && label.length <= 2;
-
   @override
   Widget build(BuildContext context) {
     final flag = SizedBox(
       width: width,
       height: height,
-      child: CustomPaint(
-        painter: _MarkerFlagPainter(fill: fill),
-        child: _inside
-            ? Center(
-                child: Text(
-                  label,
-                  style: text.copyWith(color: ink, fontSize: 8, height: 1),
-                ),
-              )
-            : null,
-      ),
+      child: CustomPaint(painter: _MarkerFlagPainter(fill: fill)),
     );
-    if (label.isEmpty || _inside) {
-      return label.isEmpty ? flag : LumitTooltip(message: label, child: flag);
-    }
+    if (label.isEmpty) return flag;
     return LumitTooltip(
       message: label,
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           flag,
-          const SizedBox(width: 3),
-          Text(label, style: text.copyWith(color: fill)),
+          // Flush against the flag, and only as tall as the flag's square
+          // part, so the pair reads as one object rather than a flag with a
+          // caption floating near it.
+          Container(
+            height: height * (1 - _pointDepth) + 2,
+            padding: const EdgeInsets.symmetric(horizontal: 3),
+            alignment: Alignment.center,
+            color: fill,
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: text.copyWith(color: ink, height: 1),
+            ),
+          ),
         ],
       ),
     );
@@ -1170,15 +1181,15 @@ class _MarkerFlagPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // Square down to the shoulders, then in to a point — the bookmark notch
-    // inverted, which is the shape every editor has settled on for a cue.
-    final shoulder = size.height * 0.6;
+    // A point at the top opening out to shoulders, then square to the bottom:
+    // the shape hangs *from* the frame it marks.
+    final shoulder = size.height * MarkerFlag._pointDepth;
     canvas.drawPath(
       Path()
-        ..moveTo(0, 0)
-        ..lineTo(size.width, 0)
+        ..moveTo(size.width / 2, 0)
         ..lineTo(size.width, shoulder)
-        ..lineTo(size.width / 2, size.height)
+        ..lineTo(size.width, size.height)
+        ..lineTo(0, size.height)
         ..lineTo(0, shoulder)
         ..close(),
       Paint()..color = fill,
@@ -1272,34 +1283,62 @@ class _MarkerLabelDialogState extends State<_MarkerLabelDialog> {
   }
 }
 
-/// Put a marker labelled [label] at [frame], replacing any marker already
-/// carrying that label (K-254).
+/// Put a marker labelled [label] at [frame], replacing anything already on that
+/// frame and any marker already carrying that label (K-254).
 ///
-/// Replacing rather than adding is what makes the numbered markers work: `1`
-/// has to name one place, so `Ctrl+1` pressed again *moves* marker 1 instead of
-/// leaving two for the bare `1` to choose between. An empty label replaces
-/// nothing — unlabelled cues are dropped as freely as you like.
+/// Two replacement rules, each for its own reason. **One per frame**, because
+/// markers do not stack: two flags on the same moment are two things to click
+/// and one place, and the second would hide the first exactly. **One per
+/// number**, because `1` has to name one place — `Ctrl+1` pressed again *moves*
+/// marker 1 rather than leaving two for the bare `1` to choose between. An
+/// empty label never replaces by label; unlabelled cues are told apart by where
+/// they are, which the frame rule already keeps distinct.
 void addMarkerFrb(
   CompositionReference comp, {
   required int frame,
   String label = '',
-}) {
-  comp.setMarkers(markers: [
-    for (final m in comp.getMarkers())
-      if (label.isEmpty || m.label != label) m,
-    BridgeMarker(
-      id: UuidValue.fromString(const Uuid().v4()),
-      time: timeOfFrame(comp, frame),
-      label: label,
-    ),
-  ]);
-}
+}) =>
+    writeMarkers(comp, markersWithFrb(comp, frame: frame, label: label));
+
+/// [comp]'s marker list with one marker placed at [frame] — the shared
+/// placement rule, used both when a marker is added and when one is dragged
+/// onto a new moment (K-254).
+///
+/// Two things give way to the newcomer. **Whatever is already on that frame**,
+/// because markers do not stack: two flags on one moment are two things to
+/// click and one place, and the second hides the first exactly. **Whatever
+/// else carries the same label**, when the label is not empty, because `1` has
+/// to name one place — `Ctrl+1` pressed again *moves* marker 1 rather than
+/// leaving two for the bare `1` to choose between. Unlabelled cues are told
+/// apart by where they are, which the frame rule already keeps distinct.
+///
+/// [id] is the marker being *moved*, if this is a move; it keeps its identity
+/// rather than being deleted and made again, so undo and selection see one
+/// marker that travelled.
+List<BridgeMarker> markersWithFrb(
+  CompositionReference comp, {
+  required int frame,
+  required String label,
+  UuidValue? id,
+}) =>
+    [
+      for (final m in markersOf(comp))
+        if (m.id != id &&
+            frameAtTime(comp, m.time) != frame &&
+            (label.isEmpty || m.label != label))
+          m,
+      BridgeMarker(
+        id: id ?? UuidValue.fromString(const Uuid().v4()),
+        time: timeOfFrame(comp, frame),
+        label: label,
+      ),
+    ];
 
 /// The frame of the marker labelled [label], or null when there is none — what
 /// the bare digit keys jump to, and what makes them a quiet no-op until the
 /// matching `Ctrl`+digit has been pressed.
 int? markerFrameFrb(CompositionReference comp, String label) {
-  for (final m in comp.getMarkers()) {
+  for (final m in markersOf(comp)) {
     if (m.label == label) return frameAtTime(comp, m.time);
   }
   return null;

--- a/flutter_ui/lib/panels/timeline_extras_frb.dart
+++ b/flutter_ui/lib/panels/timeline_extras_frb.dart
@@ -785,6 +785,11 @@ class TimelineRuler extends StatefulWidget {
   /// is a per-rebuild cost on a panel that rebuilds a lot (docs/13).
   final ({int start, int end, bool whole}) work;
 
+  /// A marker was moved, renamed or removed on the ruler (K-254) — the ruler
+  /// has already written it to the document, and this is the panel being told
+  /// so the rest of it redraws. Null in a ruler with no markers to edit.
+  final VoidCallback? onMarkersChanged;
+
   const TimelineRuler({
     super.key,
     required this.comp,
@@ -794,6 +799,7 @@ class TimelineRuler extends StatefulWidget {
     required this.onSeek,
     required this.work,
     this.onWorkArea,
+    this.onMarkersChanged,
   });
 
   @override
@@ -810,6 +816,100 @@ class _TimelineRulerState extends State<TimelineRuler> {
   /// edge is drawn while the button is down.
   int? _dragFrame;
   bool _dragIsStart = false;
+
+  /// The marker being dragged, and the frame it has reached — the same
+  /// arrangement as the work area's above, for the same reason: a flag that
+  /// waits for the document to come back round visibly trails the pointer.
+  UuidValue? _dragMarker;
+  int? _dragMarkerFrame;
+
+  /// How far into the flag the drag took hold. Without it the flag's left edge
+  /// jumped to the pointer the moment the drag started, which reads as the
+  /// marker flinching away from the grab.
+  double _dragMarkerGrab = 0;
+
+  /// Where a marker draws right now: the document's frame, or the dragged one.
+  int _markerFrame(BridgeMarker marker) =>
+      marker.id == _dragMarker && _dragMarkerFrame != null
+          ? _dragMarkerFrame!
+          : frameAtTime(widget.comp, marker.time);
+
+  /// Write a whole marker list and tell the panel. Every marker edit on the
+  /// ruler goes through here, so there is one place that knows a marker change
+  /// is a document change.
+  void _writeMarkers(List<BridgeMarker> markers) {
+    widget.comp.setMarkers(markers: markers);
+    widget.onMarkersChanged?.call();
+    if (mounted) setState(() {});
+  }
+
+  /// Drag a marker to `frame`, committing only when the drag actually crosses
+  /// one — a pointer emits many moves per frame of travel and each commit is a
+  /// document write.
+  void _dragMarkerTo(BridgeMarker marker, int frame) {
+    final comp = widget.comp;
+    final last = comp.durationFrames() - 1;
+    final to = frame.clamp(0, last < 0 ? 0 : last);
+    if (to == _dragMarkerFrame) return;
+    setState(() => _dragMarkerFrame = to);
+    _writeMarkers([
+      for (final m in comp.getMarkers())
+        if (m.id == marker.id)
+          BridgeMarker(id: m.id, time: timeOfFrame(comp, to), label: m.label)
+        else
+          m,
+    ]);
+  }
+
+  /// The right-click menu on a flag: change what it says, or take it away.
+  void _markerMenu(BuildContext context, BridgeMarker marker, Offset at) {
+    showLumitPopup<void>(
+      context: context,
+      position: at,
+      builder: (close) => FloatSurface(
+        child: IntrinsicWidth(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MenuRow(
+                key: const ValueKey('marker-menu-edit'),
+                onPressed: () {
+                  close(null);
+                  _editMarker(context, marker);
+                },
+                child: const Text('Edit marker…'),
+              ),
+              MenuRow(
+                key: const ValueKey('marker-menu-delete'),
+                onPressed: () {
+                  close(null);
+                  _writeMarkers([
+                    for (final m in widget.comp.getMarkers())
+                      if (m.id != marker.id) m,
+                  ]);
+                },
+                child: const Text('Delete marker'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _editMarker(BuildContext context, BridgeMarker marker) async {
+    final label =
+        await showMarkerLabelDialogFrb(context: context, initial: marker.label);
+    if (label == null || !mounted) return;
+    _writeMarkers([
+      for (final m in widget.comp.getMarkers())
+        if (m.id == marker.id)
+          BridgeMarker(id: m.id, time: m.time, label: label)
+        else
+          m,
+    ]);
+  }
 
   /// The work area as it should draw right now: the panel's, with the edge
   /// being dragged moved to where the pointer is. Each edge stops one frame
@@ -943,20 +1043,48 @@ class _TimelineRulerState extends State<TimelineRuler> {
                     ),
                   ),
                 ),
+            // Comp markers (docs/07 §4.1): After Effects' bookmark flags, in
+            // the ruler's lower row where the work-area band lives. The clock
+            // above stays legible, and a flag never sits on a tick.
+            //
+            // Last in the stack so they take the pointer ahead of the
+            // work-area handles: a flag is the smaller target of the two and
+            // has to win where they overlap, or a marker parked on a work-area
+            // edge could not be picked up at all.
             for (final marker in markers)
               Positioned(
-                left: axis.xOf(frameAtTime(comp, marker.time)) - 3,
-                top: 4,
-                child: IgnorePointer(
-                  child: LumitTooltip(
-                    message: marker.label,
-                    child: Container(
-                      width: 6,
-                      height: 6,
-                      decoration: BoxDecoration(
-                        color: t.warning,
-                        borderRadius: BorderRadius.circular(1),
-                      ),
+                left: axis.xOf(_markerFrame(marker)),
+                bottom: 2,
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  child: GestureDetector(
+                    key: ValueKey<String>('tl-marker-${marker.id}'),
+                    behavior: HitTestBehavior.opaque,
+                    onSecondaryTapUp: (d) =>
+                        _markerMenu(context, marker, d.globalPosition),
+                    onHorizontalDragStart: (d) => setState(() {
+                      _dragMarker = marker.id;
+                      _dragMarkerFrame = null;
+                      _dragMarkerGrab = d.localPosition.dx;
+                    }),
+                    onHorizontalDragUpdate: (d) => _dragMarkerTo(
+                        marker,
+                        axis.frameAt(d.globalPosition.dx -
+                            _originX(context) -
+                            _dragMarkerGrab)),
+                    onHorizontalDragEnd: (_) => setState(() {
+                      _dragMarker = null;
+                      _dragMarkerFrame = null;
+                    }),
+                    onHorizontalDragCancel: () => setState(() {
+                      _dragMarker = null;
+                      _dragMarkerFrame = null;
+                    }),
+                    child: MarkerFlag(
+                      label: marker.label,
+                      fill: t.warning,
+                      ink: t.surface0,
+                      text: t.small,
                     ),
                   ),
                 ),
@@ -971,6 +1099,211 @@ class _TimelineRulerState extends State<TimelineRuler> {
 /// How wide a work-area edge is to grab. Wider than the 2 px it draws, so the
 /// handle is catchable without the mark being heavy.
 const double _workHandleWidth = 10;
+
+/// A comp marker on the time ruler: After Effects' bookmark flag — a small
+/// square with its bottom corners cut away to a point, its **left edge** on the
+/// moment it marks (docs/07 §4.1, K-254).
+///
+/// A short label (the numbered markers, `1`–`0`) is drawn inside the flag, the
+/// way every editor shows a numbered cue. Anything longer sits beside it:
+/// a flag stretched to fit a sentence stops reading as a point in time.
+class MarkerFlag extends StatelessWidget {
+  final String label;
+  final Color fill;
+
+  /// What is drawn *on* the flag — the darkest surface, so a number reads as
+  /// cut out of the flag rather than printed over it. The same trick the
+  /// playhead's notch uses.
+  final Color ink;
+  final TextStyle text;
+
+  static const double width = 11;
+  static const double height = 12;
+
+  const MarkerFlag({
+    super.key,
+    required this.label,
+    required this.fill,
+    required this.ink,
+    required this.text,
+  });
+
+  bool get _inside => label.isNotEmpty && label.length <= 2;
+
+  @override
+  Widget build(BuildContext context) {
+    final flag = SizedBox(
+      width: width,
+      height: height,
+      child: CustomPaint(
+        painter: _MarkerFlagPainter(fill: fill),
+        child: _inside
+            ? Center(
+                child: Text(
+                  label,
+                  style: text.copyWith(color: ink, fontSize: 8, height: 1),
+                ),
+              )
+            : null,
+      ),
+    );
+    if (label.isEmpty || _inside) {
+      return label.isEmpty ? flag : LumitTooltip(message: label, child: flag);
+    }
+    return LumitTooltip(
+      message: label,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          flag,
+          const SizedBox(width: 3),
+          Text(label, style: text.copyWith(color: fill)),
+        ],
+      ),
+    );
+  }
+}
+
+class _MarkerFlagPainter extends CustomPainter {
+  final Color fill;
+  const _MarkerFlagPainter({required this.fill});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Square down to the shoulders, then in to a point — the bookmark notch
+    // inverted, which is the shape every editor has settled on for a cue.
+    final shoulder = size.height * 0.6;
+    canvas.drawPath(
+      Path()
+        ..moveTo(0, 0)
+        ..lineTo(size.width, 0)
+        ..lineTo(size.width, shoulder)
+        ..lineTo(size.width / 2, size.height)
+        ..lineTo(0, shoulder)
+        ..close(),
+      Paint()..color = fill,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_MarkerFlagPainter old) => old.fill != fill;
+}
+
+/// Ask for what a marker says. Returns the new label, or null when the user
+/// cancelled — an empty string is a real answer, being a marker with nothing
+/// written on it.
+Future<String?> showMarkerLabelDialogFrb({
+  required BuildContext context,
+  required String initial,
+}) =>
+    showLumitModal<String>(
+      context: context,
+      initialSize: const Size(320, 150),
+      minSize: const Size(260, 140),
+      builder: (close) => _MarkerLabelDialog(initial: initial, onDone: close),
+    );
+
+class _MarkerLabelDialog extends StatefulWidget {
+  final String initial;
+  final ValueChanged<String?> onDone;
+  const _MarkerLabelDialog({required this.initial, required this.onDone});
+
+  @override
+  State<_MarkerLabelDialog> createState() => _MarkerLabelDialogState();
+}
+
+class _MarkerLabelDialogState extends State<_MarkerLabelDialog> {
+  late final TextEditingController _label =
+      TextEditingController(text: widget.initial);
+
+  @override
+  void dispose() {
+    _label.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    return FloatSurface(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 10, 10, 6),
+            child: Text('Marker', style: t.bodyPrimary),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: HouseTextField(
+              key: const ValueKey('marker-edit-label'),
+              controller: _label,
+              autofocus: true,
+              hint: 'What this marker says',
+              onSubmitted: widget.onDone,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HouseButton(
+                  key: const ValueKey('marker-edit-cancel'),
+                  small: true,
+                  frameless: true,
+                  onPressed: () => widget.onDone(null),
+                  child: Text('Cancel', style: t.small),
+                ),
+                const SizedBox(width: 6),
+                HouseButton(
+                  key: const ValueKey('marker-edit-ok'),
+                  small: true,
+                  onPressed: () => widget.onDone(_label.text),
+                  child: Text('Done', style: t.small),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Put a marker labelled [label] at [frame], replacing any marker already
+/// carrying that label (K-254).
+///
+/// Replacing rather than adding is what makes the numbered markers work: `1`
+/// has to name one place, so `Ctrl+1` pressed again *moves* marker 1 instead of
+/// leaving two for the bare `1` to choose between. An empty label replaces
+/// nothing — unlabelled cues are dropped as freely as you like.
+void addMarkerFrb(
+  CompositionReference comp, {
+  required int frame,
+  String label = '',
+}) {
+  comp.setMarkers(markers: [
+    for (final m in comp.getMarkers())
+      if (label.isEmpty || m.label != label) m,
+    BridgeMarker(
+      id: UuidValue.fromString(const Uuid().v4()),
+      time: timeOfFrame(comp, frame),
+      label: label,
+    ),
+  ]);
+}
+
+/// The frame of the marker labelled [label], or null when there is none — what
+/// the bare digit keys jump to, and what makes them a quiet no-op until the
+/// matching `Ctrl`+digit has been pressed.
+int? markerFrameFrb(CompositionReference comp, String label) {
+  for (final m in comp.getMarkers()) {
+    if (m.label == label) return frameAtTime(comp, m.time);
+  }
+  return null;
+}
 
 /// The playhead: a hairline down the whole area with a head at the top.
 ///

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -4934,6 +4934,14 @@ class _OutlineRowState extends State<_OutlineRow> {
                   onPressed: () => close('delete'),
                   child: const Text('Delete')),
             ],
+            // Only when there is something to clear. A layer carries markers
+            // when a composition was dropped in with some (K-254); most layers
+            // have none and should not be offered a command that does nothing.
+            if (!locked && widget.entry.info.markers.isNotEmpty)
+              MenuRow(
+                  key: const ValueKey('tl-row-clear-markers'),
+                  onPressed: () => close('clear-markers'),
+                  child: const Text('Delete all markers')),
           ],
         ),
       ),
@@ -4947,6 +4955,8 @@ class _OutlineRowState extends State<_OutlineRow> {
         layer.reorder(newIndex: BigInt.from(index + 1));
       case 'delete':
         layer.delete();
+      case 'clear-markers':
+        layer.setMarkers(markers: const []);
       case 'to-sequence':
         layer.convertToSequenced();
       case 'from-sequence':
@@ -6313,9 +6323,105 @@ class _BarState extends State<_Bar> {
               ),
             ),
           ),
+          // The layer's own markers (K-254), over the bar so they take the
+          // pointer ahead of it — a flag is a much smaller target than a bar,
+          // and a right-click meant for one must not open the bar's menu.
+          // They travel with a move, because they are part of the layer.
+          for (final m in info.markers)
+            Positioned(
+              left: widget.axis.xOf(m.frame.toInt() + shift) -
+                  MarkerFlag.width / 2,
+              bottom: 0,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  key: ValueKey<String>('tl-layer-marker-${m.marker.id}'),
+                  behavior: HitTestBehavior.opaque,
+                  onSecondaryTapUp: (d) =>
+                      _markerMenu(context, m.marker, d.globalPosition),
+                  // A left click on a flag is a click on its layer, which is
+                  // what the bar under it would have done.
+                  onTap: widget.onSelect,
+                  child: MarkerFlag(
+                    label: m.marker.label,
+                    fill: t.marker,
+                    ink: t.surface0,
+                    text: t.caption.copyWith(fontWeight: FontWeight.w400),
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );
+  }
+
+  /// The right-click menu on a marker sitting on a layer's bar.
+  ///
+  /// Deleting here touches **this layer's** list and nothing else. A layer's
+  /// markers are its own copy of whatever composition was dropped in, so a
+  /// delete cannot reach into that comp — or into the other places it is used
+  /// (K-254).
+  void _markerMenu(BuildContext context, BridgeMarker marker, Offset at) {
+    showLumitPopup<void>(
+      context: context,
+      position: at,
+      builder: (close) => FloatSurface(
+        child: IntrinsicWidth(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MenuRow(
+                key: const ValueKey('tl-layer-marker-edit'),
+                onPressed: () {
+                  close(null);
+                  _editMarker(context, marker);
+                },
+                child: const Text('Edit marker…'),
+              ),
+              MenuRow(
+                key: const ValueKey('tl-layer-marker-delete'),
+                onPressed: () {
+                  close(null);
+                  _writeMarkers([
+                    for (final m in widget.entry.info.markers)
+                      if (m.marker.id != marker.id) m.marker,
+                  ]);
+                },
+                child: const Text('Delete marker'),
+              ),
+              MenuRow(
+                key: const ValueKey('tl-layer-marker-delete-all'),
+                onPressed: () {
+                  close(null);
+                  _writeMarkers(const []);
+                },
+                child: const Text('Delete all markers'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _editMarker(BuildContext context, BridgeMarker marker) async {
+    final label =
+        await showMarkerLabelDialogFrb(context: context, initial: marker.label);
+    if (label == null || !mounted) return;
+    _writeMarkers([
+      for (final m in widget.entry.info.markers)
+        if (m.marker.id == marker.id)
+          BridgeMarker(id: m.marker.id, time: m.marker.time, label: label)
+        else
+          m.marker,
+    ]);
+  }
+
+  void _writeMarkers(List<BridgeMarker> markers) {
+    widget.entry.layer.setMarkers(markers: markers);
+    widget.onChanged();
   }
 
   /// One end's hover strip: the pointer becomes the horizontal resize arrow

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -1687,9 +1687,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                                     onToggle: _toggle,
                                                     playheadFrame:
                                                         ui.playheadFrame.value,
-                                                    onSeek: (f) => ui
-                                                        .playheadFrame
-                                                        .value = f,
+                                                    onSeek: ui.scrubTo,
                                                     onSelect: (l) =>
                                                         _selectLayer(ui, l,
                                                             among: layers),
@@ -1809,15 +1807,16 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                                                 span: span);
                                                             setState(() {});
                                                           },
-                                                          onSeek: (f) => ui
-                                                                  .playheadFrame
-                                                                  .value =
-                                                              f.clamp(
+                                                          onMarkersChanged:
+                                                              () => setState(
+                                                                  () {}),
+                                                          onSeek: (f) =>
+                                                              ui.scrubTo(f.clamp(
                                                                   0,
                                                                   frames == 0
                                                                       ? 0
                                                                       : frames -
-                                                                          1),
+                                                                          1)),
                                                         ),
                                                         TimelineCacheBar(
                                                           comp: comp,
@@ -2073,12 +2072,11 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                                   onWheel: (e, x) => _wheel(
                                                       e, x, axis.perFrame),
                                                   onSeek: (f) =>
-                                                      ui.playheadFrame.value =
-                                                          f.clamp(
-                                                              0,
-                                                              frames == 0
-                                                                  ? 0
-                                                                  : frames - 1),
+                                                      ui.scrubTo(f.clamp(
+                                                          0,
+                                                          frames == 0
+                                                              ? 0
+                                                              : frames - 1)),
                                                   onSelect: (l) =>
                                                       _selectLayer(ui, l,
                                                           among: layers),
@@ -5188,6 +5186,7 @@ class _LayerArea extends StatelessWidget {
                 comp.setWorkArea(span: span);
                 onChanged();
               },
+              onMarkersChanged: onChanged,
             ),
             // Directly under the ruler and above the lanes, which is where the
             // interface spec puts it (docs/07 §3.2).

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -30,8 +30,8 @@ import 'package:provider/provider.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
 import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
-import 'package:uuid/uuid.dart';
 
+import '../panels/timeline_extras_frb.dart';
 import '../state/dock.dart';
 import '../state/file_dialogs.dart';
 import '../state/keymap.dart';
@@ -740,17 +740,11 @@ void _splitAtPlayhead(LumitUiState ui) {
   } catch (_) {}
 }
 
-void _markerAtPlayhead(LumitUiState ui, CompositionReference comp) {
-  final frame = ui.playheadFrame.value;
-  comp.setMarkers(markers: [
-    ...comp.getMarkers(),
-    BridgeMarker(
-      id: UuidValue.fromString(const Uuid().v4()),
-      time: comp.timeOfFrame(frame: frame),
-      label: '',
-    ),
-  ]);
-}
+/// The menu's *Add marker* — the same call the keyboard makes, so the two
+/// cannot drift into different ideas of what dropping a marker means (the
+/// one-per-frame rule included).
+void _markerAtPlayhead(LumitUiState ui, CompositionReference comp) =>
+    addMarkerFrb(comp, frame: ui.playheadFrame.value);
 
 Future<void> _compSettings(BuildContext context, LumitState app) async {
   final comp = context.read<LumitUiState>().selectedComp;

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -386,10 +386,13 @@ class _SettingsWindowState extends State<_SettingsWindow> {
           ),
         ),
       ]),
-      // The two the first-run screen sets (K-246). They sit here as ordinary
-      // rows, and independently of each other: the screen offers them as a
-      // pair, but somebody who wants Vegas ramps and After Effects imports is
-      // exactly the split docs/07 §13.1 expects to be common.
+      // The two the first-run screen sets (K-246), plus the transport's one
+      // (K-254). They sit here as ordinary rows, and independently of each
+      // other: the screen offers its pair together, but somebody who wants
+      // Vegas ramps and After Effects imports is exactly the split docs/07
+      // §13.1 expects to be common. The playhead row is not one the screen
+      // touches — both answers want the returning playhead, so there is
+      // nothing for the question to decide.
       _section(t, 'Editing', [
         _row(
           t,
@@ -417,6 +420,22 @@ class _SettingsWindowState extends State<_SettingsWindow> {
             value: settings.videoAsSequenceLayer,
             onChanged: (on) => setState(() {
               settings.videoAsSequenceLayer = on;
+              ui.workspace.settingsChanged();
+            }),
+          ),
+        ),
+        _row(
+          t,
+          'Playhead stays where playback stopped',
+          'Leave the playhead on the frame that was on screen when playback '
+              'stopped, instead of putting it back where playing started. '
+              'Dragging the ruler while playing always stops and follows the '
+              'pointer, whichever way this is set.',
+          HouseCheckbox(
+            key: const ValueKey('settings-playhead-stays'),
+            value: settings.playheadStaysOnStop,
+            onChanged: (on) => setState(() {
+              settings.playheadStaysOnStop = on;
               ui.workspace.settingsChanged();
             }),
           ),

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -13,7 +13,7 @@ import 'layer.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:uuid/uuid.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_at_top`, `commit`, `composition`, `dispatch`, `document`, `footage_span_and_size`, `project`, `runs_as_video`, `to_engine`
+// These functions are ignored because they are not marked as `pub`: `add_at_top`, `bridge_marker`, `commit`, `composition`, `core_marker`, `dispatch`, `document`, `footage_span_and_size`, `project`, `runs_as_video`, `to_engine`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `id`, `new`, `project_id`
 

--- a/flutter_ui/lib/src/rust/api/layer.dart
+++ b/flutter_ui/lib/src/rust/api/layer.dart
@@ -18,7 +18,7 @@ import 'solid.dart';
 import 'state.dart';
 
 // These functions are ignored because they are not marked as `pub`: `clip_under`, `clips_and_index`, `commit_clips_with_offset`, `commit_clips`, `commit_masks`, `commit_paint`, `commit`, `comp_time`, `composition`, `core`, `item`, `map_end_value`, `project`, `rational_of`, `read_at`, `read_layer_info`, `read`, `read`, `read`, `reanchored_span`, `source_length`, `unretime_op`, `with_effects`, `write_at`, `write_item`, `write`, `write`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `comp_id`, `id`, `new`, `project_id`
 
 /// A footage layer's waveform peaks: the whole source bucketed to a fixed
@@ -194,6 +194,12 @@ class BridgeLayerInfo {
   /// layer's size, so the Viewer's wireframe reads it here.
   final List<BridgeShapeItem> shapeContents;
 
+  /// The layer's own markers (K-254), and the frame each falls on so the bar
+  /// needs no time↔frame trip to draw one. In the read model because the
+  /// Timeline draws them on every rebuild, which is the cost K-184 exists to
+  /// remove.
+  final List<BridgeLayerMarker> markers;
+
   const BridgeLayerInfo({
     required this.name,
     required this.kind,
@@ -214,6 +220,7 @@ class BridgeLayerInfo {
     required this.masks,
     required this.paint,
     required this.shapeContents,
+    required this.markers,
   });
 
   @override
@@ -236,7 +243,8 @@ class BridgeLayerInfo {
       retime.hashCode ^
       masks.hashCode ^
       paint.hashCode ^
-      shapeContents.hashCode;
+      shapeContents.hashCode ^
+      markers.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -261,7 +269,8 @@ class BridgeLayerInfo {
           retime == other.retime &&
           masks == other.masks &&
           paint == other.paint &&
-          shapeContents == other.shapeContents;
+          shapeContents == other.shapeContents &&
+          markers == other.markers;
 }
 
 /// What kind of source a layer has — what the Timeline draws its bar and its
@@ -285,6 +294,29 @@ enum BridgeLayerKind {
   /// is a Dart reserved word (K-206); `lumit-core` keeps `LayerKind::Null`.
   nullLayer,
   ;
+}
+
+/// One marker on a layer's bar: the marker itself plus where it lands at the
+/// comp's rate, worked out here so drawing costs nothing across the seam.
+class BridgeLayerMarker {
+  final BridgeMarker marker;
+  final PlatformInt64 frame;
+
+  const BridgeLayerMarker({
+    required this.marker,
+    required this.frame,
+  });
+
+  @override
+  int get hashCode => marker.hashCode ^ frame.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BridgeLayerMarker &&
+          runtimeType == other.runtimeType &&
+          marker == other.marker &&
+          frame == other.frame;
 }
 
 /// Which switch an edit names. One enum rather than eight methods so the
@@ -1076,6 +1108,17 @@ class LayerReference {
         that: this,
       );
 
+  /// This layer's own markers (docs/03 §11), drawn on its bar rather than on
+  /// the comp's ruler.
+  ///
+  /// The layer's, not the source composition's: a comp dropped into another
+  /// brings a **copy** along, and from then on the two lists are unrelated
+  /// (K-254). Deleting one here never reaches into another composition.
+  List<BridgeMarker> getMarkers() =>
+      BridgeLib.instance.api.crateApiLayerLayerReferenceGetMarkers(
+        that: this,
+      );
+
   /// This layer's masks, bottom of the stack first (K-222).
   ///
   /// Empty on a layer with none, which is most layers — the Timeline asks
@@ -1334,6 +1377,12 @@ class LayerReference {
 
   void setLabel({required int label}) => BridgeLib.instance.api
       .crateApiLayerLayerReferenceSetLabel(that: this, label: label);
+
+  /// Replace this layer's whole marker list — one op, trivially invertible,
+  /// the same shape as the composition's.
+  void setMarkers({required List<BridgeMarker> markers}) =>
+      BridgeLib.instance.api
+          .crateApiLayerLayerReferenceSetMarkers(that: this, markers: markers);
 
   /// Replace one mask — its path, its name, its invert switch, its opacity.
   /// Named by id, so a stale reference is a calm error rather than an edit

--- a/flutter_ui/lib/src/rust/api/layer.dart
+++ b/flutter_ui/lib/src/rust/api/layer.dart
@@ -194,10 +194,11 @@ class BridgeLayerInfo {
   /// layer's size, so the Viewer's wireframe reads it here.
   final List<BridgeShapeItem> shapeContents;
 
-  /// The layer's own markers (K-254), and the frame each falls on so the bar
-  /// needs no time↔frame trip to draw one. In the read model because the
-  /// Timeline draws them on every rebuild, which is the cost K-184 exists to
-  /// remove.
+  /// The layer's own markers (K-254), and the comp frame each falls on — the
+  /// marker's layer-local time carried out by the layer's start offset — so
+  /// the bar needs no time↔frame trip to draw one. In the read model because
+  /// the Timeline draws them on every rebuild, which is the cost K-184 exists
+  /// to remove.
   final List<BridgeLayerMarker> markers;
 
   const BridgeLayerInfo({

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -87,7 +87,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 848570327;
+  int get rustContentHash => -1235708917;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -496,6 +496,9 @@ abstract class BridgeLibApi extends BaseApi {
 
   int crateApiLayerLayerReferenceGetLabel({required LayerReference that});
 
+  List<BridgeMarker> crateApiLayerLayerReferenceGetMarkers(
+      {required LayerReference that});
+
   List<BridgeMask> crateApiLayerLayerReferenceGetMasks(
       {required LayerReference that});
 
@@ -598,6 +601,9 @@ abstract class BridgeLibApi extends BaseApi {
 
   void crateApiLayerLayerReferenceSetLabel(
       {required LayerReference that, required int label});
+
+  void crateApiLayerLayerReferenceSetMarkers(
+      {required LayerReference that, required List<BridgeMarker> markers});
 
   void crateApiLayerLayerReferenceSetMask(
       {required LayerReference that, required BridgeMask mask});
@@ -4005,13 +4011,39 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
-  List<BridgeMask> crateApiLayerLayerReferenceGetMasks(
+  List<BridgeMarker> crateApiLayerLayerReferenceGetMarkers(
       {required LayerReference that}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_list_bridge_marker,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiLayerLayerReferenceGetMarkersConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiLayerLayerReferenceGetMarkersConstMeta =>
+      const TaskConstMeta(
+        debugName: "layer_reference_get_markers",
+        argNames: ["that"],
+      );
+
+  @override
+  List<BridgeMask> crateApiLayerLayerReferenceGetMasks(
+      {required LayerReference that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_layer_reference(that, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_mask,
@@ -4037,7 +4069,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_matte,
@@ -4062,7 +4094,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4088,7 +4120,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_stroke,
@@ -4114,7 +4146,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_Uuid,
@@ -4140,7 +4172,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -4166,7 +4198,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_shape_item,
@@ -4192,7 +4224,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_item_reference,
@@ -4218,7 +4250,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_span,
@@ -4244,7 +4276,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_switches,
@@ -4270,7 +4302,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_text_document,
@@ -4296,7 +4328,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_transform,
@@ -4322,7 +4354,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_scalar,
@@ -4349,7 +4381,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 131, port: port_);
+            funcId: 132, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4374,7 +4406,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4399,7 +4431,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4426,7 +4458,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4453,7 +4485,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4481,7 +4513,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4508,7 +4540,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4535,7 +4567,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_usize(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4566,7 +4598,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_i_64(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4593,7 +4625,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_reveal_kind(kind, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_reveal_groups,
@@ -4620,7 +4652,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4647,7 +4679,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(index, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4674,7 +4706,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(zoom, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4704,7 +4736,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(clip, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4736,7 +4768,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Uuid(clip, serializer);
         sse_encode_f_64(percent, serializer);
         sse_encode_f_64(endPercent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4767,7 +4799,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_bool(enabled, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4796,7 +4828,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4824,7 +4856,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_retime_interp(interpolation, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4851,7 +4883,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_8(label, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4871,6 +4903,33 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
+  void crateApiLayerLayerReferenceSetMarkers(
+      {required LayerReference that, required List<BridgeMarker> markers}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_layer_reference(that, serializer);
+        sse_encode_list_bridge_marker(markers, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiLayerLayerReferenceSetMarkersConstMeta,
+      argValues: [that, markers],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiLayerLayerReferenceSetMarkersConstMeta =>
+      const TaskConstMeta(
+        debugName: "layer_reference_set_markers",
+        argNames: ["that", "markers"],
+      );
+
+  @override
   void crateApiLayerLayerReferenceSetMask(
       {required LayerReference that, required BridgeMask mask}) {
     return handler.executeSync(SyncTask(
@@ -4878,7 +4937,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_mask(mask, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4905,7 +4964,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_matte(matte, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4932,7 +4991,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_Uuid(parent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4959,7 +5018,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4986,7 +5045,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_shape_item(contents, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5013,7 +5072,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5040,7 +5099,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_stroke(stroke, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5070,7 +5129,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_layer_switch(switch_, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5097,7 +5156,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_text_document(document, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5133,7 +5192,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_64(anchorY, serializer);
         sse_encode_f_64(positionX, serializer);
         sse_encode_f_64(positionY, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5170,7 +5229,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_transform_prop(prop, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5200,7 +5259,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_transform_prop(props, serializer);
         sse_encode_list_bridge_scalar(values, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5227,7 +5286,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5257,7 +5316,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(clip, serializer);
         sse_encode_i_64(toFrame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5284,7 +5343,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5310,7 +5369,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -5342,7 +5401,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Uuid(clip, serializer);
         sse_encode_i_64(startFrame, serializer);
         sse_encode_i_64(endFrame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5367,7 +5426,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(project, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_autosave,
@@ -5389,7 +5448,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -5412,7 +5471,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_effect_info,
@@ -5435,7 +5494,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 172)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_param_info,
@@ -5458,7 +5517,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 173)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_preset_info,
@@ -5480,7 +5539,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 172)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 174)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -5502,7 +5561,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 173)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 175)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5531,7 +5590,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
         sse_encode_u_32(keep, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 174)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 176)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5557,7 +5616,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 175)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 177)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -5584,7 +5643,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 176)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 178)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -5610,7 +5669,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 177)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 179)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_history,
@@ -5637,7 +5696,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 178)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 180)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_footage_reference,
@@ -5663,7 +5722,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 179)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 181)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -5693,7 +5752,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(name, serializer);
         sse_encode_opt_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 180)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_composition_reference,
@@ -5719,7 +5778,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 181)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5745,7 +5804,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5770,7 +5829,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 185)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5797,7 +5856,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_recovery,
@@ -5825,7 +5884,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 185, port: port_);
+            funcId: 187, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5853,7 +5912,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_project_cache_location(
             location, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 188)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5880,7 +5939,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_String(uiState, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 187)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5908,7 +5967,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_StreamSink_worker_response_Sse(onReponse, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 188)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5934,7 +5993,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5959,7 +6018,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 192)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5983,7 +6042,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -6005,7 +6064,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 192)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6031,7 +6090,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_bridge_scalar(scalar, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -6054,7 +6113,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 196)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -6079,7 +6138,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 197)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6105,7 +6164,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_cache_location(location, serializer);
         sse_encode_String(folder, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 196)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6130,7 +6189,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 197)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -6155,7 +6214,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_solid_def,
@@ -6182,7 +6241,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
         sse_encode_box_autoadd_bridge_solid_def(definition, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6206,7 +6265,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6229,7 +6288,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6251,7 +6310,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6274,7 +6333,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 205)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_viewer_transport,
@@ -6297,7 +6356,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 206)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -7054,8 +7113,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeLayerInfo dco_decode_bridge_layer_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 19)
-      throw Exception('unexpected arr length: expect 19 but see ${arr.length}');
+    if (arr.length != 20)
+      throw Exception('unexpected arr length: expect 20 but see ${arr.length}');
     return BridgeLayerInfo(
       name: dco_decode_String(arr[0]),
       kind: dco_decode_bridge_layer_kind(arr[1]),
@@ -7076,6 +7135,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       masks: dco_decode_list_bridge_mask(arr[16]),
       paint: dco_decode_list_bridge_stroke(arr[17]),
       shapeContents: dco_decode_list_bridge_shape_item(arr[18]),
+      markers: dco_decode_list_bridge_layer_marker(arr[19]),
     );
   }
 
@@ -7083,6 +7143,18 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeLayerKind dco_decode_bridge_layer_kind(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return BridgeLayerKind.values[raw as int];
+  }
+
+  @protected
+  BridgeLayerMarker dco_decode_bridge_layer_marker(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return BridgeLayerMarker(
+      marker: dco_decode_bridge_marker(arr[0]),
+      frame: dco_decode_i_64(arr[1]),
+    );
   }
 
   @protected
@@ -7793,6 +7865,12 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   List<BridgeLayerEntry> dco_decode_list_bridge_layer_entry(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_bridge_layer_entry).toList();
+  }
+
+  @protected
+  List<BridgeLayerMarker> dco_decode_list_bridge_layer_marker(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_bridge_layer_marker).toList();
   }
 
   @protected
@@ -8868,6 +8946,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_masks = sse_decode_list_bridge_mask(deserializer);
     var var_paint = sse_decode_list_bridge_stroke(deserializer);
     var var_shapeContents = sse_decode_list_bridge_shape_item(deserializer);
+    var var_markers = sse_decode_list_bridge_layer_marker(deserializer);
     return BridgeLayerInfo(
         name: var_name,
         kind: var_kind,
@@ -8887,7 +8966,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         retime: var_retime,
         masks: var_masks,
         paint: var_paint,
-        shapeContents: var_shapeContents);
+        shapeContents: var_shapeContents,
+        markers: var_markers);
   }
 
   @protected
@@ -8895,6 +8975,15 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_i_32(deserializer);
     return BridgeLayerKind.values[inner];
+  }
+
+  @protected
+  BridgeLayerMarker sse_decode_bridge_layer_marker(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_marker = sse_decode_bridge_marker(deserializer);
+    var var_frame = sse_decode_i_64(deserializer);
+    return BridgeLayerMarker(marker: var_marker, frame: var_frame);
   }
 
   @protected
@@ -9676,6 +9765,19 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var ans_ = <BridgeLayerEntry>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_bridge_layer_entry(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<BridgeLayerMarker> sse_decode_list_bridge_layer_marker(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <BridgeLayerMarker>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_bridge_layer_marker(deserializer));
     }
     return ans_;
   }
@@ -10870,6 +10972,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_list_bridge_mask(self.masks, serializer);
     sse_encode_list_bridge_stroke(self.paint, serializer);
     sse_encode_list_bridge_shape_item(self.shapeContents, serializer);
+    sse_encode_list_bridge_layer_marker(self.markers, serializer);
   }
 
   @protected
@@ -10877,6 +10980,14 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       BridgeLayerKind self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_bridge_layer_marker(
+      BridgeLayerMarker self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bridge_marker(self.marker, serializer);
+    sse_encode_i_64(self.frame, serializer);
   }
 
   @protected
@@ -11488,6 +11599,16 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_bridge_layer_entry(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_bridge_layer_marker(
+      List<BridgeLayerMarker> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_bridge_layer_marker(item, serializer);
     }
   }
 

--- a/flutter_ui/lib/src/rust/frb_generated.io.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.io.dart
@@ -302,6 +302,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeLayerKind dco_decode_bridge_layer_kind(dynamic raw);
 
   @protected
+  BridgeLayerMarker dco_decode_bridge_layer_marker(dynamic raw);
+
+  @protected
   BridgeLayerSwitch dco_decode_bridge_layer_switch(dynamic raw);
 
   @protected
@@ -482,6 +485,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   List<BridgeLayerEntry> dco_decode_list_bridge_layer_entry(dynamic raw);
+
+  @protected
+  List<BridgeLayerMarker> dco_decode_list_bridge_layer_marker(dynamic raw);
 
   @protected
   List<BridgeMarker> dco_decode_list_bridge_marker(dynamic raw);
@@ -913,6 +919,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeLayerKind sse_decode_bridge_layer_kind(SseDeserializer deserializer);
 
   @protected
+  BridgeLayerMarker sse_decode_bridge_layer_marker(
+      SseDeserializer deserializer);
+
+  @protected
   BridgeLayerSwitch sse_decode_bridge_layer_switch(
       SseDeserializer deserializer);
 
@@ -1114,6 +1124,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   List<BridgeLayerEntry> sse_decode_list_bridge_layer_entry(
+      SseDeserializer deserializer);
+
+  @protected
+  List<BridgeLayerMarker> sse_decode_list_bridge_layer_marker(
       SseDeserializer deserializer);
 
   @protected
@@ -1588,6 +1602,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       BridgeLayerKind self, SseSerializer serializer);
 
   @protected
+  void sse_encode_bridge_layer_marker(
+      BridgeLayerMarker self, SseSerializer serializer);
+
+  @protected
   void sse_encode_bridge_layer_switch(
       BridgeLayerSwitch self, SseSerializer serializer);
 
@@ -1808,6 +1826,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_list_bridge_layer_entry(
       List<BridgeLayerEntry> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_bridge_layer_marker(
+      List<BridgeLayerMarker> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_bridge_marker(

--- a/flutter_ui/lib/src/rust/frb_generated.web.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.web.dart
@@ -304,6 +304,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeLayerKind dco_decode_bridge_layer_kind(dynamic raw);
 
   @protected
+  BridgeLayerMarker dco_decode_bridge_layer_marker(dynamic raw);
+
+  @protected
   BridgeLayerSwitch dco_decode_bridge_layer_switch(dynamic raw);
 
   @protected
@@ -484,6 +487,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   List<BridgeLayerEntry> dco_decode_list_bridge_layer_entry(dynamic raw);
+
+  @protected
+  List<BridgeLayerMarker> dco_decode_list_bridge_layer_marker(dynamic raw);
 
   @protected
   List<BridgeMarker> dco_decode_list_bridge_marker(dynamic raw);
@@ -915,6 +921,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeLayerKind sse_decode_bridge_layer_kind(SseDeserializer deserializer);
 
   @protected
+  BridgeLayerMarker sse_decode_bridge_layer_marker(
+      SseDeserializer deserializer);
+
+  @protected
   BridgeLayerSwitch sse_decode_bridge_layer_switch(
       SseDeserializer deserializer);
 
@@ -1116,6 +1126,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   List<BridgeLayerEntry> sse_decode_list_bridge_layer_entry(
+      SseDeserializer deserializer);
+
+  @protected
+  List<BridgeLayerMarker> sse_decode_list_bridge_layer_marker(
       SseDeserializer deserializer);
 
   @protected
@@ -1590,6 +1604,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
       BridgeLayerKind self, SseSerializer serializer);
 
   @protected
+  void sse_encode_bridge_layer_marker(
+      BridgeLayerMarker self, SseSerializer serializer);
+
+  @protected
   void sse_encode_bridge_layer_switch(
       BridgeLayerSwitch self, SseSerializer serializer);
 
@@ -1810,6 +1828,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_list_bridge_layer_entry(
       List<BridgeLayerEntry> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_bridge_layer_marker(
+      List<BridgeLayerMarker> self, SseSerializer serializer);
 
   @protected
   void sse_encode_list_bridge_marker(

--- a/flutter_ui/lib/state/comp_time.dart
+++ b/flutter_ui/lib/state/comp_time.dart
@@ -1,4 +1,5 @@
-// One answer to "what time is frame N?", shared by everything that draws.
+// One answer to "what time is frame N?" — and to "what markers does this comp
+// have?" — shared by everything that draws.
 //
 // The conversion belongs to the engine (docs/17 §, `CompositionReference::
 // time_of_frame` exists so no frontend does frame-rate arithmetic itself), but
@@ -51,8 +52,36 @@ int frameAtTime(CompositionReference comp, BridgeRational time) {
   return frames[time] ??= comp.frameAtTime(time: time);
 }
 
+/// A comp's markers, remembered until the document changes (K-254).
+///
+/// Same bargain as the two above, and the one that made it worth having: the
+/// time ruler draws markers on every rebuild — sixty times a second while
+/// playback runs — and `get_markers` walks the whole list across the boundary
+/// each time. What it answers can only change when the document changes.
+final _markers = <CompositionReference, List<BridgeMarker>>{};
+
+/// The comp's markers, from memory when they are there.
+///
+/// Prefer this to `comp.getMarkers()` anywhere that runs during a build or a
+/// paint. Anything that *writes* markers must go through [writeMarkers], which
+/// is what keeps this honest.
+List<BridgeMarker> markersOf(CompositionReference comp) =>
+    _markers[comp] ??= comp.getMarkers();
+
+/// Replace a comp's whole marker list and forget the remembered copy.
+///
+/// The one way markers are written. A caller that reached for `setMarkers`
+/// directly would leave [markersOf] answering the old list until something
+/// else happened to clear it, which is the sort of bug that shows up as a
+/// marker springing back after you drag it.
+void writeMarkers(CompositionReference comp, List<BridgeMarker> markers) {
+  comp.setMarkers(markers: markers);
+  _markers.remove(comp);
+}
+
 /// Forget everything. Called on every committed engine change.
 void clearCompTimeCache() {
   _times.clear();
   _frames.clear();
+  _markers.clear();
 }

--- a/flutter_ui/lib/state/settings.dart
+++ b/flutter_ui/lib/state/settings.dart
@@ -140,12 +140,23 @@ class InterfaceSettings {
   /// Still images never do: there is nothing to cut in a single frame.
   bool videoAsSequenceLayer;
 
+  /// Whether stopping playback leaves the playhead on the frame that was on
+  /// screen, rather than putting it back where play started (K-254).
+  ///
+  /// Off by default: playback is a preview of the moment you are working on,
+  /// and coming back to a different frame than you left means finding your
+  /// place again after every space bar. On is the After Effects behaviour, and
+  /// what Lumit did before this existed — hence the phrasing as a deviation
+  /// from the default rather than a choice between two equals.
+  bool playheadStaysOnStop;
+
   InterfaceSettings({
     this.uiScale = 1.0,
     this.showTooltips = true,
     this.transformInEffectControls = false,
     this.retimeOpensToSpeed = false,
     this.videoAsSequenceLayer = false,
+    this.playheadStaysOnStop = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -154,6 +165,7 @@ class InterfaceSettings {
         'transform_in_effect_controls': transformInEffectControls,
         'retime_opens_to_speed': retimeOpensToSpeed,
         'video_as_sequence_layer': videoAsSequenceLayer,
+        'playhead_stays_on_stop': playheadStaysOnStop,
       };
   factory InterfaceSettings.fromJson(Map<String, dynamic> j) =>
       InterfaceSettings(
@@ -166,5 +178,10 @@ class InterfaceSettings {
         // must not silently change how the editor works.
         retimeOpensToSpeed: j['retime_opens_to_speed'] as bool? ?? false,
         videoAsSequenceLayer: j['video_as_sequence_layer'] as bool? ?? false,
+        // Absent means off here too, but for the opposite reason: the returning
+        // playhead is the *new* default (K-254), so a settings file written
+        // before this field existed adopts it rather than being pinned to the
+        // old behaviour by its own silence.
+        playheadStaysOnStop: j['playhead_stays_on_stop'] as bool? ?? false,
       );
 }

--- a/flutter_ui/lib/theme/theme.dart
+++ b/flutter_ui/lib/theme/theme.dart
@@ -201,11 +201,19 @@ class LumitTheme {
   /// the surface ramp cannot express because it is a ramp.
   final Color selectionFill;
 
-  /// The two Timeline tokens default from the mode rather than being spelled
+  /// Comp markers on the time ruler (K-254). A plain grey, not a role colour:
+  /// a marker says *here*, not *good* or *careful*, and the ruler already has
+  /// the accent doing the work area. Light on a dark scheme and dark on a light
+  /// one — After Effects' own reading, and the one that stays legible over the
+  /// work-area band either way.
+  final Color marker;
+
+  /// The three Timeline tokens default from the mode rather than being spelled
   /// out by every scheme: they are a *relationship* to the surface ramp (a
-  /// shade beyond `surface1`, a fill that out-contrasts it), and seven schemes
-  /// restating that relationship would be seven chances to get it wrong. A
-  /// custom theme, or any scheme that wants its own, passes them explicitly.
+  /// shade beyond `surface1`, a fill that out-contrasts it, a grey that reads
+  /// against it), and seven schemes restating that relationship would be seven
+  /// chances to get it wrong. A custom theme, or any scheme that wants its own,
+  /// passes them explicitly.
   LumitTheme({
     required this.mode,
     this.shape = ThemeShape.sharp,
@@ -232,9 +240,11 @@ class LumitTheme {
     required this.layer,
     Color? timelineOutOfRange,
     Color? selectionFill,
+    Color? marker,
   })  : timelineOutOfRange =
             timelineOutOfRange ?? defaultOutOfRange(mode, surface1),
-        selectionFill = selectionFill ?? defaultSelectionFill(mode, surface2);
+        selectionFill = selectionFill ?? defaultSelectionFill(mode, surface2),
+        marker = marker ?? defaultMarker(mode);
 
   /// The ground outside the work area: a step *away* from the surface ramp's
   /// direction — darker under a dark scheme, and darker again under a light
@@ -252,6 +262,14 @@ class LumitTheme {
     final by = mode == ThemeMode2.dark ? 0x0e : -0x1c;
     return _shift(surface2, by);
   }
+
+  /// The marker grey. A fixed pair rather than a shift off the surface ramp:
+  /// it has to read against the ruler's ground *and* the work-area wash over
+  /// it, so it is pinned to the two values that do, not derived from one of
+  /// the things it must stand out from.
+  static Color defaultMarker(ThemeMode2 mode) => mode == ThemeMode2.dark
+      ? _rgb(0xc4, 0xc4, 0xc4)
+      : _rgb(0x56, 0x56, 0x56);
 
   /// Shift every channel by [by], clamped — the one place the theme nudges a
   /// colour, so "a shade darker" means the same thing wherever it is said.
@@ -334,6 +352,7 @@ class LumitTheme {
         layer: layer,
         timelineOutOfRange: timelineOutOfRange,
         selectionFill: selectionFill,
+        marker: marker,
       );
 
   /// The full composition a scheme + shape (+ accent override) resolves to —

--- a/flutter_ui/lib/theme/theme_tokens.dart
+++ b/flutter_ui/lib/theme/theme_tokens.dart
@@ -71,6 +71,7 @@ LumitTheme _with(
   LayerColours? layer,
   Color? timelineOutOfRange,
   Color? selectionFill,
+  Color? marker,
 }) =>
     LumitTheme(
       mode: t.mode,
@@ -101,6 +102,7 @@ LumitTheme _with(
       layer: layer ?? t.layer,
       timelineOutOfRange: timelineOutOfRange ?? t.timelineOutOfRange,
       selectionFill: selectionFill ?? t.selectionFill,
+      marker: marker ?? t.marker,
     );
 
 LayerColours _layerWith(
@@ -288,6 +290,15 @@ final List<ThemeToken> themeTokens = [
     group: 'Roles',
     read: (t) => t.error,
     write: (t, c) => _with(t, error: c),
+  ),
+  ThemeToken(
+    key: 'marker',
+    label: 'Marker',
+    description: 'Comp markers on the time ruler, and the box holding what '
+        'one says. A grey by default — a marker says *here*, not *careful*.',
+    group: 'Roles',
+    read: (t) => t.marker,
+    write: (t, c) => _with(t, marker: c),
   ),
   ThemeToken(
     key: 'cacheDisk',

--- a/flutter_ui/test/frb/bridge_call_budget_test.dart
+++ b/flutter_ui/test/frb/bridge_call_budget_test.dart
@@ -21,11 +21,13 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/panels/effect_controls_panel_frb.dart';
 import 'package:lumit_flutter/panels/project_panel_frb.dart';
+import 'package:lumit_flutter/panels/timeline_extras_frb.dart';
 import 'package:lumit_flutter/panels/timeline_panel_frb.dart';
 import 'package:lumit_flutter/panels/viewer_panel_frb.dart';
 import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
 import 'package:lumit_flutter/src/rust/frb_generated.dart';
+import 'package:lumit_flutter/state/comp_time.dart';
 import 'package:lumit_flutter/state/tools.dart';
 
 import 'frb_test_support.dart';
@@ -148,6 +150,76 @@ void main() {
         lessThan(12),
         reason: 'one click re-read far too much across the bridge:\n'
             '${counter.ranking()}',
+      );
+    });
+
+    /// **Markers used to cost a bridge call per rebuild and one per frame of
+    /// drag.** `get_markers` walked the whole list across the seam on every
+    /// ruler build — sixty times a second while playback runs — and a drag
+    /// committed a document write for every frame it crossed, which is what
+    /// made dragging a flag feel heavy. The list is remembered in Dart until
+    /// the document changes, and a drag writes once, on release.
+    testWidgets('markers cost nothing per rebuild and one write per drag',
+        (tester) async {
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      comp.addSolidLayer();
+      p.uiState.setSelectedComp(comp);
+      addMarkerFrb(comp, frame: 40, label: 'Chorus');
+
+      tester.view.physicalSize = const Size(1280, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(hostPanel(
+        state: p.state,
+        uiState: p.uiState,
+        size: const Size(1280, 600),
+        child: const TimelinePanelFrb(),
+      ));
+      await settleFrb(tester, minRounds: 8);
+
+      // Ten rebuilds of the ruler, driven the way playback drives it.
+      counter
+        ..reset()
+        ..counting = true;
+      for (var i = 1; i <= 10; i++) {
+        p.uiState.playheadFrame.value = i;
+        await tester.pump();
+        tester.element(find.byType(TimelineRuler)).markNeedsBuild();
+        await tester.pump();
+      }
+      counter.counting = false;
+      // ignore: avoid_print
+      print('MARKER REBUILD COST ${counter.total} calls\n${counter.ranking()}');
+      expect(
+        counter.total,
+        lessThan(4),
+        reason: 'the ruler re-read the marker list on every rebuild:\n'
+            '${counter.ranking()}',
+      );
+
+      // And the drag: one write, not one per frame crossed.
+      final flag = find
+          .byKey(ValueKey<String>('tl-marker-${markersOf(comp).single.id}'));
+      counter
+        ..reset()
+        ..counting = true;
+      await tester.drag(flag, const Offset(120, 0));
+      await tester.pump();
+      await settleFrb(tester, minRounds: 4, maxRounds: 8);
+      counter.counting = false;
+      // ignore: avoid_print
+      print('MARKER DRAG COST ${counter.total} calls\n${counter.ranking()}');
+      expect(
+        counter.calls['composition_reference_set_markers'] ?? 0,
+        1,
+        reason: 'a drag must write the document once, on release:\n'
+            '${counter.ranking()}',
+      );
+      expect(
+        counter.total,
+        lessThan(40),
+        reason: 'dragging a marker re-read far too much:\n${counter.ranking()}',
       );
     });
 

--- a/flutter_ui/test/frb/bridge_call_budget_test.dart
+++ b/flutter_ui/test/frb/bridge_call_budget_test.dart
@@ -221,6 +221,28 @@ void main() {
         lessThan(40),
         reason: 'dragging a marker re-read far too much:\n${counter.ranking()}',
       );
+
+      // Adding one. Most of what this costs is the ordinary fan-out of *any*
+      // document change — every panel re-reads what it draws — so the budget
+      // that matters is the marker's own share of it, which is the read, the
+      // write, and one time conversion per existing marker.
+      counter
+        ..reset()
+        ..counting = true;
+      addMarkerFrb(comp, frame: 90, label: '2');
+      p.state.notifyDocumentChanged();
+      await tester.pump();
+      await settleFrb(tester, minRounds: 4, maxRounds: 8);
+      counter.counting = false;
+      // ignore: avoid_print
+      print('MARKER ADD COST ${counter.total} calls\n${counter.ranking()}');
+      expect(
+        (counter.calls['composition_reference_get_markers'] ?? 0) +
+            (counter.calls['composition_reference_set_markers'] ?? 0),
+        lessThan(4),
+        reason: 'adding a marker read or wrote the list more than once:\n'
+            '${counter.ranking()}',
+      );
     });
 
     /// Hovering the Project panel used to re-fetch names (and once, the

--- a/flutter_ui/test/frb/shortcuts_frb_test.dart
+++ b/flutter_ui/test/frb/shortcuts_frb_test.dart
@@ -357,16 +357,16 @@ void main() {
     /// Numbered markers (K-254). The pairing is the whole feature: the chord
     /// that marks a moment is the key that goes back to it, so both halves are
     /// asserted together — a set that does not return is not the feature.
-    testWidgets('Ctrl+1 sets marker 1 and the bare 1 returns to it',
+    testWidgets('Shift+1 sets marker 1 and the bare 1 returns to it',
         (tester) async {
       final p = await mount(tester);
       final comp = p.uiState.selectedComp!;
 
       p.uiState.playheadFrame.value = 24;
       await tester.pump();
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       await tester.sendKeyEvent(LogicalKeyboardKey.digit1);
-      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
       await tester.pump();
 
       final marker = comp.getMarkers().single;

--- a/flutter_ui/test/frb/shortcuts_frb_test.dart
+++ b/flutter_ui/test/frb/shortcuts_frb_test.dart
@@ -353,5 +353,61 @@ void main() {
           reason: 'setting the end leaves the start alone');
       expect(comp.frameAtTime(time: work.outPoint), 30);
     });
+
+    /// Numbered markers (K-254). The pairing is the whole feature: the chord
+    /// that marks a moment is the key that goes back to it, so both halves are
+    /// asserted together — a set that does not return is not the feature.
+    testWidgets('Ctrl+1 sets marker 1 and the bare 1 returns to it',
+        (tester) async {
+      final p = await mount(tester);
+      final comp = p.uiState.selectedComp!;
+
+      p.uiState.playheadFrame.value = 24;
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.digit1);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      final marker = comp.getMarkers().single;
+      expect(marker.label, '1', reason: 'the digit is what the marker says');
+      expect(comp.frameAtTime(time: marker.time), 24);
+
+      p.uiState.playheadFrame.value = 0;
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.digit1);
+      await tester.pump();
+      expect(p.uiState.playheadFrame.value, 24,
+          reason: 'the bare digit went back to the marker');
+    });
+
+    /// A digit with no marker behind it is a key without a meaning yet, not an
+    /// error — and it must not move the playhead anywhere.
+    testWidgets('a digit with no marker does nothing', (tester) async {
+      final p = await mount(tester);
+      p.uiState.playheadFrame.value = 15;
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.digit7);
+      await tester.pump();
+      expect(p.uiState.playheadFrame.value, 15);
+    });
+
+    /// `M` still reveals Masks in the Timeline, which is why the plain marker
+    /// key is `Shift+M` (K-254).
+    testWidgets('Shift+M drops a marker at the playhead', (tester) async {
+      final p = await mount(tester);
+      final comp = p.uiState.selectedComp!;
+
+      p.uiState.playheadFrame.value = 9;
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyM);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+
+      expect(comp.getMarkers(), hasLength(1));
+      expect(comp.getMarkers().single.label, isEmpty);
+      expect(comp.frameAtTime(time: comp.getMarkers().single.time), 9);
+    });
   }, skip: !engineAvailable);
 }

--- a/flutter_ui/test/frb/timeline_extras_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_extras_frb_test.dart
@@ -548,6 +548,83 @@ void main() {
           reason: 'a digit with no marker is nothing to jump to');
     });
 
+    // --- layer markers (K-254) -------------------------------------------
+
+    /// A composition dropped into another brings its markers along as the
+    /// layer's own. Copies, with ids of their own: from here the two lists are
+    /// unrelated, so editing the layer's never reaches into the comp it came
+    /// from — or into anywhere else that comp is used.
+    test('a comp dropped in brings its markers along as the layer\'s', () {
+      final p = freshProject();
+      final source = p.state.project!.newComposition(name: 'Beats');
+      addMarkerFrb(source, frame: 12, label: 'Drop');
+      final into = p.state.project!.newComposition(name: 'Scene');
+
+      final layer = into.addPrecompLayer(comp: source);
+      final onLayer = layer.getMarkers();
+      expect(onLayer, hasLength(1));
+      expect(onLayer.single.label, 'Drop');
+      expect(onLayer.single.id, isNot(source.getMarkers().single.id),
+          reason: 'a copy, not the same marker');
+
+      // And the copy is genuinely independent.
+      layer.setMarkers(markers: const []);
+      expect(layer.getMarkers(), isEmpty);
+      expect(source.getMarkers(), hasLength(1),
+          reason: 'clearing the layer left the composition alone');
+    });
+
+    /// Pre-composing carries the comp's markers into the new comp, and leaves
+    /// the Precomp layer without any: the same cues are on the ruler above, and
+    /// drawing them again on the layer would say it twice.
+    test('pre-composing carries markers in and leaves the layer bare', () {
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      final solid = comp.addSolidLayer();
+      addMarkerFrb(comp, frame: 30, label: 'Chorus');
+
+      final precomp = comp.precompose(
+        layerIds: [solid.internallayerId],
+        name: 'Packed',
+        leaveAttributes: false,
+        adjustDuration: false,
+      );
+      expect(precomp.getMarkers(), isEmpty,
+          reason: 'the Precomp layer draws no markers of its own');
+      expect(comp.getMarkers(), hasLength(1),
+          reason: 'the outer comp keeps its own');
+
+      final inner = precomp.getSourceItem();
+      expect(inner, isA<ItemReference_Composition>());
+      final packed = (inner as ItemReference_Composition).field0;
+      expect(packed.getMarkers(), hasLength(1),
+          reason: 'and the packed comp got a copy');
+      expect(packed.getMarkers().single.label, 'Chorus');
+      expect(packed.frameAtTime(time: packed.getMarkers().single.time), 30);
+    });
+
+    testWidgets('a layer marker draws on the bar and deletes from its menu',
+        (tester) async {
+      final p = withComp();
+      final source = p.state.project!.newComposition(name: 'Beats');
+      addMarkerFrb(source, frame: 20, label: 'Drop');
+      final layer = p.comp.addPrecompLayer(comp: source);
+      await mount(tester, p);
+
+      final id = layer.getMarkers().single.id;
+      final flag = find.byKey(ValueKey<String>('tl-layer-marker-$id'));
+      expect(flag, findsOneWidget, reason: 'it draws on the layer\'s bar');
+
+      await tester.tap(flag, buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('tl-layer-marker-delete')));
+      await tester.pumpAndSettle();
+
+      expect(layer.getMarkers(), isEmpty);
+      expect(source.getMarkers(), hasLength(1),
+          reason: 'the composition it came from is untouched');
+    });
+
     // --- the sequence view (K-248) --------------------------------------
 
     /// A Sequence layer, ready to open. Added layers land at the top of the

--- a/flutter_ui/test/frb/timeline_extras_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_extras_frb_test.dart
@@ -16,6 +16,7 @@ import 'package:lumit_flutter/src/rust/api/composition.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
 import 'package:lumit_flutter/src/rust/api/project_item.dart';
 
+import 'package:lumit_flutter/state/comp_time.dart';
 import 'package:lumit_flutter/state/tools.dart';
 
 import 'frb_test_support.dart';
@@ -477,6 +478,56 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(p.comp.getMarkers(), isEmpty);
+    });
+
+    /// Markers do not stack. Two flags on one frame are two things to click and
+    /// one place, and the second hides the first exactly — so the newcomer wins,
+    /// whether it arrives by shortcut or by being dragged on top.
+    test('a marker added to an occupied frame replaces what is there', () {
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      addMarkerFrb(comp, frame: 20, label: 'Chorus');
+      addMarkerFrb(comp, frame: 20, label: 'Drop');
+      expect(comp.getMarkers(), hasLength(1));
+      expect(comp.getMarkers().single.label, 'Drop');
+    });
+
+    /// The drop half of the same rule: a flag dragged onto another takes its
+    /// place, and keeps its own identity rather than being deleted and remade.
+    test('a marker dragged onto another replaces it', () {
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      addMarkerFrb(comp, frame: 10, label: 'Chorus');
+      addMarkerFrb(comp, frame: 60, label: 'Drop');
+      final drop = markersOf(comp).firstWhere((m) => m.label == 'Drop');
+
+      writeMarkers(
+          comp,
+          markersWithFrb(comp,
+              frame: 10, label: drop.label, id: drop.id));
+
+      final left = comp.getMarkers();
+      expect(left, hasLength(1), reason: 'the two did not stack');
+      expect(left.single.label, 'Drop', reason: 'the dragged one won');
+      expect(left.single.id, drop.id, reason: 'and it is the same marker');
+      expect(comp.frameAtTime(time: left.single.time), 10);
+    });
+
+    /// The flag's **point** is what says which frame, so it sits on the
+    /// playhead rather than beside it — the whole reason the flag is centred on
+    /// its frame instead of hung off to the right of it.
+    testWidgets('a marker flag points at the frame it marks', (tester) async {
+      final p = withComp();
+      p.comp.addAdjustmentLayer();
+      addMarkerFrb(p.comp, frame: 40, label: 'Chorus');
+      p.uiState.playheadFrame.value = 40;
+      await mount(tester, p);
+
+      final flag = tester.getTopLeft(find.byKey(
+          ValueKey<String>('tl-marker-${markersOf(p.comp).single.id}')));
+      final playhead = tester.getCenter(find.byType(PlayheadMarker).first);
+      expect(flag.dx + MarkerFlag.width / 2, closeTo(playhead.dx, 1.5),
+          reason: 'the point and the playhead are on the same frame');
     });
 
     /// A numbered marker names one place, so setting it again moves it rather

--- a/flutter_ui/test/frb/timeline_extras_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_extras_frb_test.dart
@@ -391,6 +391,112 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    /// Scrubbing during playback used to be unwinnable: the engine handed back
+    /// a frame every tick and each one put the playhead straight back where the
+    /// transport wanted it. Taking hold of the playhead takes it off the
+    /// transport (K-254), and it stays where the drag left it — the
+    /// return-to-start of a normal stop would undo the very gesture.
+    testWidgets('dragging the ruler during playback stops it and holds',
+        (tester) async {
+      final p = withComp();
+      p.comp.addAdjustmentLayer();
+      await mount(tester, p);
+
+      p.uiState.play();
+      await tester.pump();
+      expect(p.uiState.playing.value, isTrue);
+
+      await tester.drag(
+          find.byKey(const ValueKey('tl-ruler')), const Offset(120, 0));
+      await tester.pumpAndSettle();
+
+      expect(p.uiState.playing.value, isFalse,
+          reason: 'taking hold of the playhead stops the transport');
+      expect(p.uiState.playheadFrame.value, greaterThan(0),
+          reason: 'and it stays where the drag left it, not back at the start');
+    });
+
+    /// Markers on the ruler are direct manipulation now (K-254): a flag can be
+    /// dragged to another moment, and its text changed from its own menu. The
+    /// dialogue in the ⋯ menu is still there for adding one by hand.
+    testWidgets('a marker flag drags along the ruler', (tester) async {
+      final p = withComp();
+      p.comp.addAdjustmentLayer();
+      addMarkerFrb(p.comp, frame: 10, label: 'Chorus');
+      await mount(tester, p);
+
+      final id = p.comp.getMarkers().single.id;
+      final flag = find.byKey(ValueKey<String>('tl-marker-$id'));
+      expect(flag, findsOneWidget, reason: 'the marker draws on the ruler');
+
+      await tester.drag(flag, const Offset(80, 0));
+      await tester.pumpAndSettle();
+
+      final moved = p.comp.getMarkers().single;
+      expect(p.comp.frameAtTime(time: moved.time), greaterThan(10),
+          reason: 'the drag moved the marker later in the comp');
+      expect(moved.label, 'Chorus', reason: 'and left what it says alone');
+      expect(moved.id, id, reason: 'it is the same marker, not a new one');
+    });
+
+    testWidgets('right-clicking a marker edits what it says', (tester) async {
+      final p = withComp();
+      p.comp.addAdjustmentLayer();
+      addMarkerFrb(p.comp, frame: 10, label: 'Chorus');
+      await mount(tester, p);
+
+      final id = p.comp.getMarkers().single.id;
+      await tester.tap(find.byKey(ValueKey<String>('tl-marker-$id')),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('marker-menu-edit')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+          find.byKey(const ValueKey('marker-edit-label')), 'Drop');
+      await tester.tap(find.byKey(const ValueKey('marker-edit-ok')));
+      await tester.pumpAndSettle();
+
+      final edited = p.comp.getMarkers().single;
+      expect(edited.label, 'Drop');
+      expect(p.comp.frameAtTime(time: edited.time), 10,
+          reason: 'renaming did not move it');
+    });
+
+    testWidgets('a marker can be deleted from its own menu', (tester) async {
+      final p = withComp();
+      p.comp.addAdjustmentLayer();
+      addMarkerFrb(p.comp, frame: 10, label: 'Chorus');
+      await mount(tester, p);
+
+      await tester.tap(
+          find.byKey(ValueKey<String>('tl-marker-${p.comp.getMarkers().single.id}')),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('marker-menu-delete')));
+      await tester.pumpAndSettle();
+
+      expect(p.comp.getMarkers(), isEmpty);
+    });
+
+    /// A numbered marker names one place, so setting it again moves it rather
+    /// than leaving two for the bare digit to choose between. Unlabelled cues
+    /// are dropped as freely as you like.
+    test('a numbered marker is replaced, an unlabelled one is not', () {
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      addMarkerFrb(comp, frame: 10, label: '1');
+      addMarkerFrb(comp, frame: 40, label: '1');
+      expect(comp.getMarkers(), hasLength(1));
+      expect(markerFrameFrb(comp, '1'), 40);
+
+      addMarkerFrb(comp, frame: 5);
+      addMarkerFrb(comp, frame: 7);
+      expect(comp.getMarkers(), hasLength(3));
+      expect(markerFrameFrb(comp, '2'), isNull,
+          reason: 'a digit with no marker is nothing to jump to');
+    });
+
     // --- the sequence view (K-248) --------------------------------------
 
     /// A Sequence layer, ready to open. Added layers land at the top of the

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -218,7 +218,7 @@ void main() {
     /// never fire during it. The playhead moves here purely because the engine
     /// chose frames and each arriving frame said which one it was — which is the
     /// whole point of the move, and would fail if a clock crept back into Dart.
-    testWidgets('play advances the playhead, and stopping holds it',
+    testWidgets('play advances the playhead, and stopping returns it',
         (tester) async {
       final p = withLayer();
       await mount(tester, p);
@@ -236,11 +236,13 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('viewer-play')));
       await tester.pump();
       expect(p.uiState.playing.value, isFalse);
-      await settleFrb(tester, minRounds: 4, maxRounds: 4);
-      final stopped = p.uiState.playheadFrame.value;
-      await settleFrb(tester, minRounds: 8, maxRounds: 8);
-      expect(p.uiState.playheadFrame.value, stopped,
-          reason: 'stopping stops it where it is, in-flight frames included');
+      await settleFrb(tester, minRounds: 12, maxRounds: 12);
+      // K-254: the playhead goes back to where play was asked for. Playback is
+      // a preview of the moment being worked on, so stopping returns you to it
+      // rather than leaving you wherever the picture happened to stop. In-flight
+      // frames are included — a late arrival must not drag it off again.
+      expect(p.uiState.playheadFrame.value, 0,
+          reason: 'stopping puts the playhead back where play started');
 
       // The degradation badge belongs to playback alone: whatever tier the
       // controller walked to while playing (this transportless build walks
@@ -248,6 +250,29 @@ void main() {
       // The while-playing half is not asserted — it races a live controller.
       expect(find.byKey(const ValueKey('viewer-tier-badge')), findsNothing,
           reason: 'no degradation badge once playback has stopped');
+    }, skip: zeroCopyViewerUnavailable);
+
+    /// The other half of K-254: Settings ▸ Interface ▸ Editing puts the old
+    /// After Effects behaviour back, and then stopping leaves the playhead on
+    /// the frame that was on screen.
+    testWidgets('the playhead stays put when the setting asks it to',
+        (tester) async {
+      final p = withLayer();
+      p.uiState.workspace.interface.playheadStaysOnStop = true;
+      await mount(tester, p);
+
+      await tester.tap(find.byKey(const ValueKey('viewer-play')));
+      await tester.pump();
+      await settleFrb(tester,
+          minRounds: 6,
+          maxRounds: 120,
+          until: () => p.uiState.playheadFrame.value > 0);
+
+      await tester.tap(find.byKey(const ValueKey('viewer-play')));
+      await tester.pump();
+      await settleFrb(tester, minRounds: 12, maxRounds: 12);
+      expect(p.uiState.playheadFrame.value, greaterThan(0),
+          reason: 'the setting keeps the playhead where the picture stopped');
     }, skip: zeroCopyViewerUnavailable);
 
     /// Running off the end is the engine's to notice: it knows the length and it

--- a/flutter_ui/test/settings_test.dart
+++ b/flutter_ui/test/settings_test.dart
@@ -39,6 +39,20 @@ void main() {
     expect(i.videoAsSequenceLayer, isFalse);
   });
 
+  /// The returning playhead is the *new* default (K-254), so unlike the Vegas
+  /// pair it does not defer to what a settings file leaves out — an install
+  /// that predates the field adopts the new behaviour rather than being pinned
+  /// to the old one by its own silence.
+  test('the playhead returns on stop unless a settings file says otherwise',
+      () {
+    expect(InterfaceSettings().playheadStaysOnStop, isFalse);
+    expect(
+        InterfaceSettings.fromJson(const {'ui_scale': 1.25}).playheadStaysOnStop,
+        isFalse);
+    final on = InterfaceSettings()..playheadStaysOnStop = true;
+    expect(InterfaceSettings.fromJson(on.toJson()).playheadStaysOnStop, isTrue);
+  });
+
   test('the Vegas pair survives a settings round-trip', () {
     final i = InterfaceSettings()
       ..retimeOpensToSpeed = true

--- a/flutter_ui/test/theme_tokens_test.dart
+++ b/flutter_ui/test/theme_tokens_test.dart
@@ -21,6 +21,7 @@ void main() {
         'textPrimary', 'textSecondary', 'textMuted', 'textDisabled',
         'hairline', 'hairlineStrong',
         'accent', 'accentHover', 'success', 'warning', 'error', 'cacheDisk',
+        'marker',
         'timelineOutOfRange', 'selectionFill',
         'curve0', 'curve1', 'curve2', 'curve3',
         'layerFootage', 'layerSequence', 'layerPrecomp',

--- a/flutter_ui/test/timeline_razor_test.dart
+++ b/flutter_ui/test/timeline_razor_test.dart
@@ -68,6 +68,7 @@ void main() {
         masks: const [],
         paint: const [],
         shapeContents: const [],
+        markers: const [],
       ),
     );
   }


### PR DESCRIPTION
Three things about the playhead, all asked for together.

## Scrubbing during playback stops it

The engine chooses frames and each arriving frame moves the playhead to follow the picture (K-181), so a drag on the ruler was unwinnable — every tick put the playhead straight back where the transport wanted it. Taking hold of the playhead now takes it **off** the transport: every ruler and lane seek goes through one new `LumitUiState.scrubTo`, which stops playback first. One funnel rather than a guard per call site — the three `onSeek` closures were three copies of `playheadFrame.value = …` and a fourth would have been written without the guard.

## Stopping returns the playhead

Stopping puts the playhead back where `play` was asked for, including when the composition simply runs out — where you are when the transport stops should not depend on why it stopped. This realises the *"stop-to-start toggle behaviour as a setting"* line docs/07 §9 has carried since the start.

The default is the returning one: playback is a preview of the moment being worked on. **Settings ▸ Interface ▸ Editing ▸ "Playhead stays where playback stopped"** restores the older After Effects behaviour. Unlike the K-246 pair it does not defer to a settings file's silence — an install written before the field adopts the new default. The first-run screen does not touch it: both answers want the returning playhead, so there is nothing for the question to decide.

The one exception is a scrub, which stops playback *in order to* go somewhere else.

## Markers on the ruler

The engine has had markers since docs/03 §11; what was missing was the ruler. Comp markers now draw as After Effects' bookmark flags — a square with its bottom corners cut to a point, its left edge on the moment it marks — in the ruler's lower row beside the work-area band, drawn last so a flag wins the pointer over a work-area handle it sits on. A one- or two-character label sits inside the flag, a longer one beside it.

They **drag** along the ruler (committed per frame crossed, holding the grab offset so the flag does not flinch to the pointer), and **right-click** offers *Edit marker…* and *Delete marker*.

The keyboard is the numbered pair every NLE has:

| Chord | What it does |
|---|---|
| `Shift+0…9` | Set numbered marker at the playhead — pressing it again *moves* that marker |
| `0…9` | Go to that marker; a digit with no marker is left unhandled, not swallowed |
| `Shift+M` (and AE's numpad `*`) | Add an unnumbered marker at the playhead |

`M` keeps Reveal Masks in the Timeline — Premiere and Vegas both use `M` for a marker, but the mask reflex is older, so the letter stays put and the marker takes Shift. Twenty new action ids described by prefix (`marker.add.N`, `marker.goto.N`) the way `workspace.switch.N` already is; the shipped keymap stays conflict-free.

## Tests

- `lumit-keymap`: every digit binds set-and-return, `Shift+M` adds, Timeline `M` still reveals masks, keymap still conflict-free.
- `shortcuts_frb`: `Ctrl+1` sets and `1` returns; a digit with no marker does nothing; `Shift+M` drops one at the playhead.
- `timeline_extras_frb`: a flag drags to a later frame keeping its id and label; right-click renames without moving it; right-click deletes; a numbered marker is replaced and an unlabelled one is not; dragging the ruler during playback stops it and the playhead holds.
- `viewer_panel_frb`: stopping returns the playhead, and stays put when the setting asks it to.
- `settings`: the new field round-trips and an older settings file adopts the new default.

## Follow-ups (logged in docs/TODO.md and the K-254 entry)

- `set_markers` still flattens every marker to `MarkerKind::User`, so editing one turns detected beats into ordinary cues and *Clear beat markers* stops finding them. Already true of the dialogue's remove button, but far easier to hit now; it wants a kind carried across `BridgeMarker`.
- docs/07 §10 wants `8` during playback to tap a beat, and the bare digits are now spoken for.

Docs updated in the same commit: K-254 appended to `02-DECISIONS.md`; `07-UI-SPEC.md` §4.1, §4.6, §9 and the §15 keymap table; a plain-English section in `GUIDE.md`.
