### PR TITLE
Two CI gates that read as coverage and were not (K-269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,16 @@ jobs:
       # three platforms link an identical FFmpeg. The distro's own is 6.x,
       # which the crate's `ffmpeg7_1` feature does not match.
       FFMPEG_ASSET: ffmpeg-n7.1-latest-linux64-gpl-shared-7.1
+      # This runner installs Mesa's lavapipe below, so every GPU test MUST run
+      # here: a missing adapter is a broken runner, not a machine without a
+      # graphics card, and `lumit_gpu::no_adapter` turns the polite skip into a
+      # failure when this is set. Without it a job that lost its Vulkan driver
+      # would skip ~90 kernel oracles and still report green — which is exactly
+      # what the suite looked like before this line existed. The macOS and
+      # Windows jobs deliberately do NOT set it yet: nobody has confirmed those
+      # runners enumerate an adapter, and a gate is only worth having where it
+      # has been verified. Flip it on there the day a run proves they do.
+      LUMIT_REQUIRE_GPU: 1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -147,8 +157,10 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --exclude lumit-gpu
       # The GPU oracles single-threaded (the project convention), so a software
-      # rasteriser neither races nor thrashes. They skip themselves when no
-      # adapter is present, so this can only fail on a real regression.
+      # rasteriser neither races nor thrashes. With LUMIT_REQUIRE_GPU set (see
+      # the job env) they can no longer skip themselves here: on this runner a
+      # missing lavapipe adapter fails the job instead of quietly proving
+      # nothing about the kernels.
       - name: GPU oracle tests (lavapipe software Vulkan)
         run: cargo test -p lumit-gpu -- --test-threads=1
       - name: Release-mode compile check
@@ -480,6 +492,33 @@ jobs:
           if [ -n "$hits" ]; then
             echo "Colour values outside the theme (docs/15-DESIGN.md):"
             echo "$hits"
+            exit 1
+          fi
+      # The Rust grep above guarded a frontend that no longer exists (K-182):
+      # every widget now lives in Dart, so that is where a stray hex actually
+      # gets written. flutter_ui/lib/theme/ is the one place colours may be
+      # spelled out (its own header says so); everywhere else must read a token
+      # off LumitTheme, or the seven colour schemes and any custom theme simply
+      # do not reach that pixel.
+      #
+      # Three shapes are caught: a hex Color(0x...) literal, Material's Colors.*
+      # palette (a named hex by another route), and a Color.fromARGB/fromRGBO
+      # built entirely from number literals. A fromARGB whose channels come from
+      # variables is how a *stored* colour is rebuilt — that is data, not a
+      # design decision, so it passes. Fully transparent (0x00000000) passes
+      # too: it is the absence of a colour, not a choice of one.
+      - name: Dart-side design-token lint (flutter_ui/lib outside theme/)
+        run: |
+          hits=$(
+            grep -rnP "Color\(0x(?!00000000)[0-9a-fA-F]{8}\)|\bColors\.[a-zA-Z]|Color\.from(ARGB|RGBO)\( *[0-9][^,]*, *[0-9][^,]*, *[0-9]" \
+              flutter_ui/lib --include='*.dart' \
+            | grep -v '^flutter_ui/lib/theme/' || true
+          )
+          if [ -n "$hits" ]; then
+            echo "Colour values outside flutter_ui/lib/theme/ (docs/15-DESIGN.md §4.1):"
+            echo "$hits"
+            echo
+            echo "Read the colour off LumitTheme instead; add a token if none fits."
             exit 1
           fi
 

--- a/crates/lumit-flow/src/lib.rs
+++ b/crates/lumit-flow/src/lib.rs
@@ -1315,7 +1315,7 @@ mod tests {
 
     fn gpu_flow() -> Option<gpu::GpuFlow> {
         let Ok(ctx) = lumit_gpu::GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter available");
+            lumit_gpu::no_adapter();
             return None;
         };
         match gpu::GpuFlow::new(&ctx) {

--- a/crates/lumit-gpu/src/composite.rs
+++ b/crates/lumit-gpu/src/composite.rs
@@ -1647,7 +1647,7 @@ mod tests {
     #[test]
     fn blending_happens_in_linear_light() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -1701,7 +1701,7 @@ mod tests {
     #[test]
     fn matte_gates_a_layer_per_pixel() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -1798,7 +1798,7 @@ mod tests {
     #[test]
     fn luma_matte_uses_perceptual_encoded_luminance() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -1874,7 +1874,7 @@ mod tests {
     #[test]
     fn camera_perspective_scales_by_depth() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -1926,7 +1926,7 @@ mod tests {
     #[test]
     fn screen_blend_matches_the_perceptual_formula() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -1977,7 +1977,7 @@ mod tests {
     #[test]
     fn perceptual_blend_modes_match_the_reference_formula() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2200,7 +2200,7 @@ mod tests {
     #[test]
     fn layer_mask_texture_gates_alpha() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2247,7 +2247,7 @@ mod tests {
     #[test]
     fn snapshot_blends_match_their_formulas() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2332,7 +2332,7 @@ mod tests {
     #[test]
     fn add_blend_adds_light_linearly() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2380,7 +2380,7 @@ mod tests {
     #[test]
     fn subtract_blend_removes_light_linearly() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2438,7 +2438,7 @@ mod tests {
     #[test]
     fn a_seeded_composite_continues_the_accumulation() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2500,7 +2500,7 @@ mod tests {
     #[test]
     fn a_render_scale_shrinks_the_target_but_not_the_geometry() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2555,7 +2555,7 @@ mod tests {
     #[test]
     fn motion_blur_average_widens_coverage_and_preserves_static_alpha() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2643,7 +2643,7 @@ mod tests {
     #[test]
     fn accumulate_averages_premultiplied_frames() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2725,7 +2725,7 @@ mod tests {
     #[test]
     fn accumulate_is_bit_exact_at_fractional_coverage() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);
@@ -2783,7 +2783,7 @@ mod tests {
     #[test]
     fn transforms_place_layers_in_comp_pixels() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let colour = ColourEngine::new(&ctx);

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -61,7 +61,7 @@ fn worst_f16_ulp(a: &[f32], b: &[f32]) -> i32 {
 #[test]
 fn wgsl_blur_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -130,7 +130,7 @@ fn wgsl_blur_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_sharpen_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -183,7 +183,7 @@ fn wgsl_sharpen_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_sharpen_simple_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -227,7 +227,7 @@ fn wgsl_sharpen_simple_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_rgb_split_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -283,7 +283,7 @@ fn wgsl_rgb_split_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_spectral_split_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -348,7 +348,7 @@ fn wgsl_spectral_split_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_chromatic_aberration_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -403,7 +403,7 @@ fn wgsl_chromatic_aberration_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_flash_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -447,7 +447,7 @@ fn wgsl_flash_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_colour_balance_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -502,7 +502,7 @@ fn wgsl_colour_balance_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_saturation_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -576,7 +576,7 @@ fn wgsl_saturation_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_vibrancy_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -646,7 +646,7 @@ fn wgsl_vibrancy_matches_the_cpu_oracle() {
 fn wgsl_matte_key_matches_the_cpu_oracle() {
     use lumit_core::fx::MatteKeyParams;
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -783,7 +783,7 @@ fn wgsl_matte_key_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_vignette_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -896,7 +896,7 @@ fn wgsl_vignette_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_exposure_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -971,7 +971,7 @@ fn wgsl_exposure_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_temperature_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1070,7 +1070,7 @@ fn corpus_with_partials(w: u32, h: u32) -> Vec<f32> {
 #[test]
 fn wgsl_invert_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1111,7 +1111,7 @@ fn wgsl_invert_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_tint_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1182,7 +1182,7 @@ fn wgsl_tint_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_contrast_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1242,7 +1242,7 @@ fn wgsl_contrast_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_gamma_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1329,7 +1329,7 @@ fn wgsl_gamma_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_hue_shift_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1383,7 +1383,7 @@ fn wgsl_hue_shift_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_transform_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1459,7 +1459,7 @@ fn wgsl_transform_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_shake_matches_the_cpu_oracle_through_the_transform_kernel() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1530,7 +1530,7 @@ fn wgsl_shake_motion_blur_matches_the_cpu_oracle() {
     assert_eq!(SHAKE_MB_SAMPLES, lumit_core::fx::SHAKE_MB_SAMPLES);
 
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1669,7 +1669,7 @@ fn wgsl_shake_motion_blur_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_glow_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1745,7 +1745,7 @@ fn wgsl_glow_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_block_glitch_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1857,7 +1857,7 @@ fn wgsl_block_glitch_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_scanlines_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1945,7 +1945,7 @@ fn wgsl_scanlines_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_dir_blur_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -1996,7 +1996,7 @@ fn wgsl_dir_blur_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_radial_blur_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2053,7 +2053,7 @@ fn wgsl_radial_blur_matches_the_cpu_oracle() {
 #[test]
 fn adjust_blend_lerps_by_coverage_times_opacity() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2142,7 +2142,7 @@ fn adjust_blend_lerps_by_coverage_times_opacity() {
 #[test]
 fn wgsl_echo_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2281,7 +2281,7 @@ fn wgsl_echo_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_motion_blur_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2428,7 +2428,7 @@ fn wgsl_motion_blur_matches_the_cpu_oracle() {
 #[test]
 fn wgsl_datamosh_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2571,7 +2571,7 @@ fn build_lut(size: usize, f: impl Fn([f32; 3]) -> [f32; 3]) -> lumit_core::lut::
 #[test]
 fn wgsl_lut_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -2805,7 +2805,7 @@ fn dof_reference(
 #[test]
 fn wgsl_dof_matches_the_cpu_oracle() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3180,7 +3180,7 @@ fn lens_flare_dump_frame() {
         return;
     };
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3271,7 +3271,7 @@ fn lens_flare_dump_frame() {
 #[ignore = "a measurement, not a gate: prints a time, asserts nothing"]
 fn lens_flare_frame_cost() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3331,7 +3331,7 @@ fn lens_flare_frame_cost() {
 #[test]
 fn wgsl_lens_flare_ghost_blur_matches_the_cpu_reference() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3483,7 +3483,7 @@ fn lens_flare_bake_cache_evicts_the_oldest_not_everything() {
 #[test]
 fn wgsl_lens_flare_trace_matches_the_cpu_reference() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3645,7 +3645,7 @@ fn wgsl_lens_flare_trace_matches_the_cpu_reference() {
 #[test]
 fn wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3756,7 +3756,7 @@ fn wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals() {
 #[test]
 fn wgsl_lens_flare_padded_anamorphic_matches_and_fills_the_edge() {
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);
@@ -3845,7 +3845,7 @@ fn wgsl_lens_flare_matte_mode_matches_the_cpu_reference() {
     assert_eq!(MAX_LIGHTS as usize, lumit_core::fx::lens_flare::MAX_LIGHTS);
 
     let Ok(ctx) = GpuContext::headless() else {
-        eprintln!("no GPU adapter; skipping WGSL parity test");
+        crate::no_adapter();
         return;
     };
     let fx = FxEngine::new(&ctx);

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -37,6 +37,52 @@ pub struct GpuContext {
     pub software: bool,
 }
 
+/// The environment variable that turns "no GPU adapter" from a skip into a
+/// failure. Set it on any machine that is *supposed* to have one.
+pub const REQUIRE_ADAPTER_ENV: &str = "LUMIT_REQUIRE_GPU";
+
+/// What a GPU test does when [`GpuContext::headless`] finds no adapter
+/// (docs/16-ROADMAP.md standing rules: verification beats assertion).
+///
+/// Every kernel test in the workspace is written to skip itself on a machine
+/// with no graphics adapter, which is what lets the suite run on a laptop with
+/// nothing installed — and is also how a CI job with no adapter went green
+/// while proving nothing at all about the shaders. Mesa's software Vulkan
+/// driver (`mesa-vulkan-drivers`, the `lvp` ICD) is enough to make every one of
+/// them run, so a job that installs it and then silently skips is reporting a
+/// broken *runner*, not a passing suite.
+///
+/// So: with `LUMIT_REQUIRE_GPU` set to anything but `0`, a missing adapter is a
+/// panic — the CI jobs that should have one set it, and a developer's machine
+/// leaves it unset and keeps the friendly skip.
+///
+/// Call it at the skip site and return:
+/// ```ignore
+/// let Ok(ctx) = GpuContext::headless() else {
+///     lumit_gpu::no_adapter();
+///     return;
+/// };
+/// ```
+pub fn no_adapter() {
+    let set = std::env::var(REQUIRE_ADAPTER_ENV).ok();
+    assert!(
+        !adapter_is_required(set.as_deref()),
+        "no GPU adapter, but {REQUIRE_ADAPTER_ENV} is set — this machine is \
+         supposed to have one (install mesa-vulkan-drivers for the lavapipe \
+         software rasteriser, or unset the variable to skip)"
+    );
+    eprintln!("skipping: no GPU adapter");
+}
+
+/// Whether [`REQUIRE_ADAPTER_ENV`]'s value demands an adapter. Unset, empty and
+/// `0` all mean "skip politely"; anything else means "this machine has one, and
+/// not finding it is the bug". Split out from [`no_adapter`] so the rule can be
+/// tested without a process-global environment variable in a parallel suite.
+#[must_use]
+fn adapter_is_required(value: Option<&str>) -> bool {
+    matches!(value, Some(v) if !v.is_empty() && v != "0")
+}
+
 impl GpuContext {
     /// Wrap an existing device/queue (eframe's render state — wgpu handles
     /// are internally reference-counted, so cloning shares the one device).
@@ -741,13 +787,29 @@ impl ColourEngine {
 mod tests {
     use super::*;
 
+    /// **A machine that is supposed to have an adapter must fail, not skip.**
+    ///
+    /// Every kernel test here skips itself without an adapter, which is how a
+    /// Linux job that already installs Mesa's software Vulkan driver could go
+    /// green while running none of them: a skip and a pass look identical in
+    /// the summary. `LUMIT_REQUIRE_GPU` is what tells the difference, so the
+    /// rule it encodes is pinned here rather than only in a workflow file.
+    #[test]
+    fn requiring_an_adapter_is_opt_in_and_zero_still_means_skip() {
+        assert!(!adapter_is_required(None), "a laptop keeps the polite skip");
+        assert!(!adapter_is_required(Some("")), "an empty value is unset");
+        assert!(!adapter_is_required(Some("0")), "0 turns it off explicitly");
+        assert!(adapter_is_required(Some("1")), "CI sets 1");
+        assert!(adapter_is_required(Some("yes")));
+    }
+
     /// The gpu-foundation §7 golden: every 8-bit value survives
     /// sRGB → linear fp16 → sRGB within 1 LSB. This is the test that makes
     /// double-gamma bugs impossible to reintroduce silently (K-031).
     #[test]
     fn colour_round_trip_is_within_one_lsb() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter available");
+            crate::no_adapter();
             return;
         };
         let engine = ColourEngine::new(&ctx);
@@ -784,7 +846,7 @@ mod tests {
     #[test]
     fn dark_end_precision_survives_fp16() {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter available");
+            crate::no_adapter();
             return;
         };
         let engine = ColourEngine::new(&ctx);

--- a/crates/lumit-gpu/src/oklab.rs
+++ b/crates/lumit-gpu/src/oklab.rs
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn wgsl_twin_compiles() {
         let Ok(ctx) = crate::GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let _module = ctx

--- a/crates/lumit-gpu/src/scope.rs
+++ b/crates/lumit-gpu/src/scope.rs
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     fn luma_waveform_counts_match_the_cpu_oracle() {
         let Some(ctx) = ctx() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let engine = ScopeEngine::new(&ctx);
@@ -708,7 +708,7 @@ mod tests {
     #[test]
     fn histogram_counts_match_the_cpu_oracle() {
         let Some(ctx) = ctx() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let engine = ScopeEngine::new(&ctx);
@@ -729,7 +729,7 @@ mod tests {
     #[test]
     fn vectorscope_centres_a_neutral_grey() {
         let Some(ctx) = ctx() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let engine = ScopeEngine::new(&ctx);
@@ -749,7 +749,7 @@ mod tests {
     #[test]
     fn luma_trace_pixels_match_within_tolerance() {
         let Some(ctx) = ctx() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let engine = ScopeEngine::new(&ctx);
@@ -795,7 +795,7 @@ mod tests {
     #[test]
     fn a_short_frame_is_calm() {
         let Some(ctx) = ctx() else {
-            eprintln!("skipping: no GPU adapter");
+            crate::no_adapter();
             return;
         };
         let engine = ScopeEngine::new(&ctx);

--- a/crates/lumit-gpu/tests/exec_skeleton.rs
+++ b/crates/lumit-gpu/tests/exec_skeleton.rs
@@ -381,7 +381,7 @@ struct Rig {
 impl Rig {
     fn new(size: (u32, u32)) -> Option<Self> {
         let Ok(ctx) = GpuContext::headless() else {
-            eprintln!("skipping: no GPU adapter");
+            lumit_gpu::no_adapter();
             return None;
         };
         let ctx = Rc::new(ctx);

--- a/crates/lumit-render/src/export.rs
+++ b/crates/lumit-render/src/export.rs
@@ -763,7 +763,7 @@ mod tests {
         let cancel = AtomicBool::new(false);
         match run(doc, comp, &[], path, spec, &tx, &cancel) {
             Err(e) if e.starts_with("export renderer:") => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 None
             }
             other => Some(other),

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -1934,7 +1934,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -1962,7 +1962,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -1987,7 +1987,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2027,7 +2027,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2090,7 +2090,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2127,7 +2127,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2210,7 +2210,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2234,7 +2234,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2294,7 +2294,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2345,7 +2345,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2395,7 +2395,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2453,7 +2453,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2556,7 +2556,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2637,7 +2637,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2699,7 +2699,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2727,7 +2727,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2816,7 +2816,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -2963,7 +2963,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -3161,7 +3161,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -3188,7 +3188,7 @@ mod tests {
     #[ignore = "timing, not correctness"]
     fn preview_cost() {
         let Ok(mut renderer) = HeadlessRenderer::new() else {
-            eprintln!("skipping: no GPU adapter");
+            lumit_gpu::no_adapter();
             return;
         };
         let (store, comp_id) = doc_with_solid(LinearColour([0.2, 0.4, 0.8, 1.0]), 1920, 1080);
@@ -3232,7 +3232,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };
@@ -3297,7 +3297,7 @@ mod tests {
         let mut r = match HeadlessRenderer::new() {
             Ok(r) => r,
             Err(_) => {
-                eprintln!("skipping: no GPU adapter");
+                lumit_gpu::no_adapter();
                 return;
             }
         };

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5524,3 +5524,26 @@ preview factor — preview only, full resolution always correct. The Nested arm 
 the identical correction the adjustment path has taken since K-266. Both fixes land with
 end-to-end GPU regression tests (a matte that must gate, a shift that must stay a quarter
 of the frame at Full and at Half); both fail on the code as it stood.
+
+**K-269 · DECIDED · A skipped GPU test is a failure where an adapter was installed, and
+the no-hex rule follows the widgets into Dart.** Two CI gates that read as coverage and
+were not. **(1) `LUMIT_REQUIRE_GPU`.** Every kernel test skips itself without a graphics
+adapter — the friendly behaviour on a developer's machine, and the reason a Linux job that
+*installs* Mesa's lavapipe could lose its Vulkan driver, run none of about ninety shader
+oracles, and still report green. `lumit_gpu::no_adapter()` is now the one skip site
+(89 call sites converted from a bare `eprintln!`), and with `LUMIT_REQUIRE_GPU` set to
+anything but `0` it panics instead. The Linux job sets it; macOS and Windows deliberately
+do not, because nobody has confirmed those runners enumerate an adapter and a gate is only
+worth having where it has been verified — flipping them on is a TODO with a one-run test.
+The rule itself (unset/empty/`0` skip, anything else demand) is unit-tested rather than
+living only in a workflow file. **(2) The design-token lint greps Rust, where no widget has
+lived since K-182.** All the colours are in Dart now, so the same rule runs over
+`flutter_ui/lib` outside `theme/`: hex `Color(0x…)` literals, Material's `Colors.*` palette,
+and `Color.fromARGB`/`fromRGBO` calls built entirely from number literals. It found three:
+a modal scrim spelled out as `0x99000000`, and `Colors.red`/`Colors.amber` standing in for
+the theme's error and warning roles. The scrim becomes a **token** (`LumitTheme.scrim`),
+defaulting from the mode in the K-202 manner rather than being restated by all seven
+schemes — translucent black in both families, lighter on a light scheme where the same
+opacity reads as a blackout. Two shapes stay legal and are documented in the job: fully
+transparent `0x00000000` (the absence of a colour, not a choice of one) and a colour
+rebuilt from stored numbers (data, not a design decision).

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2927,6 +2927,30 @@ stayed green for weeks while nobody could actually clone the repository on Linux
 it. The jobs now leave that route alone and let the build find FFmpeg the ordinary way. If
 a step exists purely to make CI work, ask who else has to run it.
 
+Two of those checks were quietly weaker than they looked, and K-269 fixed both.
+
+**A skipped test looks exactly like a passing one.** Every test that needs a graphics card
+is written to *skip itself* when there isn't one — that is what lets the suite run on a
+laptop with nothing installed. But it also means a machine whose graphics driver went
+missing runs none of them and still reports a green tick: about ninety checks of the actual
+shader maths, silently not run. So there is now an environment variable,
+`LUMIT_REQUIRE_GPU`, that turns "no adapter" from a polite skip into a failure, and the
+Linux job — the one that deliberately installs lavapipe — sets it. Your own machine leaves
+it unset and keeps the friendly skip. The macOS and Windows jobs deliberately do not set it
+yet: nobody has confirmed those runners offer an adapter at all, and a gate is only worth
+having where it has been checked.
+
+**The no-hex rule was being enforced on the wrong language.** Every colour is supposed to
+come from the theme, so the schemes and any custom theme actually reach every pixel — and
+CI was grepping for stray colour values in the *Rust* code, which is where the old frontend
+lived. All the widgets are Dart now. The same grep now runs over `flutter_ui/lib` outside
+`theme/`, and it found three real ones: a modal window's dimming wash spelled out in hex,
+and Material's own red and amber standing in for the theme's error and warning colours. The
+wash became a proper token (`scrim`), so it follows the scheme like everything else. Two
+things deliberately still pass: fully transparent (`0x00000000`), which is the *absence* of
+a colour rather than a choice of one, and rebuilding a colour from numbers that came out of
+a saved file, which is data rather than a design decision.
+
 ### How Lumit knows how much memory your machine has (K-194, K-204)
 
 Settings → Performance lets you type a cache size in megabytes, which means the engine

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -403,9 +403,6 @@ plugins/decoder page; autosave interval/keep; export defaults (preset + filename
 template). Each lands wired to the engine through the bridge, not as a Dart-side
 setting nothing reads.
 
-**The no-hex lint only greps Rust** ([15-DESIGN.md](15-DESIGN.md) §4.1) - a Dart-side gate
-over `flutter_ui/lib` outside `theme/` would catch the literals where widgets actually live.
-
 **Engineering-rules tooling still owed** ([14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md)):
 `cargo deny` in CI (§9); fuzz targets for the `.lum` deserialiser and journal replayer (§6);
 a `rust-toolchain.toml` pin and the edition-2024 move (§9); the `indexing_slicing` /
@@ -419,14 +416,10 @@ profiler (§7.1) is likewise unbuilt - the render-time indicator entry above is 
 visible piece.
 
 **CI coverage the Flutter port left thin:**
-- **The WGSL/CPU-oracle parity tests skip silently without an adapter** - they
-    print "no GPU adapter; skipping" and the run still goes green, so a job
-    without one proves nothing about the kernels. Installing Mesa's software
-    Vulkan driver (`mesa-vulkan-drivers`, the `lvp` ICD) is enough to make them
-    all run: verified 2026-08-03 on a container with no graphics hardware, where
-    the whole `lumit-gpu` suite passed in about five seconds. Worth adding to any
-    Linux job, and worth making the skip loud (an env var that turns "no adapter"
-    into a failure on the machines that should have one).
+- **macOS and Windows CI do not require an adapter.** `LUMIT_REQUIRE_GPU` turns
+    a "no adapter" skip into a failure and the Linux job sets it (K-269); the
+    other two do not, because nobody has confirmed those runners enumerate one.
+    One run with the variable set says whether they can.
 - **Nothing in CI proves a Viewer frame arrives.** The Linux job is the only one
     running the Flutter suite and has no GPU, so the six Viewer tests that wait
     for a frame skip there on `LUMIT_NO_ZERO_COPY_VIEWER=1`. They still fail on a

--- a/flutter_ui/lib/panels/debug_panel.dart
+++ b/flutter_ui/lib/panels/debug_panel.dart
@@ -56,11 +56,11 @@ class _DebugPanelState extends State<DebugPanel> {
     final theme = ThemeScope.of(context).theme;
 
     if (ms > 8) {
-      return Colors.red;
+      return theme.error;
     }
 
     if (ms > 3) {
-      return Colors.amber;
+      return theme.warning;
     }
 
     return theme.textMuted;
@@ -145,7 +145,7 @@ class _DebugPanelState extends State<DebugPanel> {
             HouseButton(
               child: Text(
                 "$len in last second",
-                style: theme.body.copyWith(color: len > 20 ? Colors.red : null),
+                style: theme.body.copyWith(color: len > 20 ? theme.error : null),
               ),
             ),
             HouseButton(

--- a/flutter_ui/lib/panels/performance_view.dart
+++ b/flutter_ui/lib/panels/performance_view.dart
@@ -161,11 +161,11 @@ class _PerformanceMonitorState extends State<PerformanceMonitor> {
     final theme = ThemeScope.of(context).theme;
 
     if (ms > 30) {
-      return Colors.red;
+      return theme.error;
     }
 
     if (ms > 17) {
-      return Colors.amber;
+      return theme.warning;
     }
 
     return theme.textMuted;

--- a/flutter_ui/lib/theme/theme.dart
+++ b/flutter_ui/lib/theme/theme.dart
@@ -208,6 +208,13 @@ class LumitTheme {
   /// work-area band either way.
   final Color marker;
 
+  /// The wash a modal window lays over the app behind it (K-269). Its own
+  /// token because it is not a surface: it is the *absence* of attention, a
+  /// translucent black that dims whatever it covers rather than a colour the
+  /// ramp could supply. Translucent black under a light scheme too — dimming
+  /// is dimming, and a pale scrim over pale panels would say nothing.
+  final Color scrim;
+
   /// The three Timeline tokens default from the mode rather than being spelled
   /// out by every scheme: they are a *relationship* to the surface ramp (a
   /// shade beyond `surface1`, a fill that out-contrasts it, a grey that reads
@@ -241,10 +248,12 @@ class LumitTheme {
     Color? timelineOutOfRange,
     Color? selectionFill,
     Color? marker,
+    Color? scrim,
   })  : timelineOutOfRange =
             timelineOutOfRange ?? defaultOutOfRange(mode, surface1),
         selectionFill = selectionFill ?? defaultSelectionFill(mode, surface2),
-        marker = marker ?? defaultMarker(mode);
+        marker = marker ?? defaultMarker(mode),
+        scrim = scrim ?? defaultScrim(mode);
 
   /// The ground outside the work area: a step *away* from the surface ramp's
   /// direction — darker under a dark scheme, and darker again under a light
@@ -270,6 +279,18 @@ class LumitTheme {
   static Color defaultMarker(ThemeMode2 mode) => mode == ThemeMode2.dark
       ? _rgb(0xc4, 0xc4, 0xc4)
       : _rgb(0x56, 0x56, 0x56);
+
+  /// The modal scrim. Black either way — a scrim dims, and on a light scheme
+  /// there is nothing above white to dim *with* — but a shade lighter over a
+  /// light one, where the same opacity would read as a blackout rather than a
+  /// hush (§calm voice: the window in front is louder, the app behind is not
+  /// being punished).
+  static Color defaultScrim(ThemeMode2 mode) => Color.fromARGB(
+        mode == ThemeMode2.dark ? 0x99 : 0x66,
+        0,
+        0,
+        0,
+      );
 
   /// Shift every channel by [by], clamped — the one place the theme nudges a
   /// colour, so "a shade darker" means the same thing wherever it is said.
@@ -353,6 +374,7 @@ class LumitTheme {
         timelineOutOfRange: timelineOutOfRange,
         selectionFill: selectionFill,
         marker: marker,
+        scrim: scrim,
       );
 
   /// The full composition a scheme + shape (+ accent override) resolves to —

--- a/flutter_ui/lib/widgets/controls.dart
+++ b/flutter_ui/lib/widgets/controls.dart
@@ -669,7 +669,7 @@ Future<T?> showLumitModal<T>({
             behavior: HitTestBehavior.opaque,
             onTap: () => close(null),
             child: ColoredBox(
-              color: const Color(0x99000000),
+              color: ThemeScope.of(context).theme.scrim,
             ),
           ),
         ),


### PR DESCRIPTION
Stacked on #43 (base is `claude/todo-review-cleanup-0zj03t`, so this diff is only the new work; merge #43 first and this retargets cleanly to `main`).

Two more `docs/TODO.md` items, both about checks that looked like they were proving something.

## 1. A skipped GPU test looks exactly like a passing one

Every kernel test skips itself when there is no graphics adapter — right on a laptop with nothing installed, wrong on the Linux job, which installs Mesa's lavapipe *on purpose*. If that driver ever went missing, the job would run none of ~90 shader oracles and still go green.

- `lumit_gpu::no_adapter()` is now the single skip site — 89 bare `eprintln!("skipping: no GPU adapter")` call sites across `lumit-gpu`, `lumit-render` and `lumit-flow` converted to call it.
- With `LUMIT_REQUIRE_GPU` set to anything but `0`, it panics instead of skipping. The Linux job sets it in its `env:`.
- macOS and Windows deliberately **do not** set it: nobody has confirmed those runners enumerate an adapter, and a gate is only worth having where it has been verified. That is now a narrow TODO ("one run with the variable set says whether they can") instead of an assumption.
- The rule itself — unset / empty / `0` skip, anything else demand — is unit-tested, so it does not live only in a workflow file.

Verified locally with `LUMIT_REQUIRE_GPU=1` on lavapipe: `lumit-gpu` 73 + 7 + 1, `lumit-render` 69, `lumit-flow` 13, all passing, nothing skipped.

## 2. The no-hex lint was greping the wrong language

No widget has lived in Rust since K-182, so the design-token gate has been guarding an empty room. The same rule now runs over `flutter_ui/lib` outside `theme/` and catches three shapes: hex `Color(0x…)` literals, Material's `Colors.*` palette, and `Color.fromARGB`/`fromRGBO` built entirely from number literals.

It found three real violations, all fixed here:
- a modal window's dimming wash spelled `Color(0x99000000)` → new `LumitTheme.scrim` token, defaulting from the mode in the K-202 manner rather than restated by all seven schemes (lighter on a light scheme, where the same opacity reads as a blackout rather than a hush);
- `Colors.red` / `Colors.amber` in the performance and debug panels → the theme's `error` and `warning` roles.

Two things deliberately still pass, documented in the job: fully transparent `0x00000000` (the absence of a colour, not a choice of one) and a colour rebuilt from stored numbers (data, not a design decision). Both were checked against the current tree — the lint is green on it, and I self-tested the regex against a file containing each banned shape.

## Notes

`cargo fmt --check`, `cargo clippy --workspace --all-targets` and the full workspace suite are green locally. The Dart changes could not be analysed here (no Flutter toolchain in this environment) — the `flutter-linux` job is the check on those.

Docs in the same commit: **K-269** appended to `02-DECISIONS.md`, both TODO entries deleted, and a plain-English pair of paragraphs added to `GUIDE.md`'s "What the robots check".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u)_