### PR TITLE
A marker write-back merges onto the marker already there (K-270)

### DIFF
--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -21,9 +21,12 @@ use crate::api::{
 
 /// One timeline marker (docs/03 §11): a cue on the comp's timebase.
 ///
-/// The engine's marker also carries a duration and a kind; neither has a
-/// control yet, so they are not carried across — a marker written back keeps
-/// what the panel can actually edit and does not pretend to round-trip the rest.
+/// The engine's marker also carries a duration, a kind and any unknown fields
+/// a newer Lumit wrote (docs/10 §1.1); none of the three has a control, so none
+/// of them crosses. They are **not** lost on a write-back: [`core_markers`]
+/// merges each incoming marker onto the one the document already holds under
+/// that id, so the panel edits what it can see and the rest survives untouched
+/// (K-270).
 #[frb(non_opaque)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeMarker {
@@ -48,18 +51,58 @@ pub(crate) fn bridge_marker(m: &lumit_core::markers::Marker) -> BridgeMarker {
     }
 }
 
+/// A whole marker list coming back from the panel, merged onto the list the
+/// document holds (K-270).
+///
+/// **Why a merge and not a conversion.** The bridge marker carries the three
+/// fields a panel can edit — id, time, label — and the engine's marker carries
+/// three more it cannot: the *kind* (a detected beat's provenance, plus its
+/// confidence), a spanning marker's *duration*, and the `extra` map that keeps
+/// fields a newer Lumit wrote (docs/10 §1.1's forward-compatibility promise).
+/// Rebuilding each marker from the bridge's three fields alone flattened all
+/// three to their defaults, so **dragging or renaming a beat marker on the
+/// ruler turned it into an ordinary cue** — and then *Clear beat markers* could
+/// no longer find it, because there was nothing left to say it had ever been
+/// one. K-254's ruler markers made that a click away.
+///
+/// So each incoming marker is matched by id against what the document already
+/// holds: found, and it keeps that marker's kind, duration and extra; new, and
+/// it is a plain user marker, which is exactly what a marker the panel just
+/// created is. Nothing about the frb surface changes — the panel has no use for
+/// a kind it cannot edit, and inventing a control for one to fix a data-loss
+/// bug would be the wrong order.
 #[frb(ignore)]
