### PR TITLE
Precomps, in the two places they fell through: a track matte that gates, and effects that keep their pixels (K-268)

### DIFF
--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -373,42 +373,50 @@ pub fn build_comp_draws_at(
     // planner (app_state::collect_comp_jobs) decodes layer-input references
     // exactly like matte sources, and export applies the same in-span-only
     // gate (K-031).
-    // A layer-input reference to a PRECOMP (K-266): its picture exists only
-    // as a render, so package the nested comp's draw list for realise to
-    // run recursively — the DrawSource::Nested shape, on the input slot.
+    // A reference to a PRECOMP — as a layer input (K-266) or as a track matte
+    // (K-268): its picture exists only as a render, so package the nested
+    // comp's draw list for realise to run recursively — the DrawSource::Nested
+    // shape, on the referencing slot.
     // `visited_path` is a snapshot of the ancestor chain at this comp's
     // entry, so a matte that (transitively) contains its own comp stops at
-    // the cycle instead of recursing forever; a fresh clone per input keeps
-    // the closure borrow-free. Footage INSIDE such a precomp only has
-    // pixels when the decode planner visited it as a placed layer too —
-    // solids, text, shapes and nested renders always work (docs boundary).
+    // the cycle instead of recursing forever; a fresh clone per reference keeps
+    // the closure borrow-free. Footage INSIDE such a precomp decodes with the
+    // rest of the frame: the decode planner walks matte and layer-input
+    // references (plan::collect_comp_jobs) whether or not the referenced
+    // layer is visible.
     let visited_path: Vec<uuid::Uuid> = visited.clone();
-    let nested_input_for = |src: &lumit_core::model::Layer| -> Option<DofInputDraw> {
-        let lumit_core::model::LayerKind::Precomp { comp: nested_id } = &src.kind else {
-            return None;
+    let nested_comp_draw =
+        |src: &lumit_core::model::Layer| -> Option<Box<crate::draw::NestedInputDraw>> {
+            let lumit_core::model::LayerKind::Precomp { comp: nested_id } = &src.kind else {
+                return None;
+            };
+            if visited_path.contains(nested_id) {
+                return None;
+            }
+            let nested = doc.comp(*nested_id)?;
+            let slt = t_comp - src.start_offset.0.to_f64();
+            let frame_slt = frame_t - src.start_offset.0.to_f64();
+            let mut path = visited_path.clone();
+            path.push(*nested_id);
+            let draws =
+                build_comp_draws_at(doc, nested, slt, frame_slt, pixels_by_layer, &mut path);
+            Some(Box::new(crate::draw::NestedInputDraw {
+                width: nested.width,
+                height: nested.height,
+                background: [0.0, 0.0, 0.0, 0.0],
+                draws,
+                camera: nested.camera_pose(slt),
+            }))
         };
-        if visited_path.contains(nested_id) {
-            return None;
-        }
-        let nested = doc.comp(*nested_id)?;
-        let slt = t_comp - src.start_offset.0.to_f64();
-        let frame_slt = frame_t - src.start_offset.0.to_f64();
-        let mut path = visited_path.clone();
-        path.push(*nested_id);
-        let draws = build_comp_draws_at(doc, nested, slt, frame_slt, pixels_by_layer, &mut path);
+    let nested_input_for = |src: &lumit_core::model::Layer| -> Option<DofInputDraw> {
+        let nested = nested_comp_draw(src)?;
         Some(DofInputDraw {
             rgba: Vec::new(),
             tex_w: nested.width,
             tex_h: nested.height,
             fx: Vec::new(),
             lut_files: Vec::new(),
-            nested: Some(Box::new(crate::draw::NestedInputDraw {
-                width: nested.width,
-                height: nested.height,
-                background: [0.0, 0.0, 0.0, 0.0],
-                draws,
-                camera: nested.camera_pose(slt),
-            })),
+            nested: Some(nested),
         })
     };
 
@@ -807,10 +815,25 @@ pub fn build_comp_draws_at(
 
         let matte = layer.matte.as_ref().and_then(|mr| {
             let src = comp.layers.iter().find(|l| l.id == mr.layer)?;
+            // A Precomp matte renders its comp (K-268): a comp has no pixels
+            // until it is rendered, so `pixels_for` gives up on one and the
+            // matte silently gated nothing — a layer set to a precomp matte
+            // simply vanished. The nested render stands in for the source
+            // texture; the source-mode toggles below do not apply to it,
+            // because a comp already carries its layers' own masks and
+            // effects (the K-266 layer-input boundary, unchanged).
+            let nested = in_span(src).then(|| nested_comp_draw(src)).flatten();
             // Matte source mode (K-142). None reads the source's raw pixels —
             // clear its masks so `pixels_for` skips them; Masks and Effects and
             // masks keep them.
-            let (m_rgba, m_w, m_h, m_nat) = if mr.source.applies_masks() {
+            let (m_rgba, m_w, m_h, m_nat) = if let Some(n) = &nested {
+                (
+                    Vec::new(),
+                    n.width,
+                    n.height,
+                    (n.width as f32, n.height as f32),
+                )
+            } else if mr.source.applies_masks() {
                 pixels_for(src)?
             } else {
                 let mut bare = src.clone();
@@ -825,7 +848,10 @@ pub fn build_comp_draws_at(
             // (its px@comp radii stay honest under reduced-res preview), the same
             // §1.4 markers and the same resolve export uses (K-031). Empty for
             // None / Masks or when the source's fx switch is off.
-            let (fx, lut_files) = if mr.source.folds_effects() && src.switches.fx {
+            let (fx, lut_files) = if nested.is_some() {
+                // The nested render already ran every layer's own stack.
+                (Vec::new(), Vec::new())
+            } else if mr.source.folds_effects() && src.switches.fx {
                 let comp_diag = ((comp.width as f32).powi(2) + (comp.height as f32).powi(2)).sqrt();
                 let scale = m_w as f32 / m_nat.0.max(1.0);
                 let markers = lumit_core::fx::MarkerContext::for_layer(comp, src);
@@ -869,6 +895,7 @@ pub fn build_comp_draws_at(
                 inverted: mr.inverted,
                 fx,
                 lut_files,
+                nested,
             })
         });
 
@@ -903,6 +930,17 @@ pub fn build_comp_draws_at(
             } else {
                 Vec::new()
             }
+        };
+        // Effects ON a Precomp layer run on the nested comp's raster, and that
+        // raster shrinks with the preview scale while the stack above resolved
+        // px@comp parameters at factor 1 — the K-266 disease on the nested arm
+        // (K-268). Hand realise the width the stack was resolved against (the
+        // nested comp's own width) and it rescales to whatever it renders at,
+        // exactly as it does for an adjustment layer. `None` for every other
+        // kind: a Pixels stack already resolved at its decode scale above.
+        let fx_ref_width = match &source {
+            DrawSource::Nested { width, .. } => Some(*width as f32),
+            DrawSource::Pixels { .. } | DrawSource::Adjust => None,
         };
         // Decoded neighbour frames for a temporal effect (echo), carried from
         // the layer's decode job; empty for a plain stack.
@@ -976,7 +1014,7 @@ pub fn build_comp_draws_at(
             dof_inputs: dof_inputs_for(&layer.effects),
             flare_mattes: flare_mattes_for(&layer.effects),
             flare_lens_files: flare_lens_files(&layer.effects, lt),
-            fx_ref_width: None,
+            fx_ref_width,
             // Per-layer motion blur (docs/06 §4, K-120): the layer's own
             // transform sampled across the open shutter, empty unless it blurs.
             // Built the same way export does, so the two smear identically.

--- a/crates/lumit-render/src/draw.rs
+++ b/crates/lumit-render/src/draw.rs
@@ -47,6 +47,16 @@ pub struct MatteDraw {
     /// Lut` ops in `fx` (as for a layer's own `lut_files`). Empty unless the
     /// source mode is `EffectsAndMasks` and the matte source has a LUT.
     pub lut_files: Vec<Option<String>>,
+    /// Set when the matte source is a **Precomp** (K-268): the nested comp's
+    /// own draw list, realised recursively exactly as a Precomp layer's
+    /// picture is — `rgba` is then empty and `tex_w`/`tex_h` are the nested
+    /// comp's size. A comp has no pixels until it is rendered, so `pixels_for`
+    /// answers None for one, and a track matte set to a precomp silently
+    /// gated nothing at all until this field existed (the layer-input twin of
+    /// the same hole was K-266's `DofInputDraw::nested`). The source-mode
+    /// masks/effects toggles do not apply to a comp reference — the comp
+    /// renders as itself, its layers' own masks and effects included.
+    pub nested: Option<Box<NestedInputDraw>>,
 }
 
 /// A depth-of-field depth input packaged for the compositor (docs/impl/

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -3111,4 +3111,143 @@ mod tests {
             println!("PREVIEW {label:>10} scale={scale:<5} {each:>7.2} ms/frame");
         }
     }
+
+    /// **A precomp set as a track matte must actually gate the layer** (K-268).
+    ///
+    /// The regression: a comp has no pixels until it is rendered, so the draw
+    /// builder's `pixels_for` answered None for a Precomp matte source and the
+    /// whole matte quietly disappeared — the consumer drew everywhere, as if
+    /// no matte had been set. K-266 fixed the same hole for the *layer-input*
+    /// mattes (a flare source, a DoF depth pass); the track matte, which is
+    /// how everyone actually reaches for a precomp matte, still had it.
+    ///
+    /// The scene: a full-frame red solid matted by a hidden precomp layer whose
+    /// own 16×16 blue solid covers the LEFT half of a 32×16 comp. Red survives
+    /// where the precomp has alpha and nowhere else.
+    #[test]
+    fn a_precomp_track_matte_gates_the_layer() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("skipping: no GPU adapter");
+                return;
+            }
+        };
+        let (cw, ch) = (32u32, 16u32);
+        let (mut doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.8, 0.1, 0.1, 1.0]));
+        let (child_doc, child_id, _) = matrix_base(16, 16, LinearColour([0.1, 0.2, 0.9, 1.0]));
+        for item in child_doc.items {
+            doc.items.push(item);
+        }
+        // The matte itself is hidden, as a matte source always is.
+        let mut matte = matrix_layer("Matte", LayerKind::Precomp { comp: child_id }, 16, 16);
+        matte.switches.visible = false;
+        let matte_id = matte.id;
+        {
+            let comp = doc.comp_mut(comp_id).unwrap();
+            comp.layers[0].matte = Some(lumit_core::model::MatteRef {
+                layer: matte_id,
+                channel: lumit_core::model::MatteChannel::Alpha,
+                inverted: false,
+                source: lumit_core::model::LayerInputSource::default(),
+            });
+            comp.layers.push(matte);
+        }
+
+        let (rgba, w, h) = r.render_rgba(&doc, comp_id, 0, 1.0).expect("render");
+        assert_eq!((w, h), (cw, ch));
+        let at = |x: u32, y: u32| {
+            let i = ((y * w + x) * 4) as usize;
+            (rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3])
+        };
+        // Left half: inside the precomp's opaque square, so the red shows.
+        let (lr, _lg, _lb, la) = at(8, 8);
+        assert!(lr > 150, "red should survive under the matte, got {lr}");
+        assert_eq!(la, 255, "and it should be opaque there");
+        // Right half: the precomp is transparent there, so nothing is drawn —
+        // this is the pixel that stayed red while the matte was being dropped.
+        let (rr, rg, rb, _ra) = at(24, 8);
+        assert!(
+            rr < 30 && rg < 30 && rb < 30,
+            "outside the precomp matte the layer must be gated out, got {:?}",
+            (rr, rg, rb)
+        );
+    }
+
+    /// **An effect ON a Precomp layer must keep its px@comp parameters where
+    /// they were put when the preview renders at a reduced resolution**
+    /// (K-268, the twin of K-266's adjustment-layer fix).
+    ///
+    /// The regression: the stack of a Precomp layer resolves against the nested
+    /// comp's full width (factor 1) but runs on the nested comp's *preview*
+    /// raster, so every px@comp parameter — a Transform's offset here, a
+    /// flare's light or a blur radius in the wild — landed further across the
+    /// picture the coarser the preview got. Preview-only drift: full resolution
+    /// was always right.
+    ///
+    /// The scene: a 32×32 precomp of solid white, offset 8 px right by a
+    /// Transform effect on the precomp layer. Eight of thirty-two is a quarter
+    /// of the frame at every resolution, so the same fractions are empty and
+    /// filled at Full and at Half.
+    #[test]
+    fn an_effect_on_a_precomp_layer_keeps_its_pixels_under_half_preview() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                eprintln!("skipping: no GPU adapter");
+                return;
+            }
+        };
+        let (cw, ch) = (32u32, 32u32);
+        let white = LinearColour([1.0, 1.0, 1.0, 1.0]);
+        let (mut doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.0, 0.0, 0.0, 1.0]));
+        let (child_doc, child_id, _) = matrix_base(cw, ch, white);
+        for item in child_doc.items {
+            doc.items.push(item);
+        }
+        // The base black solid only exists to give matrix_base a comp; the
+        // precomp layer covers it entirely, so what is measured is the
+        // precomp's own white, shifted.
+        let mut nested = matrix_layer("Nested", LayerKind::Precomp { comp: child_id }, cw, ch);
+        let mut fx = lumit_core::fx::instantiate("transform").unwrap();
+        for p in &mut fx.params {
+            let v = match p.id.as_str() {
+                "position_x" => 8.0,
+                "anchor_x" | "anchor_y" | "position_y" | "rotation" => 0.0,
+                _ => continue,
+            };
+            p.value = lumit_core::model::EffectValue::Float(Property::fixed(v));
+        }
+        nested.effects.push(fx);
+        // Index 0 is the top of the stack, over the black base.
+        doc.comp_mut(comp_id).unwrap().layers.insert(0, nested);
+
+        // The white starts a quarter of the way across, at both resolutions.
+        for (label, scale) in [("full", 1.0f32), ("half", 0.5f32)] {
+            let quality = Quality {
+                auto_res: scale < 1.0,
+                display_scale: scale,
+                ..Quality::default()
+            };
+            let (rgba, w, h) = r
+                .render_preview(&doc, comp_id, 0, quality, scale)
+                .expect("render");
+            let at = |fx: f32| {
+                let x = ((w as f32 * fx) as u32).min(w - 1);
+                let y = h / 2;
+                let i = ((y * w + x) * 4) as usize;
+                rgba[i]
+            };
+            assert!(
+                at(0.125) < 40,
+                "{label}: the first eighth is behind the offset, got {}",
+                at(0.125)
+            );
+            assert!(
+                at(0.375) > 200,
+                "{label}: three eighths across is inside the shifted picture, got {}",
+                at(0.375)
+            );
+        }
+    }
 }

