### PR TITLE
Menus navigate by hover, not only by click (K-255)

### DIFF
--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5009,3 +5009,21 @@ Flutter Linux embedder needs GTK 3, which only the GNOME runtime ships. Sandbox 
 (`--filesystem=host`, dri, pulseaudio) carry over from the old manifest's reasoning
 verbatim. Published as a single-file `.flatpak` on the GitHub Release; Flathub submission,
 if ever, is a separate decision.
+
+**K-254 · DECIDED · Menus navigate by hover, and the barrier stops blocking the pointer.**
+K-194 gave the menus submenus and left every one of them behind a click: with File open,
+reaching Window meant dismissing File and clicking Window, and a submenu — Open recent,
+Layer ▸ New, an Effect category — only appeared when its row was clicked. Every desktop menu
+bar these sit beside hands over on hover once a menu is open, and flies a submenu out under
+the resting pointer. The obstacle was `showLumitPopup`'s full-window barrier: `HitTestBehavior
+.opaque` swallowed hover as well as clicks, so neither the bar nor the menu underneath ever
+felt the pointer move. Menus now pass `hoverThrough: true`, which makes that barrier
+*translucent* — it still wins the click, being above what it covers, but the pointer reaches
+through. Only menus opt in: a dropdown that let the panel behind it light up under the pointer
+would be answering to a click it will never get. Two pieces of state follow. The bar keeps one
+`_openHeading`/`_closeHeading` pair (only one menu is ever open) and clears it on the open
+menu's *disposal* rather than on its close call, so a menu that goes with its window leaves the
+bar out of menus too. Each `FloatSurface` carries the hovered row of its own surface, because
+the row that flies a submenu out is never the row that has to take it back — the sibling the
+pointer moves to is — and scoping it to the surface keeps a flyout's own rows from disturbing
+the menu it came from. Regression tests: the two hover tests in `menu_bar_frb_test.dart`.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5351,6 +5351,18 @@ you rebind Save in Settings ▸ Keymap, the menu changes to match without anyone
 a menu can never teach you a shortcut that does nothing, because the same table answers both the
 menu and the keyboard.
 
+**Menus follow the pointer.** Once a menu is open, the bar is *in menus*: sliding across to
+Window or Effect swaps to that menu without another click, and resting on a row that has a
+submenu — Open recent, Layer ▸ New, an Effect category — flies it out, then takes it back when
+you move on to another row. Clicking still does everything it did.
+
+Getting that to work took one small trick worth knowing about. An open menu covers the whole
+window with an invisible sheet, which is what catches a click anywhere else and closes the menu.
+That sheet also swallowed the *pointer*, so the menu bar underneath never felt it move. Menus now
+use a sheet that still takes the click but lets hovering through, and each floating menu keeps
+track of which of its rows the pointer is on — because the row that opens a submenu is never the
+row that has to close it again.
+
 **Closing a panel is just rearranging.** The Window menu lists every panel with a tick beside
 it. Ticking one off does not set a "hidden" flag anywhere; it takes the panel out of the
 workspace arrangement, which is the thing Lumit already saves to disk when you drag panels

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -959,6 +959,15 @@ class _PaletteHotkeyState extends State<_PaletteHotkey> {
   }
 }
 
+/// The heading whose menu is up, and the handle that takes it down.
+///
+/// While one menu is open the bar is *in menus*: crossing another heading hands
+/// over to it rather than making the user click a second time, which is how the
+/// bar behaves in every application these menus sit beside. One pair for the
+/// whole bar, because only one menu is ever open.
+String? _openHeading;
+VoidCallback? _closeHeading;
+
 class _MenuButton extends StatelessWidget {
   final String title;
   final List<MenuEntry> items;
@@ -966,12 +975,19 @@ class _MenuButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return HouseButton(
-      key: ValueKey<String>('menu-$title'),
-      frameless: true,
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      onPressed: () => _open(context),
-      child: Text(title),
+    return MouseRegion(
+      // Only once a menu is already open: hovering the bar with nothing open
+      // must not start dropping menus at a passing pointer.
+      onEnter: (_) {
+        if (_openHeading != null && _openHeading != title) _open(context);
+      },
+      child: HouseButton(
+        key: ValueKey<String>('menu-$title'),
+        frameless: true,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        onPressed: () => _open(context),
+        child: Text(title),
+      ),
     );
   }
 
@@ -979,11 +995,52 @@ class _MenuButton extends StatelessWidget {
     final box = context.findRenderObject();
     if (box is! RenderBox) return;
     final origin = box.localToGlobal(Offset(0, box.size.height));
+    _closeHeading?.call();
+    _openHeading = title;
     showLumitPopup<void>(
       context: context,
       position: origin,
-      builder: (close) => _MenuList(items: items, close: () => close(null)),
+      // The bar underneath has to keep feeling the pointer; that is the whole
+      // mechanism of handing over to the next heading.
+      hoverThrough: true,
+      builder: (close) {
+        if (_openHeading == title) _closeHeading = () => close(null);
+        return _OpenMenu(
+          title: title,
+          child: _MenuList(items: items, close: () => close(null)),
+        );
+      },
     );
+  }
+}
+
+/// The open menu itself, which forgets it is open when it goes.
+///
+/// Told by disposal rather than by the close call, so a menu that goes with its
+/// window — a test ending, a reload — leaves the bar out of menus too, rather
+/// than with a heading it thinks is still open.
+class _OpenMenu extends StatefulWidget {
+  final String title;
+  final Widget child;
+  const _OpenMenu({required this.title, required this.child});
+
+  @override
+  State<_OpenMenu> createState() => _OpenMenuState();
+}
+
+class _OpenMenuState extends State<_OpenMenu> {
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  @override
+  void dispose() {
+    // Not if another heading has already taken over: this menu's disposal
+    // arrives a frame after the one that replaced it opened.
+    if (_openHeading == widget.title) {
+      _openHeading = null;
+      _closeHeading = null;
+    }
+    super.dispose();
   }
 }
 

--- a/flutter_ui/lib/widgets/controls.dart
+++ b/flutter_ui/lib/widgets/controls.dart
@@ -133,11 +133,19 @@ class MenuRow extends StatefulWidget {
   final Widget child;
   final VoidCallback onPressed;
   final bool selected;
+
+  /// What this row calls itself in its surface's hover state, for the rows that
+  /// have to know which of them the pointer is over. Defaults to the row's own
+  /// state; [SubmenuRow] passes its own, because the flyout belongs to the
+  /// submenu row rather than to the plain row it draws itself with.
+  final Object? hoverId;
+
   const MenuRow({
     super.key,
     required this.child,
     required this.onPressed,
     this.selected = false,
+    this.hoverId,
   });
 
   @override
@@ -157,7 +165,12 @@ class _MenuRowState extends State<MenuRow> {
             : null;
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hover = true),
+      onEnter: (_) {
+        setState(() => _hover = true);
+        // Tell the surface which row the pointer is on, so a submenu that is
+        // out can take itself back when the pointer moves to another row.
+        FloatSurface.hoveredRow(context)?.value = widget.hoverId ?? this;
+      },
       onExit: (_) => setState(() => _hover = false),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
@@ -177,26 +190,62 @@ class _MenuRowState extends State<MenuRow> {
 
 /// The floating popup surface every menu and dropdown shares: `surface3`
 /// fill, hairline edge, the float radius and the real drop shadow.
-class FloatSurface extends StatelessWidget {
+///
+/// It also carries the surface's hover state — which of its rows the pointer is
+/// over — because opening a flyout is one row's business and closing it again is
+/// every other row's (see [SubmenuRow]). Scoped to the surface, so the rows of a
+/// flyout never disturb the menu the flyout came from.
+class FloatSurface extends StatefulWidget {
   final Widget child;
   final double? width;
   const FloatSurface({super.key, required this.child, this.width});
 
+  /// The row of the nearest floating surface the pointer is on, or null outside
+  /// one, where no menu is being drawn.
+  static ValueNotifier<Object?>? hoveredRow(BuildContext context) =>
+      context.getInheritedWidgetOfExactType<_MenuHoverScope>()?.hovered;
+
+  @override
+  State<FloatSurface> createState() => _FloatSurfaceState();
+}
+
+class _FloatSurfaceState extends State<FloatSurface> {
+  final _hovered = ValueNotifier<Object?>(null);
+
+  @override
+  void dispose() {
+    _hovered.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
-    return Container(
-      width: width,
-      padding: const EdgeInsets.all(6),
-      decoration: BoxDecoration(
-        color: t.surface3,
-        borderRadius: BorderRadius.circular(t.tokens.floatRadius),
-        border: Border.all(color: t.hairline, width: 1),
-        boxShadow: t.floatShadow,
+    return _MenuHoverScope(
+      hovered: _hovered,
+      child: Container(
+        width: widget.width,
+        padding: const EdgeInsets.all(6),
+        decoration: BoxDecoration(
+          color: t.surface3,
+          borderRadius: BorderRadius.circular(t.tokens.floatRadius),
+          border: Border.all(color: t.hairline, width: 1),
+          boxShadow: t.floatShadow,
+        ),
+        child: widget.child,
       ),
-      child: child,
     );
   }
+}
+
+class _MenuHoverScope extends InheritedWidget {
+  final ValueNotifier<Object?> hovered;
+
+  const _MenuHoverScope({required this.hovered, required super.child});
+
+  // The notifier itself never changes; the rows listen to it directly.
+  @override
+  bool updateShouldNotify(_MenuHoverScope old) => false;
 }
 
 /// A dropdown drawn as a bare label + caret; the open list floats on the
@@ -724,7 +773,14 @@ class _HouseTextFieldState extends State<HouseTextField> {
 /// first would take this row's `BuildContext` with it, and the overlay the
 /// submenu needs is reached *through* that context. Picking something in the
 /// submenu dismisses both.
-class SubmenuRow extends StatelessWidget {
+///
+/// **Hovering is enough.** Resting on the row flies the submenu out and moving
+/// on to another row of the same menu takes it back, which is how every menu on
+/// every desktop behaves; clicking still works for anyone who clicks. The row
+/// cannot see the pointer leave for a sibling — the flyout's own barrier is in
+/// the way — so it watches the surface's hover state instead ([FloatSurface]),
+/// which the sibling sets when the pointer arrives on it.
+class SubmenuRow extends StatefulWidget {
   final Widget child;
 
   /// Closes the menu this row belongs to.
@@ -742,32 +798,85 @@ class SubmenuRow extends StatelessWidget {
   });
 
   @override
+  State<SubmenuRow> createState() => _SubmenuRowState();
+}
+
+class _SubmenuRowState extends State<SubmenuRow> {
+  ValueNotifier<Object?>? _hovered;
+
+  /// True from the moment the flyout is asked for; [_close] arrives a frame
+  /// later, when the overlay builds it.
+  bool _out = false;
+  VoidCallback? _close;
+
+  @override
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
-    return Builder(
-      builder: (rowContext) => MenuRow(
-        onPressed: () {
-          final box = rowContext.findRenderObject();
-          if (box is! RenderBox) return;
-          // Beside the row, overlapping it slightly, the way a flyout sits.
-          final at = box.localToGlobal(Offset(box.size.width - 6, -4));
-          showLumitPopup<void>(
-            context: rowContext,
-            position: at,
-            builder: (close) => submenu(() {
-              close(null);
-              closeParent();
-            }),
-          );
-        },
-        child: Row(
-          children: [
-            Expanded(child: child),
-            Text('›', style: t.body.copyWith(color: t.textMuted)),
-          ],
-        ),
+    final hovered = FloatSurface.hoveredRow(context);
+    if (hovered != _hovered) {
+      _hovered?.removeListener(_hoverMoved);
+      _hovered = hovered?..addListener(_hoverMoved);
+    }
+    return MenuRow(
+      hoverId: this,
+      onPressed: _open,
+      child: Row(
+        children: [
+          Expanded(child: widget.child),
+          Text('›', style: t.body.copyWith(color: t.textMuted)),
+        ],
       ),
     );
+  }
+
+  void _hoverMoved() {
+    if (_hovered?.value == this) {
+      _open();
+    } else {
+      _out = false;
+      _close?.call();
+      _close = null;
+    }
+  }
+
+  void _open() {
+    if (_out) return;
+    final box = context.findRenderObject();
+    if (box is! RenderBox) return;
+    // Beside the row, overlapping it slightly, the way a flyout sits.
+    final at = box.localToGlobal(Offset(box.size.width - 6, -4));
+    _out = true;
+    showLumitPopup<void>(
+      context: context,
+      position: at,
+      // So the menu underneath still feels the pointer: moving to another row
+      // is what takes this flyout back.
+      hoverThrough: true,
+      builder: (close) {
+        _close = () => close(null);
+        return widget.submenu(() {
+          close(null);
+          widget.closeParent();
+        });
+      },
+    ).then((_) {
+      _out = false;
+      _close = null;
+    });
+  }
+
+  @override
+  void dispose() {
+    _hovered?.removeListener(_hoverMoved);
+    // The menu this row belongs to has gone (another heading took over, say);
+    // its flyout goes with it rather than being left behind. After the frame,
+    // because removing an overlay entry sets the overlay's state and this is
+    // the middle of a tear-down.
+    final close = _close;
+    if (close != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => close());
+    }
+    super.dispose();
   }
 }
 
@@ -775,6 +884,11 @@ Future<T?> showLumitPopup<T>({
   required BuildContext context,
   required Offset position,
   required Widget Function(void Function(T?) close) builder,
+  // Whether what is underneath still feels the pointer while this popup is up.
+  // Menus want it — hovering another heading or another row is how a menu is
+  // navigated — and nothing else does: a dropdown that let the panel behind it
+  // light up under the pointer would be answering to a click it will not get.
+  bool hoverThrough = false,
 }) {
   final overlay = Overlay.of(context);
   final completer = Completer<T?>();
@@ -795,8 +909,13 @@ Future<T?> showLumitPopup<T>({
       builder: (context, constraints) => Stack(
         children: [
           Positioned.fill(
+            // Translucent still takes the click — it is above whatever it
+            // covers, so it wins the gesture arena — but lets hover through to
+            // the menu bar and to the menu this one flew out of.
             child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
+              behavior: hoverThrough
+                  ? HitTestBehavior.translucent
+                  : HitTestBehavior.opaque,
               onTap: () => close(null),
               onSecondaryTap: () => close(null),
             ),

--- a/flutter_ui/test/frb/keymap_frb_test.dart
+++ b/flutter_ui/test/frb/keymap_frb_test.dart
@@ -212,15 +212,24 @@ void main() {
       // The Timeline's zoom-in takes Undo's app-wide chord: both are live in
       // the Timeline at once, so it is a clash rather than a replacement.
       //
-      // Made before the page opens, and *not* awaited: a bridge Future only
+      // Made before the page opens, because the banner is built from the
+      // keymap the page finds. It is *not* awaited — a bridge Future only
       // completes on a real event-loop turn, and there is no tester to turn
-      // one until a widget is pumped. The engine applies the change on the
-      // call itself, which is all this needs.
+      // one until a widget is pumped — but nor is it done when it returns:
+      // the call lands on the engine's worker thread, and a machine quick
+      // enough to make that look instant is not a machine to design a test
+      // around (the Linux runner lost this race). So the clash is waited for
+      // at its source, which needs a tree to pump: hence the placeholder.
       unawaited(keymapRebind(
         context: BridgeKeyContext.timeline,
         action: 'timeline.zoom.in',
         chord: 'Mod+Z',
       ));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await settleFrb(tester, until: () => keymapConflicts().isNotEmpty);
+      expect(keymapConflicts(), isNotEmpty,
+          reason: 'the engine has the clash before the page is built');
+
       await openKeymapPage(tester);
 
       expect(find.byKey(const ValueKey('keymap-conflicts')), findsOneWidget);

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -16,6 +16,7 @@
 
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/main.dart';
@@ -697,6 +698,85 @@ void main() {
       await tester.tap(find.text('Open recent'));
       await tester.pump();
       expect(find.text('C:/projects/yesterday.lum'), findsOneWidget);
+    });
+
+    /// A pointer that can hover, for the two tests below. The menus are driven
+    /// by hover as much as by clicks, and a test's synthetic taps carry no
+    /// pointer at all unless one is added.
+    Future<TestGesture> mouse(WidgetTester tester) async {
+      final gesture =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+      return gesture;
+    }
+
+    /// **Once a menu is open the bar is in menus.** Crossing another heading
+    /// hands over to it, rather than leaving the first menu up until it is
+    /// clicked away and the second one clicked open.
+    testWidgets('a heading hands over to the next one on hover', (tester) async {
+      await mount(tester);
+      final pointer = await mouse(tester);
+
+      // Nothing open: the bar is inert under a passing pointer.
+      await pointer
+          .moveTo(tester.getCenter(find.byKey(const ValueKey('menu-Edit'))));
+      await tester.pump();
+      expect(find.text('Redo'), findsNothing,
+          reason: 'hover alone must not start dropping menus');
+
+      // Onto the heading being clicked, the way a real pointer arrives: the
+      // handover is an *arrival* on a heading, and a pointer that never left
+      // Edit has not arrived anywhere.
+      await pointer
+          .moveTo(tester.getCenter(find.byKey(const ValueKey('menu-File'))));
+      await tester.tap(find.byKey(const ValueKey<String>('menu-File')));
+      await tester.pump();
+      expect(find.text('Open recent'), findsOneWidget);
+
+      await pointer
+          .moveTo(tester.getCenter(find.byKey(const ValueKey('menu-Edit'))));
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Redo'), findsOneWidget, reason: 'Edit took over');
+      expect(find.text('Open recent'), findsNothing,
+          reason: 'and File went with it');
+
+      await dismiss(tester);
+      await pointer
+          .moveTo(tester.getCenter(find.byKey(const ValueKey('menu-Layer'))));
+      await tester.pump();
+      expect(find.text('Pre-compose…'), findsNothing,
+          reason: 'dismissed means out of menus again');
+    });
+
+    /// A submenu flies out under the pointer and takes itself back when the
+    /// pointer moves on to another row — Open recent here, the Effect
+    /// categories by the same mechanism.
+    testWidgets('a submenu opens on hover and closes when you move off',
+        (tester) async {
+      final p = await mount(tester);
+      p.uiState.workspace.rememberProject('C:/projects/yesterday.lum');
+      p.state.notifyDocumentChanged();
+      await tester.pump();
+      final pointer = await mouse(tester);
+
+      await tester.tap(find.byKey(const ValueKey<String>('menu-File')));
+      await tester.pump();
+
+      await pointer.moveTo(tester.getCenter(find.text('Open recent')));
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('C:/projects/yesterday.lum'), findsOneWidget,
+          reason: 'resting on the row is enough to see what is behind it');
+
+      await pointer.moveTo(tester.getCenter(find.text('Save')));
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('C:/projects/yesterday.lum'), findsNothing,
+          reason: 'the flyout goes back when another row takes the pointer');
+      expect(find.text('Open recent'), findsOneWidget,
+          reason: 'the menu it flew out of is still up');
     });
   }, skip: !engineAvailable);
 }


### PR DESCRIPTION
## What

Once a menu is open, the bar is *in menus*: sliding across to Window or Effect swaps to that menu without a second click, and resting on a row with a submenu — Open recent, Layer ▸ New, View ▸ Resolution, Window ▸ Workspace, an Effect category — flies it out, then takes it back when the pointer moves to another row. Clicking still does everything it did, and hovering the bar with nothing open still does nothing.

## Why it needed a change to the barrier

K-194 gave the menus submenus and left every one of them behind a click. The obstacle was `showLumitPopup`'s full-window barrier — the invisible sheet that catches a click anywhere else and closes the menu. At `HitTestBehavior.opaque` it swallowed hover as well as clicks, so neither the bar nor the menu underneath ever felt the pointer move.

Menus now pass `hoverThrough: true`, which makes that barrier **translucent**: it still wins the click, being above what it covers, but the pointer reaches through. Only menus opt in — a dropdown that let the panel behind it light up under the pointer would be answering to a click it will never get.

## What a reviewer should look at

- **`FloatSurface` now carries state.** Each floating surface tracks which of its rows the pointer is on, because the row that flies a submenu out is never the row that has to take it back — the sibling the pointer moves to is. Scoping it per surface is what keeps a flyout's own rows from disturbing the menu it came from.
- **The bar's open-heading pair is module state** (`_openHeading`/`_closeHeading` in `menu_bar_frb.dart`). One pair, because only one menu is ever open. It is cleared on the open menu's *disposal* rather than on its close call, so a menu that goes with its window — a test ending, a reload — leaves the bar out of menus too rather than with a heading it thinks is still up.
- **The gesture arena is load-bearing.** A translucent barrier still consumes the click because it sits above what it covers and is therefore first in the hit-test path. The existing `dismiss()` tests cover that; worth a sanity read.
- `SubmenuRow` became stateful and closes its flyout from `dispose` via a post-frame callback, since removing an overlay entry sets the overlay's state and disposal is the middle of a tear-down.

## One unrelated test fix, because it failed here

`keymap_frb_test.dart`'s clash test rebinds `timeline.zoom.in` onto Undo's chord and then opens the Keymap page, which builds its banner from the keymap it finds. The rebind is an frb call onto the engine's worker thread — not done when it returns — so the page could be built before the clash existed. The Linux runner lost that race on this branch; **re-running the same commit passed**, which is what identified it as a pre-existing flake rather than fallout from these changes. It now settles on `keymapConflicts()` before opening the page.

## Tests and docs

Two regression tests in `menu_bar_frb_test.dart`: heading handover (including that hover alone opens nothing), and a submenu opening on hover and closing when the pointer moves off. `flutter analyze` clean; all CI green.

`docs/GUIDE.md` gains a plain-English paragraph and `docs/02-DECISIONS.md` a **K-255** entry, which extends rather than reverses K-194. (The first commit's subject says K-254 — #39 landed and claimed that number first, so the entry was renumbered when main was merged in.)

Not done: keyboard traversal of menus (arrow keys, alt-mnemonics).