-pub(crate) fn core_marker(m: BridgeMarker) -> Result<lumit_core::markers::Marker, BridgeError> {
+pub(crate) fn core_markers(
+    incoming: Vec<BridgeMarker>,
+    existing: &[lumit_core::markers::Marker],
+) -> Result<Vec<lumit_core::markers::Marker>, BridgeError> {
+    incoming
+        .into_iter()
+        .map(|m| {
+            let was = existing.iter().find(|e| e.id == m.id);
+            core_marker(m, was)
+        })
+        .collect()
+}
+
+#[frb(ignore)]
+pub(crate) fn core_marker(
+    m: BridgeMarker,
+    existing: Option<&lumit_core::markers::Marker>,
+) -> Result<lumit_core::markers::Marker, BridgeError> {
     use lumit_core::time::{CompTime, Rational};
     Ok(lumit_core::markers::Marker {
         id: m.id,
         time: CompTime(
             Rational::new(m.time.num, m.time.den).map_err(|_| BridgeError::InvalidTime)?,
         ),
-        duration: None,
+        // Everything the panel cannot edit is carried from the marker that was
+        // already there; a marker it has just made has nothing to carry, and
+        // takes the plain-user defaults.
+        duration: existing.and_then(|e| e.duration),
         label: m.label,
-        kind: lumit_core::markers::MarkerKind::default(),
-        extra: serde_json::Map::new(),
+        kind: existing.map(|e| e.kind).unwrap_or_default(),
+        extra: existing.map(|e| e.extra.clone()).unwrap_or_default(),
     })
 }
 
@@ -974,10 +1017,9 @@ impl CompositionReference {
     /// also how beat detection commits a regenerated set.
     #[frb(sync)]
     pub fn set_markers(&self, markers: Vec<BridgeMarker>) -> Result<(), BridgeError> {
-        let markers = markers
-            .into_iter()
-            .map(core_marker)
-            .collect::<Result<Vec<_>, BridgeError>>()?;
+        // Merged onto what the comp already holds, so a dragged or renamed beat
+        // marker stays a beat marker (K-270).
+        let markers = core_markers(markers, &self.composition()?.markers)?;
 
         self.commit(lumit_core::Op::SetCompMarkers {
             comp: self.id,

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -7,7 +7,7 @@ use lumit_core::time::{CompTime, Duration, Rational, SourceTime};
 use uuid::Uuid;
 
 use crate::api::{
-    composition::{bridge_marker, core_marker, BridgeMarker},
+    composition::{bridge_marker, core_markers, BridgeMarker},
     effect::{BridgeEffectInstance, BridgeRational, BridgeScalar},
     project_item::ItemReference,
     state::{LumitBridgeState, PROJECTS},
@@ -1991,10 +1991,9 @@ impl LayerReference {
     /// the same shape as the composition's.
     #[frb(sync)]
     pub fn set_markers(&self, markers: Vec<BridgeMarker>) -> Result<(), BridgeError> {
-        let markers = markers
-            .into_iter()
-            .map(core_marker)
-            .collect::<Result<Vec<_>, BridgeError>>()?;
+        // Merged onto the layer's current list, so a marker's kind, duration
+        // and unknown fields survive a drag or a rename (K-270).
+        let markers = core_markers(markers, &self.item()?.markers)?;
         let (comp, layer) = (self.comp_id, self.layer_id);
         self.commit(lumit_core::Op::SetLayerMarkers {
             comp,

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -3740,6 +3740,114 @@ fn clearing_beats_keeps_the_markers_a_person_made() {
     assert_eq!(comp.get_markers().expect("markers").len(), 1);
 }
 
+/// **Dragging or renaming a beat marker must leave it a beat marker** (K-270).
+///
+/// The regression: the panel writes the whole list back through `set_markers`,
+/// and a bridge marker carries only id, time and label — so every marker was
+/// rebuilt with the *default* kind, no duration, and an empty `extra`. Moving a
+/// detected beat one frame turned it into an ordinary cue, and *Clear beat
+/// markers* then walked straight past it: nothing was left to say it had ever
+/// been detected. K-254's ruler markers made that a drag away.
+///
+/// The same merge protects a spanning marker's duration and the unknown fields
+/// a newer Lumit wrote (docs/10 §1.1), which the panel equally cannot see.
+#[test]
+fn dragging_a_beat_marker_leaves_it_a_beat_marker() {
+    use crate::api::composition::BridgeMarker;
+    use crate::api::effect::BridgeRational;
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+
+    // A beat marker with a duration and a field from a newer version, placed
+    // the way detection and a forward-compatible load place them.
+    let beat_id = Uuid::now_v7();
+    {
+        let mut beat = lumit_core::markers::Marker::beat(
+            beat_id,
+            lumit_core::Rational::new(1, 1).expect("1 s"),
+            0.9,
+        );
+        beat.duration = Some(lumit_core::Rational::new(1, 4).expect("a quarter second"));
+        beat.extra
+            .insert("from_a_newer_lumit".into(), serde_json::json!(true));
+        let state = project.state().expect("state");
+        let state = state.write().expect("write");
+        state
+            .store
+            .commit(lumit_core::Op::SetCompMarkers {
+                comp: comp.id,
+                markers: vec![beat],
+            })
+            .expect("seeded");
+    }
+
+    // The panel's write-back: same marker, moved and renamed.
+    comp.set_markers(vec![BridgeMarker {
+        id: beat_id,
+        time: BridgeRational { num: 3, den: 2 },
+        label: "Moved".into(),
+    }])
+    .expect("dragged");
+
+    let stored = comp.composition().expect("comp").markers;
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].label, "Moved", "the edit landed");
+    assert_eq!(
+        stored[0].time.0,
+        lumit_core::Rational::new(3, 2).expect("1.5 s"),
+        "and so did the move"
+    );
+    assert!(
+        matches!(
+            stored[0].kind,
+            lumit_core::markers::MarkerKind::Beat { confidence }
+                if (confidence - 0.9).abs() < 1e-6
+        ),
+        "it is still the beat it was, confidence and all: {:?}",
+        stored[0].kind
+    );
+    assert_eq!(
+        stored[0].duration,
+        Some(lumit_core::Rational::new(1, 4).expect("a quarter second")),
+        "a spanning marker keeps its span"
+    );
+    assert_eq!(
+        stored[0].extra.get("from_a_newer_lumit"),
+        Some(&serde_json::json!(true)),
+        "and the forward-compatibility promise holds across an edit"
+    );
+
+    // Which is the whole point: clearing beats still finds it.
+    comp.clear_beat_markers().expect("cleared");
+    assert!(comp.get_markers().expect("markers").is_empty());
+}
+
+/// A marker the panel has just made is a plain user marker — the merge above
+/// must not invent provenance for one the document has never seen.
+#[test]
+fn a_marker_the_panel_just_made_is_a_user_marker() {
+    use crate::api::composition::BridgeMarker;
+    use crate::api::effect::BridgeRational;
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    comp.set_markers(vec![BridgeMarker {
+        id: Uuid::now_v7(),
+        time: BridgeRational { num: 1, den: 2 },
+        label: "Mine".into(),
+    }])
+    .expect("marked");
+
+    let stored = comp.composition().expect("comp").markers;
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].kind, lumit_core::markers::MarkerKind::User);
+    assert_eq!(stored[0].duration, None);
+    assert!(stored[0].extra.is_empty());
+    comp.clear_beat_markers().expect("no beats to clear");
+    assert_eq!(comp.get_markers().expect("markers").len(), 1);
+}
+
 /// A composition dropped into another brings its markers with it as the
 /// layer's own — **copies**, so editing them never reaches back into the
 /// composition they came from, or into anywhere else it is used (K-254).

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5547,3 +5547,22 @@ schemes — translucent black in both families, lighter on a light scheme where 
 opacity reads as a blackout. Two shapes stay legal and are documented in the job: fully
 transparent `0x00000000` (the absence of a colour, not a choice of one) and a colour
 rebuilt from stored numbers (data, not a design decision).
+
+**K-270 · DECIDED · A marker write-back merges onto the marker that is already there.**
+The panel writes its whole marker list back through `set_markers`, and a `BridgeMarker`
+carries the three fields a panel can edit: id, time, label. Each one was then rebuilt from
+those three alone, which silently reset the three the engine owns — the **kind** (a
+detected beat's provenance and its confidence), a spanning marker's **duration**, and the
+**`extra`** map that keeps fields a newer Lumit wrote (docs/10 §1.1). So dragging a beat
+marker one frame turned it into an ordinary cue, and *Clear beat markers* then walked past
+it; K-254's ruler markers put that one drag away. Fixed by merging rather than converting:
+each incoming marker is matched by id against the list the document holds and keeps that
+marker's kind, duration and extra; an id the document has never seen is a plain user
+marker, which is exactly what a marker the panel just made is. **Deliberately not** by
+adding the kind to the frb struct (the TODO's own suggestion): the panel has no control for
+a kind, no use for one it cannot edit, and inventing a UI to fix a data-loss bug is the
+wrong order — while the merge also saves the duration and the forward-compatibility fields,
+which no widening of `BridgeMarker` was going to cover. Both the composition's list and
+every layer's own (K-254) go through the one helper. Also recorded: the TODO entry claiming
+installed RAM is read only on Windows was stale — K-204 answers it on all three desktops;
+only `video_memory_bytes` is still Windows-only, and the entry now says that instead.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1552,6 +1552,19 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   never your hand-placed cues). The markers show as clay ticks on the timeline ruler — faint
   or bright by confidence — and scrubbing the playhead snaps to a nearby marker, so you land
   on the beat.
+
+  One thing worth knowing about how the panel and the engine share a marker (K-270). The
+  panel can see and change three things about one: where it is, what it is called, and which
+  marker it is. The engine knows three more: whether it was detected or placed by hand (and
+  how confident the detector was), how long it lasts if it spans time, and any fields a
+  *newer* version of Lumit wrote that this one has never heard of. When you drag a marker,
+  the panel sends the whole list back — and it used to send back only the three things it
+  knows, which quietly reset the other three. Move a detected beat by one frame and it
+  stopped being a beat: **Clear beat markers** would then leave it behind, because nothing
+  was left to say where it came from. Now the write-back is a *merge* — each marker is
+  matched up with the one already there by its id, and everything the panel cannot see is
+  carried straight over. A marker you have just made has nothing to carry over, so it is a
+  plain user marker, which is what it is.
 - **The timeline waveform** — a strip under the ruler draws the composition's mixed audio as
   a min/max envelope on the same time axis, so the beats sit right above the transients that
   made them. It's built by `waveform_peaks` (in `lumit-audio::mix`), which buckets the mono

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -224,9 +224,13 @@ which is what the envelope authors. Slow/Fast/Smooth/Sharp come back with the
 preset-shelf rework above, rebuilt on the property like everything else K-249
 moved.
 
-**System memory is only read on Windows.** `system_memory_bytes` and
-`video_memory_bytes` answer 0 elsewhere and the settings fall back to a 16 GB
-ceiling. macOS/Linux want `sysctl hw.memsize` and `/proc/meminfo` (K-033).
+**Video memory is only read on Windows.** `video_memory_bytes` answers the
+first DXGI adapter's dedicated memory there and 0 everywhere else, so the GPU
+cache ceiling falls back to the frontend's documented figure on macOS and
+Linux. Wants Metal's `recommendedMaxWorkingSetSize` and the Vulkan adapter's
+device-local heap (K-033). *Installed RAM is answered on all three already
+(K-204: `GlobalMemoryStatusEx`, `/proc/meminfo`, `hw.memsize`) — this entry
+used to claim otherwise.*
 
 **Bound keys with nothing behind them.** The **Tools**, **Project**, **Panels**
 and **Effects** keymap contexts have real bindings and no commands. Either build
@@ -284,11 +288,6 @@ colour individually; only the two Timeline tokens default from the mode.
     shared engine (audio device, render worker) across test *files*. Give those
     files a serial marker or make the engine per-file - the serial run is a
     mitigation, not the fix, and it costs wall-clock.
-- **`set_markers` flattens every marker to `MarkerKind::User`** - so dragging or
-    renaming one on the ruler turns detected beats into ordinary cues and *Clear
-    beat markers* stops finding them (`crates/lumit-bridge/src/api/composition.rs`).
-    Carry the kind across the bridge (`BridgeMarker`) and map it back. Pre-dates
-    K-254's ruler markers, which made it far easier to hit.
 - **Beat tap has no key left** - [07-UI-SPEC.md](07-UI-SPEC.md) §10 wants `8`
     during playback to tap a beat, and K-254 gave the bare digits to the numbered
     markers. Needs its own chord or a modal reading.

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -1056,7 +1056,9 @@ class _SettingsWindowState extends State<_SettingsWindow> {
       );
 
   /// What the machine has, in MiB, falling back to a documented ceiling when
-  /// it will not say (every platform but Windows so far).
+  /// it will not say. Installed RAM is answered on all three desktops
+  /// (K-204); video memory is Windows-only so far, so that is the one that
+  /// still falls back off Windows.
   static double get _systemMib => _mibOf(systemMemoryBytes());
   static double get _vramMib => _mibOf(videoMemoryBytes());
 

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -13,7 +13,7 @@ import 'layer.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'package:uuid/uuid.dart';
 
-// These functions are ignored because they are not marked as `pub`: `add_at_top`, `bridge_marker`, `commit`, `composition`, `core_marker`, `dispatch`, `document`, `footage_span_and_size`, `project`, `runs_as_video`, `to_engine`
+// These functions are ignored because they are not marked as `pub`: `add_at_top`, `bridge_marker`, `commit`, `composition`, `core_marker`, `core_markers`, `dispatch`, `document`, `footage_span_and_size`, `project`, `runs_as_video`, `to_engine`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `id`, `new`, `project_id`
 
@@ -185,9 +185,12 @@ class BridgeLayerEntry {
 
 /// One timeline marker (docs/03 §11): a cue on the comp's timebase.
 ///
-/// The engine's marker also carries a duration and a kind; neither has a
-/// control yet, so they are not carried across — a marker written back keeps
-/// what the panel can actually edit and does not pretend to round-trip the rest.
+/// The engine's marker also carries a duration, a kind and any unknown fields
+/// a newer Lumit wrote (docs/10 §1.1); none of the three has a control, so none
+/// of them crosses. They are **not** lost on a write-back: [`core_markers`]
+/// merges each incoming marker onto the one the document already holds under
+/// that id, so the panel edits what it can see and the rest survives untouched
+/// (K-270).
 class BridgeMarker {
   final UuidValue id;
   final BridgeRational time;


### PR DESCRIPTION
Stacked on #44 (which is stacked on #43). The diff here is only the new work.

## The bug

The panel writes its **whole** marker list back through `set_markers`, and a `BridgeMarker` carries the three fields a panel can edit: id, time, label. Each marker was then rebuilt from those three alone — silently resetting the three the engine owns:

- the **kind** (a detected beat's provenance, and its confidence),
- a spanning marker's **duration**,
- the **`extra`** map that keeps fields a newer Lumit wrote (docs/10 §1.1's forward-compatibility promise).

So dragging a detected beat one frame turned it into an ordinary cue, and *Clear beat markers* then walked straight past it — nothing was left to say it had ever been detected. K-254's ruler markers put that one drag away.

## The fix

Merge instead of convert: each incoming marker is matched by id against the list the document already holds and keeps that marker's kind, duration and extra. An id the document has never seen is a plain user marker — exactly what a marker the panel just made is. Both the composition's list and every layer's own (K-254) go through one helper.

**Deliberately not** by adding the kind to the frb struct, which is what the TODO entry suggested. The panel has no control for a kind and no use for one it cannot edit; inventing a UI to fix a data-loss bug is the wrong order. The merge also rescues the duration and the forward-compatibility fields, which no widening of `BridgeMarker` was going to cover — and it leaves the generated bridge bindings untouched.

## Tests

- `dragging_a_beat_marker_leaves_it_a_beat_marker` — a beat with a duration and an unknown field is dragged and renamed; the edit lands, the kind (with confidence), the duration and the unknown field all survive, and *Clear beat markers* still finds it. Verified red without the fix.
- `a_marker_the_panel_just_made_is_a_user_marker` — the merge must not invent provenance.

## Also in here

The TODO entry **"System memory is only read on Windows"** was stale: K-204 answers installed RAM on all three desktops (`GlobalMemoryStatusEx`, `/proc/meminfo`, `hw.memsize`) and a test pins it. Only `video_memory_bytes` is still Windows-only, so the entry now says that — along with what the other two platforms would need — and the settings-panel comment that repeated the stale claim is corrected.

`cargo fmt --check`, `cargo clippy --workspace --all-targets` and `cargo test -p lumit_bridge` (183 passing) are green locally. **K-270** appended to `02-DECISIONS.md`; the markers paragraph in `GUIDE.md` gains a plain-English note on what the panel can and cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u)_