--- a/crates/lumit-render/src/plan.rs
+++ b/crates/lumit-render/src/plan.rs
@@ -575,4 +575,156 @@ mod tests {
         wide.target_width = Some(640);
         assert!(!same_decode(&[job(l, i, 5)], &[wide]));
     }
+
+    /// **Footage inside a precomp that is referenced only as a matte still gets
+    /// decoded** (K-268).
+    ///
+    /// K-266 recorded this as an open boundary — "the decode planner never
+    /// visits a matte-only precomp" — and taught the draw builder to render the
+    /// nested comp anyway. The planner turned out to walk the reference
+    /// already: a matte source and a layer-input reference are both `wanted`
+    /// whether or not the layer is visible, and a Precomp among them recurses.
+    /// So the boundary was the *draw* side, which K-266 and K-268 have now
+    /// closed at both ends — and this test is what keeps the planner honest, so
+    /// nobody has to re-derive it from a black matte.
+    ///
+    /// Both shapes of reference are checked: the track matte (`Layer::matte`)
+    /// and the layer-input parameter a flare's Matte source or a DoF depth pass
+    /// uses.
+    #[test]
+    fn a_matte_only_precomp_still_decodes_its_footage() {
+        use lumit_core::model::{
+            Composition, Document, EffectInstance, EffectKey, EffectNamespace, EffectParam,
+            EffectValue, FootageItem, Layer, LayerKind, LinearColour, MatteChannel, MatteRef,
+            MediaRef, Switches, TransformGroup,
+        };
+        use lumit_core::time::{CompTime, Duration, FrameRate, Rational};
+        use std::collections::HashMap;
+
+        let layer = |kind: LayerKind| Layer {
+            markers: Vec::new(),
+            id: Uuid::now_v7(),
+            name: "l".into(),
+            kind,
+            in_point: CompTime(Rational::ZERO),
+            out_point: CompTime(Rational::new(10, 1).unwrap()),
+            start_offset: CompTime(Rational::ZERO),
+            transform: TransformGroup::default(),
+            matte: None,
+            parent: None,
+            label: 0,
+            volume_db: lumit_core::anim::Property::zero(),
+            retime: None,
+            interpolation: lumit_core::retime::Interpolation::default(),
+            blend: lumit_core::model::BlendMode::default(),
+            masks: Vec::new(),
+            paint: Vec::new(),
+            effects: Vec::new(),
+            switches: Switches::default(),
+            extra: serde_json::Map::new(),
+        };
+        let comp = |layers: Vec<Layer>| Composition {
+            id: Uuid::now_v7(),
+            name: "c".into(),
+            width: 64,
+            height: 64,
+            frame_rate: FrameRate::new(60, 1).unwrap(),
+            duration: Duration(Rational::new(10, 1).unwrap()),
+            background: LinearColour::BLACK,
+            work_area: None,
+            layers,
+            markers: Vec::new(),
+            motion_blur: lumit_core::model::MotionBlur::default(),
+            extra: serde_json::Map::new(),
+        };
+
+        // Two ways of pointing at the same hidden precomp, one per case.
+        for track_matte in [true, false] {
+            let mut doc = Document::new();
+            let item = Uuid::now_v7();
+            doc.items.push(ProjectItem::Footage(FootageItem {
+                id: item,
+                name: "f".into(),
+                media: MediaRef {
+                    relative_path: "f.mp4".into(),
+                    absolute_path: "/f.mp4".into(),
+                    fingerprint: None,
+                    extra: serde_json::Map::new(),
+                },
+                extra: serde_json::Map::new(),
+            }));
+            let inner = comp(vec![layer(LayerKind::Footage { item })]);
+            let inner_id = inner.id;
+            doc.items.push(ProjectItem::Composition(inner));
+
+            // The precomp is hidden — a matte source always is.
+            let mut matte_layer = layer(LayerKind::Precomp { comp: inner_id });
+            matte_layer.switches.visible = false;
+            let mut consumer = layer(LayerKind::Solid {
+                def: Uuid::now_v7(),
+            });
+            if track_matte {
+                consumer.matte = Some(MatteRef {
+                    layer: matte_layer.id,
+                    channel: MatteChannel::Alpha,
+                    inverted: false,
+                    source: lumit_core::model::LayerInputSource::default(),
+                });
+            } else {
+                consumer.effects.push(EffectInstance {
+                    id: Uuid::now_v7(),
+                    effect: EffectKey {
+                        namespace: EffectNamespace::Builtin,
+                        match_name: "lens_flare".into(),
+                        version: 1,
+                        extra: serde_json::Map::new(),
+                    },
+                    enabled: true,
+                    params: vec![
+                        EffectParam {
+                            id: "source_type".into(),
+                            value: EffectValue::Choice(1),
+                            extra: serde_json::Map::new(),
+                        },
+                        EffectParam {
+                            id: "matte".into(),
+                            value: EffectValue::Layer(Some(matte_layer.id)),
+                            extra: serde_json::Map::new(),
+                        },
+                    ],
+                    sample_temporally: true,
+                    extra: serde_json::Map::new(),
+                });
+            }
+            let outer = comp(vec![consumer, matte_layer]);
+            let outer_id = outer.id;
+            doc.items.push(ProjectItem::Composition(outer));
+
+            let probes: HashMap<Uuid, crate::SourceProbe> = [(
+                item,
+                crate::SourceProbe::Video {
+                    fps: 60.0,
+                    width: 64,
+                    height: 64,
+                    frames: 600,
+                    audio: false,
+                },
+            )]
+            .into_iter()
+            .collect();
+            let outer = doc.comp(outer_id).unwrap();
+            let jobs = plan_comp_frame(&doc, outer, 0.0, Quality::default(), &probes);
+            let how = if track_matte {
+                "a track matte"
+            } else {
+                "a layer-input matte"
+            };
+            assert_eq!(
+                jobs.len(),
+                1,
+                "{how} onto a precomp must plan the one decode its footage needs"
+            );
+            assert_eq!(jobs[0].item, item);
+        }
+    }
 }

--- a/crates/lumit-render/src/realise.rs
+++ b/crates/lumit-render/src/realise.rs
@@ -425,13 +425,27 @@ impl Realiser<'_> {
                 let layer_inputs = self.render_dof_inputs(&l.dof_inputs, w, h);
                 let flare_mattes = self.render_dof_inputs(&l.flare_mattes, w, h);
                 let flare_lens = self.load_flare_lens(&l.flare_lens_files);
+                // A stack resolved against a raster wider than the one it is
+                // about to run on (a Precomp layer's, under reduced-resolution
+                // preview) has its px@comp parameters rescaled to this raster,
+                // the same correction the adjustment path applies (K-266,
+                // K-268). `None` — every other kind — resolved at its own
+                // decode scale already, so nothing moves.
+                let fx_ops = match l.fx_ref_width {
+                    Some(ref_w) if ref_w > 0.0 => {
+                        let mut ops = l.fx.clone();
+                        lumit_core::fx::rescale_px(&mut ops, w as f32 / ref_w);
+                        ops
+                    }
+                    _ => l.fx.clone(),
+                };
                 crate::fxops::run_ops(
                     self.fx,
                     &self.ctx,
                     tex,
                     w,
                     h,
-                    &l.fx,
+                    &fx_ops,
                     &neighbours,
                     flow.as_ref(),
                     &luts,
@@ -486,10 +500,17 @@ impl Realiser<'_> {
             .iter()
             .map(|l| {
                 l.matte.as_ref().map(|m| {
-                    let src = self
-                        .engine
-                        .upload_srgb8(&self.ctx, &m.rgba, m.tex_w, m.tex_h);
-                    let linear = self.engine.linearise(&self.ctx, &src);
+                    // A Precomp matte realises its nested comp exactly as a
+                    // Precomp layer's picture does (K-268, the K-266 layer-input
+                    // shape); anything else is the uploaded source pixels.
+                    let linear = if let Some(n) = &m.nested {
+                        self.realise(n.camera, n.width, n.height, n.background, &n.draws)
+                    } else {
+                        let src = self
+                            .engine
+                            .upload_srgb8(&self.ctx, &m.rgba, m.tex_w, m.tex_h);
+                        self.engine.linearise(&self.ctx, &src)
+                    };
                     // After-effects matte (K-decision): run the matte source's own
                     // stack on its texture before it gates the consumer, so a keyed
                     // or blurred matte works. Temporal inputs stay empty in v1 — the

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5496,3 +5496,31 @@ order, CPU and GPU op-for-op). A one-tile point source is its own anchor's only
 contributor and reads exactly as before; the owner's white-circle precomp now carries
 the flux of every tile it lights. Position stays the anchor pixel; sub-tile centroid
 positioning would be the next refinement if ever needed.
+
+**K-268 · DECIDED · A precomp gates as a track matte, and an effect on a Precomp layer
+keeps its pixels under a reduced preview.** Two holes on the same seam — what a Precomp
+layer *is* to the code that consumes it — found by reading K-266's own recorded
+boundary. **(1) A precomp set as a TRACK matte gated nothing at all.** K-266 fixed the
+layer-input mattes (a flare's Matte source, a DoF depth pass) by giving them an optional
+nested draw list; the track matte — `Layer::matte`, the row everyone actually reaches for
+— still ran through `pixels_for`, which has no pixels for a comp, so the matte silently
+became "no matte" and the consumer drew everywhere. `MatteDraw` now carries the same
+`nested` draw list, built by the shared `nested_comp_draw` helper (one ancestor-path
+cycle guard for both kinds of reference) and realised recursively exactly as a Precomp
+layer's picture is. The source-mode toggles (None / Masks / Effects and masks) do not
+apply to a comp reference — a comp already carries its layers' own masks and effects —
+which is the K-266 boundary, unchanged and now shared. **(2) K-266's recorded boundary
+was on the wrong side.** "Footage inside a matte-only precomp needs the decode planner
+taught" — the planner was already teaching it: `collect_comp_jobs` puts a matte source
+and a layer-input reference into `wanted` whether or not the layer is visible, and a
+Precomp among them recurses. Pinned now by a test over both shapes of reference, so the
+next reader gets a passing test rather than a note to re-derive. **(3) The Precomp twin
+of K-266's px@comp drift.** Effects ON a Precomp layer resolved px@comp parameters at
+factor 1 against the nested comp's width while running on the nested comp's *preview*
+raster, so a Transform's offset, a flare's light or a blur radius drifted by exactly the
+preview factor — preview only, full resolution always correct. The Nested arm now carries
+`fx_ref_width` (the nested comp's own width) and the realise walk applies
+`raster_width / ref_width` through `fx::rescale_px` before running the stack, which is
+the identical correction the adjustment path has taken since K-266. Both fixes land with
+end-to-end GPU regression tests (a matte that must gate, a shift that must stay a quarter
+of the frame at Full and at Half); both fail on the code as it stood.

--- a/docs/06-RENDER-PIPELINE.md
+++ b/docs/06-RENDER-PIPELINE.md
@@ -148,6 +148,12 @@ the AE 2023 model). Four combinations: alpha or luma, normal or inverted.
   before blending.
 - A matte layer keeps its own visibility switch; being a matte does not disable it. A layer MAY
   matte a layer that is itself matted; cycles are rejected at compile time.
+- A **Precomp** matte source has no pixels of its own: its nested comp is rendered (the same
+  recursion §1.4 performs for a Precomp layer's picture, under the same cycle guard) and that
+  render is the matte signal (K-268). The matte **source mode** (§none/masks/effects, K-142)
+  does not apply to a comp reference — a comp already carries its own layers' masks and
+  effects. Footage inside such a comp decodes with the rest of the frame: the decode plan
+  follows matte and layer-input references whether or not the referenced layer is visible.
 
 ## 2. ROI and DoD
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -702,6 +702,8 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   guarded, and hands the picture to the light detector. One honest edge
   remains written down: footage inside a matte-only precomp needs the
   decode planner taught before it appears there.
+  (K-268 closed that edge, and it turned out to be smaller than feared —
+  see *Precomps, in the two places they used to fall through* below.)
   A fifth pass (K-267) closed the next round. The choppy ghost edges that
   survived at corner lights turned out to be a measuring problem, not a
   drawing one: the effect sizes each ghost's ray budget from a once-per-lens
@@ -1048,6 +1050,32 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   knowing (unchanged): "Effects and masks" applies the layer's *look* effects (keys, blurs, colour)
   but not its *time-based* ones — an Echo or motion-blur-from-movement on the referenced layer is
   treated as a still frame; the everyday cases are exact.
+- **Precomps, in the two places they used to fall through (K-268).** Every other kind of layer
+  has *pixels*: a solid is a colour, footage is a decoded frame, text is rasterised type. A
+  **precomp** has none — its picture only exists once it has been rendered, which is a job in
+  itself. Anywhere the code reached for "this layer's pixels" and got a precomp, it had to be
+  taught to render one instead, and two such places had been missed.
+  - **A precomp used as a track matte gated nothing.** Set a layer's matte to a precomp and
+    the matte quietly did not exist: the layer drew everywhere, exactly as if the row had been
+    left unset. (The sibling case — a precomp as a lens flare's Matte source or a depth-of-field
+    depth pass — was fixed in K-266; the track matte, which is the row you actually reach for,
+    was still asking for pixels that a comp does not have.) It now renders the nested comp the
+    same way a precomp *layer* is rendered, loops guarded, and gates with the result. Because
+    a comp already contains its own layers' masks and effects, the None / Masks / Effects and
+    masks combobox above has nothing left to decide for one, and is ignored there.
+  - **An effect ON a precomp layer drifted in reduced-resolution preview.** Parameters measured
+    in comp pixels — a Transform's offset, a flare's light position, a blur radius — are worked
+    out for a full-size frame and then have to be scaled down when preview renders smaller. That
+    correction was being applied to adjustment layers (K-266) and to ordinary layers, but not to
+    a precomp layer, so an effect on one landed further across the picture the coarser the
+    preview got, and snapped back at Full. Preview and export were never wrong at full
+    resolution; now they agree at every resolution, which is the whole point of a preview.
+
+  While closing the first of those, a note K-266 left behind — "footage inside a matte-only
+  precomp won't decode" — turned out to be about a bridge that was already built: the part of
+  the engine that decides which video frames to read (the *decode plan*) follows matte and
+  layer-input references whether or not the layer is visible. It is now pinned by a test rather
+  than by a warning in a document.
 - **Colour picker and dropper (K-210).** Every effect **Colour** parameter — a Flash tint, a
   Colour balance wheel, the Matte key's Key colour, and so on — shows a **clickable swatch**.
   Click it and Lumit's own picker opens: the **red, green and blue numbers across the top**,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -41,16 +41,6 @@ These sit above everything else: they are what the editor feels like in the hand
     Same shape of win in Matte mode from skipping dead light slots with an
     indirect dispatch: eight slots are always dispatched, however many sources
     the detection actually found.
-- **Mattes that decode footage.** A precomp referenced ONLY as a matte
-    renders solids/text/shapes but not footage: the decode planner never
-    visits it (K-266 boundary in `pixels_for`) — teach `collect_comp_jobs`
-    to walk matte references. (Area sources themselves landed in K-267:
-    per-tile flux onto the nearest of up to sixteen anchors.)
-- **The Precomp-layer twin of the K-266 adjustment fix.** Effects ON a
-    Precomp layer also resolve px@comp with factor 1 (`DrawSource::Nested`'s
-    arm in build.rs) while running on whatever raster the nested comp
-    realises at — same preview-only drift `fx::rescale_px` fixed for
-    Adjust; wire the same factor through the nested arm.
 - **Replace `poll(Maintain::Wait)` with a keyed mutex** - every present waits for
     the card to go idle before handing the texture over (`shared.rs`,
     `shared_linux.rs`, `shared_metal.rs`; find it by the call, not a line number).


### PR DESCRIPTION
Picked from `docs/TODO.md` — a group of items on one seam: **what a Precomp layer is to the code that consumes it**. Every other layer kind has pixels; a comp has none until it is rendered, and two places still asked for them.

## What changed

**1. A precomp set as a *track matte* gated nothing at all.**
Set a layer's matte to a precomp and the matte quietly did not exist — the layer drew everywhere, exactly as if the row were unset. K-266 fixed the sibling case (a precomp as a flare's Matte source or a DoF depth pass) by giving layer inputs a nested draw list; the track matte, the row you actually reach for, still went through `pixels_for`, which answers `None` for a comp. `MatteDraw` now carries the same `nested` draw list, built by a shared `nested_comp_draw` helper — one ancestor-path cycle guard for both kinds of reference — and realised recursively exactly as a Precomp layer's picture is. The source-mode toggles (None / Masks / Effects and masks) do not apply to a comp reference, since a comp already carries its layers' own masks and effects.

**2. Effects ON a Precomp layer drifted under reduced-resolution preview** — the twin of K-266's adjustment-layer fix, TODO'd there with its diagnosis. The stack resolved px@comp parameters at factor 1 against the nested comp's width, then ran on the nested comp's *preview* raster, so a Transform's offset, a flare's light or a blur radius landed further across the picture the coarser the preview got, and snapped back at Full. The Nested arm now carries `fx_ref_width`, and the realise walk applies `raster_width / ref_width` through `fx::rescale_px` — the identical correction the adjustment path has taken since K-266.

**3. K-266's third recorded boundary was on the wrong side.** "Footage inside a matte-only precomp needs the decode planner taught" — the planner was already teaching it: `collect_comp_jobs` puts matte sources and layer-input references into `wanted` whether or not the layer is visible, and recurses through a Precomp among them. Pinned now by a test over both shapes of reference, rather than left as a note for the next reader to re-derive.

## Tests

- `a_precomp_track_matte_gates_the_layer` — red solid matted by a hidden precomp covering the left half; the right half must be background. Fails on `main` with the red still there (231, 89, 89).
- `an_effect_on_a_precomp_layer_keeps_its_pixels_under_half_preview` — an 8 px Transform offset on a 32 px precomp is a quarter of the frame at Full and at Half. Fails on `main` at Half.
- `a_matte_only_precomp_still_decodes_its_footage` — the decode plan over both a track matte and a layer-input matte onto a hidden precomp.

Both new GPU tests were verified red with the fixes stashed and green with them applied. Full workspace suite, `cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean locally (the GPU tests ran on Mesa lavapipe).

## Docs (same commit)

`02-DECISIONS.md` gains **K-268** (appended, nothing edited); `06-RENDER-PIPELINE.md` §1.6 states the Precomp-matte rule and its source-mode boundary; `GUIDE.md` gains a plain-English section and a pointer from the K-266 paragraph whose boundary this supersedes; the two `TODO.md` entries are deleted, their regression tests standing as the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u)_