### PR TITLE
The LUT kernel remaps through the cube's own domain, and the cache notices the file changing (K-271)

### DIFF
--- a/crates/lumit-gpu/src/fx/dof.rs
+++ b/crates/lumit-gpu/src/fx/dof.rs
@@ -41,9 +41,11 @@ struct AdjustParams {
 
 /// One resolved 3D-LUT lookup (docs/08 §3.11; docs/impl/lut.md). The cube
 /// itself arrives as its own 3D texture (see [`upload_lut_3d`] and
-/// [`FxEngine::lut`]); this uniform carries only the edge length the shader
-/// needs to turn a colour into grid coordinates and the host Mix. Domain is
-/// assumed 0..1 (a domain remap is a documented follow-up, docs/impl/lut.md).
+/// [`FxEngine::lut`]); this uniform carries the edge length the shader needs to
+/// turn a colour into grid coordinates, the host Mix, and the cube's input
+/// domain (K-271 — the shader remaps through it exactly as the CPU reference
+/// does; before that it assumed 0..1 and a cube saying otherwise rendered
+/// silently wrong).
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct LutParams {
@@ -52,6 +54,11 @@ struct LutParams {
     /// 0..1, blended against the unprocessed input.
     mix: f32,
     _pad: [f32; 2],
+    /// `DOMAIN_MIN`, per channel; the fourth lane is padding (a uniform vec3
+    /// is 16-byte aligned regardless, so it costs nothing).
+    domain_min: [f32; 4],
+    /// `DOMAIN_MAX`, per channel, same padding.
+    domain_max: [f32; 4],
 }
 
 impl FxEngine {
@@ -163,8 +170,9 @@ impl FxEngine {
     /// Apply one 3D-LUT lookup (docs/08 §3.11; docs/impl/lut.md) to a linear
     /// working texture, returning a new texture of the same size. One pass on
     /// **unpremultiplied** colour (§2.2 — a LUT is an arbitrary colour map):
-    /// per output pixel, unpremultiply, map each channel to a grid coordinate
-    /// in `[0, size-1]` (domain assumed 0..1, clamped), `textureLoad` the eight
+    /// per output pixel, unpremultiply, map each channel through
+    /// `[domain_min, domain_max]` to a grid coordinate in `[0, size-1]`
+    /// (clamped, and a zero span reading as 0), `textureLoad` the eight
     /// integer corners of `lut_tex` and trilinearly interpolate in f32 — **not**
     /// the hardware sampler, whose precision is not guaranteed bit-for-bit
     /// across GPUs (docs/impl/lut.md §3) — re-premultiply, then blend against
@@ -182,6 +190,8 @@ impl FxEngine {
         lut_tex: &wgpu::Texture,
         size: u32,
         mix: f32,
+        domain_min: [f32; 3],
+        domain_max: [f32; 3],
     ) -> wgpu::Texture {
         use wgpu::util::DeviceExt;
         let out = work_texture(ctx, w, h, "fx-lut-out");
@@ -193,6 +203,8 @@ impl FxEngine {
                     size,
                     mix,
                     _pad: [0.0; 2],
+                    domain_min: [domain_min[0], domain_min[1], domain_min[2], 0.0],
+                    domain_max: [domain_max[0], domain_max[1], domain_max[2], 0.0],
                 }),
                 usage: wgpu::BufferUsages::UNIFORM,
             });

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -2541,19 +2541,34 @@ fn wgsl_datamosh_matches_the_cpu_oracle() {
 /// pushed **red-fastest** (index `r + g*size + b*size*size`) — the layout
 /// `upload_lut_3d` and the shader assume.
 fn build_lut(size: usize, f: impl Fn([f32; 3]) -> [f32; 3]) -> lumit_core::lut::Lut3d {
+    build_lut_over(size, [0.0; 3], [1.0; 3], f)
+}
+
+/// The same, over an explicit `DOMAIN_MIN`/`DOMAIN_MAX` (K-271): the grid
+/// points are the domain's own even spacing, so a cube built here says the
+/// same thing as one exported by a grading tool that declares a domain.
+fn build_lut_over(
+    size: usize,
+    domain_min: [f32; 3],
+    domain_max: [f32; 3],
+    f: impl Fn([f32; 3]) -> [f32; 3],
+) -> lumit_core::lut::Lut3d {
     let maxf = (size - 1) as f32;
+    let at = |i: usize, ch: usize| {
+        domain_min[ch] + (domain_max[ch] - domain_min[ch]) * (i as f32 / maxf)
+    };
     let mut data = Vec::with_capacity(size * size * size);
     for b in 0..size {
         for g in 0..size {
             for r in 0..size {
-                data.push(f([r as f32 / maxf, g as f32 / maxf, b as f32 / maxf]));
+                data.push(f([at(r, 0), at(g, 1), at(b, 2)]));
             }
         }
     }
     lumit_core::lut::Lut3d {
         size,
-        domain_min: [0.0; 3],
-        domain_max: [1.0; 3],
+        domain_min,
+        domain_max,
         data,
     }
 }
@@ -2627,12 +2642,29 @@ fn wgsl_lut_matches_the_cpu_oracle() {
     // A non-separable swap of red and blue: out = [b, g, r].
     let swap = build_lut(2, |c| [c[2], c[1], c[0]]);
 
-    let cases: [(&str, &lumit_core::lut::Lut3d, f32); 5] = [
+    // A cube over a NON-DEFAULT domain (K-271): the shipped shader assumed
+    // 0..1 and skipped the `(c - lo) / (hi - lo)` remap the CPU applies, so a
+    // cube like this rendered silently wrong on the GPU while the oracle was
+    // right. Asymmetric per channel, and one axis deliberately narrower than
+    // 0..1 so mid-grey lands in a different cell on each path if the remap is
+    // missing.
+    let domained = build_lut_over(4, [-0.25, 0.0, 0.1], [1.5, 0.75, 1.0], |c| {
+        [c[2], c[0], c[1]]
+    });
+    // The degenerate domain a malformed file can declare: DOMAIN_MIN equal to
+    // DOMAIN_MAX. The CPU reads a zero span as 0 rather than dividing; the
+    // shader must do the same and not produce NaN.
+    let zero_span = build_lut_over(3, [0.5; 3], [0.5; 3], |c| [c[1], c[2], c[0]]);
+
+    let cases: [(&str, &lumit_core::lut::Lut3d, f32); 8] = [
         ("identity-full", &identity, 1.0),
         ("identity-mix0", &identity, 0.0),
         ("gamma-full", &gamma, 1.0),
         ("gamma-mixed", &gamma, 0.5),
         ("swap-rb", &swap, 1.0),
+        ("domained-full", &domained, 1.0),
+        ("domained-mixed", &domained, 0.5),
+        ("zero-span-domain", &zero_span, 1.0),
     ];
 
     for (name, lut, mix) in cases {
@@ -2652,7 +2684,17 @@ fn wgsl_lut_matches_the_cpu_oracle() {
 
         let tex = upload_linear_f32(&ctx, &img, w, h);
         let lut_tex = upload_lut_3d(&ctx, lut.size as u32, &lut.data);
-        let out = fx.lut(&ctx, &tex, w, h, &lut_tex, lut.size as u32, mix);
+        let out = fx.lut(
+            &ctx,
+            &tex,
+            w,
+            h,
+            &lut_tex,
+            lut.size as u32,
+            mix,
+            lut.domain_min,
+            lut.domain_max,
+        );
         let gpu = readback_linear_f32(&ctx, &out, w, h).unwrap();
 
         let worst = worst_f16_ulp(&cpu, &gpu);
@@ -2665,7 +2707,17 @@ fn wgsl_lut_matches_the_cpu_oracle() {
         }
 
         // Determinism: a second run is bit-identical to the first (§2.4).
-        let out2 = fx.lut(&ctx, &tex, w, h, &lut_tex, lut.size as u32, mix);
+        let out2 = fx.lut(
+            &ctx,
+            &tex,
+            w,
+            h,
+            &lut_tex,
+            lut.size as u32,
+            mix,
+            lut.domain_min,
+            lut.domain_max,
+        );
         let gpu2 = readback_linear_f32(&ctx, &out2, w, h).unwrap();
         assert_eq!(gpu, gpu2, "{name}: GPU LUT must be bit-stable");
     }
@@ -2678,7 +2730,17 @@ fn wgsl_lut_matches_the_cpu_oracle() {
     let tex = upload_linear_f32(&ctx, &img, w, h);
     let gpu = readback_linear_f32(
         &ctx,
-        &fx.lut(&ctx, &tex, w, h, &lut_tex, identity.size as u32, 1.0),
+        &fx.lut(
+            &ctx,
+            &tex,
+            w,
+            h,
+            &lut_tex,
+            identity.size as u32,
+            1.0,
+            identity.domain_min,
+            identity.domain_max,
+        ),
         w,
         h,
     )

--- a/crates/lumit-gpu/src/fx_lut.wgsl
+++ b/crates/lumit-gpu/src/fx_lut.wgsl
@@ -11,15 +11,23 @@
 // index order (x=r, y=g, z=b) matches the red-fastest flat index the cube is
 // uploaded with (r + g*N + b*N*N), so there is no transpose.
 //
-// Domain is assumed 0..1 (a domain remap is a documented follow-up,
-// docs/impl/lut.md §2). Out-of-domain input clamps to the edge (it does not
-// wrap). `mix == 0` reproduces the input bit-exactly.
+// The cube's DOMAIN_MIN/DOMAIN_MAX remap is applied here exactly as the CPU
+// reference's `axis()` applies it (docs/impl/lut.md §2): `(c - lo) / (hi - lo)`,
+// with a zero span reading as 0 rather than dividing. Almost every creative
+// `.cube` uses the default 0..1 domain, where this is the identity — but a cube
+// that does not used to render with the domain silently ignored on the GPU
+// while the CPU oracle remapped it (K-271). Out-of-domain input clamps to the
+// edge (it does not wrap). `mix == 0` reproduces the input bit-exactly.
 
 struct Params {
     size: u32,     // LUT edge length N (the cube holds N³ samples)
     mix: f32,      // 0..1, blended against the unprocessed input
     _pad0: f32,
     _pad1: f32,
+    // The cube's input domain, per channel, in .xyz (.w is padding: a uniform
+    // vec3 is 16-byte aligned anyway, so the pad is free).
+    domain_min: vec4<f32>,
+    domain_max: vec4<f32>,
 };
 
 @group(0) @binding(0) var src: texture_2d<f32>;
@@ -59,12 +67,16 @@ fn lut_apply(@builtin(global_invocation_id) gid: vec3<u32>) {
     let o = textureLoad(src, xy, 0);
     let u = unpremult(o);
 
-    // Map each channel onto the grid and clamp (out-of-domain clamps to the
-    // edge). Domain 0..1, so the coordinate is `c * (N - 1)` == the CPU
-    // reference's `axis()` with lo=0, hi=1 (docs/impl/lut.md §2).
+    // Map each channel through its domain onto the grid and clamp
+    // (out-of-domain clamps to the edge) — the CPU reference's `axis()`,
+    // operation for operation, including the zero-span guard (a DOMAIN_MIN
+    // equal to its DOMAIN_MAX reads as 0, not as a division by zero).
     let maxi = i32(p.size) - 1;
     let maxf = f32(maxi);
-    let g = clamp(u * maxf, vec3<f32>(0.0), vec3<f32>(maxf));
+    let lo = p.domain_min.xyz;
+    let span = p.domain_max.xyz - lo;
+    let t = select(vec3<f32>(0.0), (u - lo) / span, span != vec3<f32>(0.0));
+    let g = clamp(t * maxf, vec3<f32>(0.0), vec3<f32>(maxf));
     let base = floor(g);
     let f = g - base;
     let x0 = i32(base.x);

--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -1438,7 +1438,7 @@ mod render_below_at_tests {
         let engine = lumit_gpu::ColourEngine::new(&ctx);
         let compositor = lumit_gpu::Compositor::new(&ctx);
         let fx = lumit_gpu::fx::FxEngine::new(&ctx);
-        let lut_cache = std::cell::RefCell::new(HashMap::new());
+        let lut_cache = std::cell::RefCell::new(crate::fxops::LutCache::default());
         let realiser = Realiser {
             ctx: lumit_gpu::GpuContext::from_parts(ctx.device.clone(), ctx.queue.clone()),
             engine: &engine,
@@ -1762,7 +1762,7 @@ mod render_below_at_tests {
         let engine = lumit_gpu::ColourEngine::new(&ctx);
         let compositor = lumit_gpu::Compositor::new(&ctx);
         let fx = lumit_gpu::fx::FxEngine::new(&ctx);
-        let lut_cache = std::cell::RefCell::new(HashMap::new());
+        let lut_cache = std::cell::RefCell::new(crate::fxops::LutCache::default());
         let realiser = Realiser {
             ctx: lumit_gpu::GpuContext::from_parts(ctx.device.clone(), ctx.queue.clone()),
             engine: &engine,
@@ -1907,7 +1907,7 @@ mod render_below_at_tests {
         let engine = lumit_gpu::ColourEngine::new(&ctx);
         let compositor = lumit_gpu::Compositor::new(&ctx);
         let fx = lumit_gpu::fx::FxEngine::new(&ctx);
-        let lut_cache = std::cell::RefCell::new(HashMap::new());
+        let lut_cache = std::cell::RefCell::new(crate::fxops::LutCache::default());
         let realiser = Realiser {
             ctx: lumit_gpu::GpuContext::from_parts(ctx.device.clone(), ctx.queue.clone()),
             engine: &engine,

--- a/crates/lumit-render/src/fxops.rs
+++ b/crates/lumit-render/src/fxops.rs
@@ -14,14 +14,96 @@ use lumit_gpu::GpuContext;
 type Tex = wgpu::Texture;
 
 /// A parsed-and-uploaded `.cube` LUT ready to bind (docs/08 §3.11,
-/// docs/impl/lut.md): the 3D cube texture plus its per-axis size `N`. Held by
-/// the caller's path-keyed cache and cloned into a `run_ops` `luts` slot;
-/// `wgpu::Texture` is an `Arc` handle, so the clone is cheap and shares the one
-/// upload.
+/// docs/impl/lut.md): the 3D cube texture, its per-axis size `N`, and the input
+/// domain the file declared. Held by [`LutCache`] and cloned into a `run_ops`
+/// `luts` slot; `wgpu::Texture` is an `Arc` handle, so the clone is cheap and
+/// shares the one upload.
 #[derive(Clone)]
 pub struct LoadedLut {
     pub texture: Tex,
     pub size: u32,
+    /// `DOMAIN_MIN` / `DOMAIN_MAX` from the file (default `0..1`), carried to
+    /// the kernel so the GPU remaps exactly as the CPU oracle does (K-271).
+    pub domain_min: [f32; 3],
+    pub domain_max: [f32; 3],
+}
+
+/// How many distinct `.cube` files stay uploaded at once. A comp references a
+/// handful at most (docs/impl/lut.md §4); past that the least recently used one
+/// is dropped, which releases its GPU texture. Small on purpose: an unbounded
+/// cache turned every path a session ever touched into a permanent upload.
+const LUT_CACHE_MAX: usize = 8;
+
+/// The parsed-and-uploaded `.cube` files a render can bind, keyed by **path and
+/// last-modified time** and bounded to [`LUT_CACHE_MAX`] entries, most recently
+/// used first (docs/impl/lut.md §4).
+///
+/// **Why the mtime is part of the key.** Grading is iterative: export a cube
+/// from the grading tool, look at it in Lumit, adjust, export again over the
+/// same path. Keyed by path alone, the second export never appeared — Lumit
+/// kept showing the first grade until the application was restarted, with
+/// nothing on screen to say so (K-271). A file whose mtime has moved is a
+/// different entry, so it is parsed and uploaded again.
+///
+/// A path the filesystem will not stat (it vanished, or the platform has no
+/// mtime for it) keys as `None`, which still matches itself: such a file is
+/// cached by path exactly as before rather than being re-read every frame.
+#[derive(Default)]
+pub struct LutCache {
+    /// Most recently used first. A `Vec` rather than a map because the bound is
+    /// eight: a linear scan of eight strings is faster than hashing one, and
+    /// the ordering the LRU needs is the `Vec`'s own.
+    entries: Vec<(String, Option<std::time::SystemTime>, LoadedLut)>,
+}
+
+impl LutCache {
+    /// The cube at `path`, parsed and uploaded on a miss. `None` for anything
+    /// that is not a usable 3D cube — an unreadable file, a parse error, or a
+    /// 1D LUT — which leaves the effect a labelled passthrough rather than a
+    /// render failure (docs/08 §3.11, the never-crash rule).
+    pub fn get_or_load(&mut self, ctx: &GpuContext, path: &str) -> Option<LoadedLut> {
+        let mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+        if let Some(i) = self
+            .entries
+            .iter()
+            .position(|(p, t, _)| p == path && *t == mtime)
+        {
+            // Touch: this entry is now the most recently used.
+            let hit = self.entries.remove(i);
+            let lut = hit.2.clone();
+            self.entries.insert(0, hit);
+            return Some(lut);
+        }
+        // A stale entry for this path (the file was edited) is replaced, not
+        // kept alongside: the old grade is exactly what nobody wants back.
+        self.entries.retain(|(p, _, _)| p != path);
+        let text = std::fs::read_to_string(path).ok()?;
+        let lumit_core::lut::Lut::Cube3d(l) = lumit_core::lut::parse_cube(&text).ok()? else {
+            return None;
+        };
+        let loaded = LoadedLut {
+            texture: lumit_gpu::fx::upload_lut_3d(ctx, l.size as u32, &l.data),
+            size: l.size as u32,
+            domain_min: l.domain_min,
+            domain_max: l.domain_max,
+        };
+        self.entries
+            .insert(0, (path.to_owned(), mtime, loaded.clone()));
+        self.entries.truncate(LUT_CACHE_MAX);
+        Some(loaded)
+    }
+
+    /// How many cubes are held — the bound's test hook, and a number worth
+    /// having when a profile asks where the video memory went.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 /// Render one referenced layer alone into the depth input a depth-of-field
@@ -729,7 +811,17 @@ pub fn run_ops(
                 let loaded = luts.get(lut_i).and_then(|o| o.as_ref());
                 lut_i += 1;
                 if let Some(l) = loaded {
-                    tex = fx.lut(ctx, &tex, w, h, &l.texture, l.size, *mix);
+                    tex = fx.lut(
+                        ctx,
+                        &tex,
+                        w,
+                        h,
+                        &l.texture,
+                        l.size,
+                        *mix,
+                        l.domain_min,
+                        l.domain_max,
+                    );
                 }
             }
             Resolved::Dof {
@@ -888,4 +980,158 @@ pub fn run_ops(
         }
     }
     tex
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// A tiny valid `.cube` of `size`, with an optional declared domain.
+    fn cube_text(size: usize, domain: Option<([f32; 3], [f32; 3])>) -> String {
+        let mut s = format!("LUT_3D_SIZE {size}\n");
+        if let Some((lo, hi)) = domain {
+            s += &format!("DOMAIN_MIN {} {} {}\n", lo[0], lo[1], lo[2]);
+            s += &format!("DOMAIN_MAX {} {} {}\n", hi[0], hi[1], hi[2]);
+        }
+        let maxf = (size - 1) as f32;
+        for b in 0..size {
+            for g in 0..size {
+                for r in 0..size {
+                    s += &format!(
+                        "{} {} {}\n",
+                        r as f32 / maxf,
+                        g as f32 / maxf,
+                        b as f32 / maxf
+                    );
+                }
+            }
+        }
+        s
+    }
+
+    /// **A `.cube` edited on disk must be re-read** (K-271, docs/impl/lut.md §4).
+    ///
+    /// The regression: the cache keyed by path alone, so exporting a new grade
+    /// over the same filename — the whole loop of grading — kept showing the
+    /// first one until the application was restarted, with nothing on screen to
+    /// say the file on disk and the picture had parted company.
+    #[test]
+    fn an_edited_cube_is_read_again() {
+        let Ok(ctx) = lumit_gpu::GpuContext::headless() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let path = dir.path().join("grade.cube");
+        std::fs::write(&path, cube_text(2, None)).expect("written");
+        let name = path.to_string_lossy().to_string();
+
+        let mut cache = LutCache::default();
+        let first = cache.get_or_load(&ctx, &name).expect("loaded");
+        assert_eq!(first.size, 2);
+        assert_eq!(cache.len(), 1);
+
+        // Re-asking without touching the file is a cache hit: still one entry,
+        // still the cube that was parsed the first time.
+        let again = cache.get_or_load(&ctx, &name).expect("loaded");
+        assert_eq!(cache.len(), 1, "an untouched file is not read twice");
+        assert_eq!(again.size, first.size);
+
+        // Now edit it. The sleep is the point of the test, not laziness: two
+        // writes inside one filesystem timestamp tick are indistinguishable,
+        // and the cache is keyed on that tick.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&path, cube_text(3, None)).expect("re-written");
+        let edited = cache.get_or_load(&ctx, &name).expect("loaded");
+        assert_eq!(edited.size, 3, "the new grade is the one that renders");
+        assert_eq!(
+            cache.len(),
+            1,
+            "and the stale entry is replaced, not kept beside it"
+        );
+    }
+
+    /// The declared domain travels with the cube, so the kernel can remap
+    /// through it exactly as the CPU oracle does (K-271). A default-domain file
+    /// still reads 0..1.
+    #[test]
+    fn the_declared_domain_travels_with_the_cube() {
+        let Ok(ctx) = lumit_gpu::GpuContext::headless() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let mut cache = LutCache::default();
+
+        let plain = dir.path().join("plain.cube");
+        std::fs::write(&plain, cube_text(2, None)).expect("written");
+        let loaded = cache
+            .get_or_load(&ctx, &plain.to_string_lossy())
+            .expect("loaded");
+        assert_eq!(loaded.domain_min, [0.0; 3]);
+        assert_eq!(loaded.domain_max, [1.0; 3]);
+
+        let log = dir.path().join("log.cube");
+        std::fs::write(
+            &log,
+            cube_text(2, Some(([-0.25, 0.0, 0.1], [1.5, 0.75, 1.0]))),
+        )
+        .expect("written");
+        let loaded = cache
+            .get_or_load(&ctx, &log.to_string_lossy())
+            .expect("loaded");
+        assert_eq!(loaded.domain_min, [-0.25, 0.0, 0.1]);
+        assert_eq!(loaded.domain_max, [1.5, 0.75, 1.0]);
+    }
+
+    /// The cache is bounded and evicts the least recently used, so a long
+    /// session that touches many `.cube` files does not accumulate uploads
+    /// (docs/impl/lut.md §4). Re-asking for an old file *keeps it alive*, which
+    /// is what "least recently used" has to mean.
+    #[test]
+    fn the_cache_is_bounded_and_keeps_what_is_used() {
+        let Ok(ctx) = lumit_gpu::GpuContext::headless() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let mut cache = LutCache::default();
+        let path = |i: usize| dir.path().join(format!("cube{i}.cube"));
+        for i in 0..=LUT_CACHE_MAX {
+            std::fs::write(path(i), cube_text(2, None)).expect("written");
+        }
+
+        // Fill it exactly, then keep the first one fresh by asking for it again.
+        for i in 0..LUT_CACHE_MAX {
+            cache
+                .get_or_load(&ctx, &path(i).to_string_lossy())
+                .expect("loaded");
+        }
+        assert_eq!(cache.len(), LUT_CACHE_MAX);
+        cache
+            .get_or_load(&ctx, &path(0).to_string_lossy())
+            .expect("still there");
+
+        // One more file evicts the least recently used — which is now cube1,
+        // not cube0.
+        cache
+            .get_or_load(&ctx, &path(LUT_CACHE_MAX).to_string_lossy())
+            .expect("loaded");
+        assert_eq!(cache.len(), LUT_CACHE_MAX, "the bound holds");
+        assert!(
+            cache
+                .entries
+                .iter()
+                .any(|(p, _, _)| p == &*path(0).to_string_lossy()),
+            "the one that was used again survived"
+        );
+        assert!(
+            !cache
+                .entries
+                .iter()
+                .any(|(p, _, _)| p == &*path(1).to_string_lossy()),
+            "and the least recently used went"
+        );
+    }
 }

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -46,7 +46,7 @@ struct Parts {
     colour: lumit_gpu::ColourEngine,
     compositor: lumit_gpu::Compositor,
     fx: lumit_gpu::fx::FxEngine,
-    lut_cache: std::cell::RefCell<HashMap<String, crate::fxops::LoadedLut>>,
+    lut_cache: std::cell::RefCell<crate::fxops::LutCache>,
 }
 
 /// One footage item's probe result, cached so a scrub does not re-probe. Slate
@@ -462,7 +462,7 @@ impl HeadlessRenderer {
             colour: lumit_gpu::ColourEngine::new(&gpu),
             compositor: lumit_gpu::Compositor::new(&gpu),
             fx: lumit_gpu::fx::FxEngine::new(&gpu),
-            lut_cache: std::cell::RefCell::new(HashMap::new()),
+            lut_cache: std::cell::RefCell::new(crate::fxops::LutCache::default()),
         };
         let scope = lumit_gpu::scope::ScopeEngine::new(&gpu);
         Ok(Self {

--- a/crates/lumit-render/src/realise.rs
+++ b/crates/lumit-render/src/realise.rs
@@ -32,7 +32,7 @@ pub struct Realiser<'a> {
     pub engine: &'a lumit_gpu::ColourEngine,
     pub compositor: &'a lumit_gpu::Compositor,
     pub fx: &'a lumit_gpu::fx::FxEngine,
-    pub lut_cache: &'a std::cell::RefCell<std::collections::HashMap<String, LoadedLut>>,
+    pub lut_cache: &'a std::cell::RefCell<crate::fxops::LutCache>,
     /// The preview render scale (the K-185 follow-up): every composite this
     /// walk performs allocates its target at [`lumit_gpu::scaled_size`] of the
     /// comp dims while all geometry stays in logical comp pixels. A field
@@ -43,12 +43,6 @@ pub struct Realiser<'a> {
 }
 
 impl Realiser<'_> {
-    /// Turn a layer's ordered `lut_files` into the parallel `luts` list
-    /// `run_ops` binds (docs/08 §3.11): each `Some(path)` is parsed and
-    /// uploaded once (cached by path), a 1D or unreadable/absent file yields a
-    /// `None` slot (a labelled no-op, never a fault — docs/impl/lut.md §8). The
-    /// output is 1:1 and in order with `files`, so the k-th slot lines up with
-    /// the k-th `Resolved::Lut` op.
     /// Read a layer's `lens_file` paths into (content hash, text) slots,
     /// 1:1 with the stack's `Resolved::LensFlare` ops (K-264). A `None`
     /// slot (unset, missing on disk, unreadable) degrades to the picked
@@ -70,35 +64,18 @@ impl Realiser<'_> {
             .collect()
     }
 
+    /// Turn a layer's ordered `lut_files` into the parallel `luts` list
+    /// `run_ops` binds (docs/08 §3.11): each `Some(path)` is parsed and
+    /// uploaded once — cached by path *and* last-modified time, bounded and
+    /// LRU-evicted (K-271, docs/impl/lut.md §4) — and a 1D or unreadable/absent
+    /// file yields a `None` slot (a labelled no-op, never a fault). The output
+    /// is 1:1 and in order with `files`, so the k-th slot lines up with the
+    /// k-th `Resolved::Lut` op.
     fn load_luts(&self, files: &[Option<String>]) -> Vec<Option<LoadedLut>> {
         let mut cache = self.lut_cache.borrow_mut();
         files
             .iter()
-            .map(|slot| {
-                let path = slot.as_ref()?;
-                if !cache.contains_key(path) {
-                    // Any IO/parse error, or a 1D LUT, leaves the slot empty:
-                    // the effect is a passthrough, never a panic (§3.11).
-                    if let Some(loaded) = std::fs::read_to_string(path)
-                        .ok()
-                        .and_then(|text| lumit_core::lut::parse_cube(&text).ok())
-                        .and_then(|lut| match lut {
-                            lumit_core::lut::Lut::Cube3d(l) => Some(LoadedLut {
-                                texture: lumit_gpu::fx::upload_lut_3d(
-                                    &self.ctx,
-                                    l.size as u32,
-                                    &l.data,
-                                ),
-                                size: l.size as u32,
-                            }),
-                            lumit_core::lut::Lut::Cube1d(_) => None,
-                        })
-                    {
-                        cache.insert(path.clone(), loaded);
-                    }
-                }
-                cache.get(path).cloned()
-            })
+            .map(|slot| cache.get_or_load(&self.ctx, slot.as_ref()?))
             .collect()
     }
 

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5566,3 +5566,25 @@ which no widening of `BridgeMarker` was going to cover. Both the composition's l
 every layer's own (K-254) go through the one helper. Also recorded: the TODO entry claiming
 installed RAM is read only on Windows was stale — K-204 answers it on all three desktops;
 only `video_memory_bytes` is still Windows-only, and the entry now says that instead.
+
+**K-271 · DECIDED · The LUT kernel remaps through the cube's own domain, and the cube
+cache notices the file changing.** Both halves of [impl/lut.md](impl/lut.md)'s recorded
+K-114 gaps, closed together because they are the same effect's two ways of showing the
+wrong grade. **(1) The domain.** `fx_lut.wgsl` assumed the default `0..1` input domain and
+skipped the `(c - lo) / (hi - lo)` remap `Lut3d::sample` applies, so a `.cube` declaring a
+`DOMAIN_MIN`/`DOMAIN_MAX` — the log and display-referred cubes a grading tool exports —
+rendered silently wrong on the GPU while the CPU oracle was right. `LutParams` now carries
+the six floats (two padded `vec4`s; a uniform `vec3` is 16-byte aligned regardless) and the
+shader remaps operation for operation, including the zero-span guard: a `DOMAIN_MIN` equal
+to its `DOMAIN_MAX` reads as 0 on both paths rather than dividing. Chosen over the recorded
+alternative (refusing such cubes as a labelled no-op) because the maths was already written
+down in §2 and the file is not wrong — Lumit was. The oracle test gains an asymmetric
+non-default-domain cube and a degenerate zero-span one; the old shader misses the first by
+23684 fp16 ULP. **(2) The cache.** One `LutCache` keyed by `(path, mtime)` and bounded to
+eight entries, most recently used first, replacing the unbounded path-only map. Grading is
+iterative — export the cube, look, adjust, export again over the same path — and keyed by
+path alone the second export never appeared until the application restarted, with nothing
+on screen to say the file and the picture had parted company. A stale entry for a path is
+replaced rather than kept beside the new one; a path that cannot be stat'd keys as `None`,
+which still matches itself, so it is cached by path exactly as before instead of being
+re-read every frame.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1157,6 +1157,19 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   texture adds a third dimension (depth), so the card can look a colour up by its red, green and
   blue coordinates in one fetch — the first effect in Lumit to need one. The preview and the
   export load and apply the LUT the same way, so an exported file matches what you saw.
+
+  Two things about LUTs were quietly wrong until K-271. A `.cube` file may declare the *range
+  of input colours it was built for* — most say "nought to one", but a cube meant for log
+  footage might say "−0.25 to 1.5". Lumit's plain-Rust reference honoured that; the version
+  running on the graphics card ignored it and assumed nought-to-one, so such a cube came out
+  with the wrong colours and nothing said so. The card now does the same conversion, and the
+  test that compares the two paths includes a cube with an odd range, which the old shader
+  missed by a mile. Separately, Lumit remembered a `.cube` **by its filename only** — so the
+  loop everyone actually works in (export a grade, look at it, adjust, export again over the
+  same file) showed you the *first* version until you restarted the application. It now
+  remembers the file's last-changed time as well, so a re-exported grade appears on the next
+  frame, and it keeps only the eight most recently used cubes rather than every one the
+  session ever touched.
 - `crates/lumit-core/src/lut.rs` — **reading a colour LUT (`.cube` file).** A LUT
   (look-up table) is a colour recipe a colourist bakes elsewhere: feed it a red/green/blue
   and it hands back a graded red/green/blue. The common `.cube` text format stores that as a

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -308,13 +308,6 @@ in the Effect controls panel ([13-PERFORMANCE-RULES.md](13-PERFORMANCE-RULES.md)
 
 ## Next - engine/bridge follow-ups
 
-**The LUT effect's GPU path ignores a non-default domain**
-([impl/lut.md](impl/lut.md) §3 status): `fx_lut.wgsl` skips the
-`DOMAIN_MIN`/`DOMAIN_MAX` remap the CPU oracle applies, so such a cube renders
-silently wrong. Pass the six domain floats through `LutParams`, or refuse
-non-default-domain cubes as a labelled no-op. The LUT caches also key by path
-alone - no mtime, no LRU bound (§4).
-
 **Lens flare follow-ups (K-256..K-264, [impl/lens-flare.md](impl/lens-flare.md))** — the
 shipped core is docs/08 §3.27 (FlareSim model + 1299-lens library, K-261; artefact and
 picker pass K-262; bounded-submission and batching pass K-263; smooth-shading,

--- a/docs/impl/lut.md
+++ b/docs/impl/lut.md
@@ -88,16 +88,15 @@ in the working space as-is (no implicit input transfer), documented in §3.11; a
 colour-managed "LUT input space" control is a recorded follow-up. Flag this when
 the effect lands so it can be logged as a K-decision.
 
-Status (shipped, K-114) — **domain gap**: the shipped shader (`fx_lut.wgsl`)
-assumes the default `0..1` domain and skips the `(c - lo) / (hi - lo)` remap
-above; the CPU reference (`Lut3d::sample`) applies it in full. Almost every
-creative `.cube` uses the default domain, where the two are identical — but a
-cube with a non-default `DOMAIN_MIN`/`DOMAIN_MAX` currently renders with the
-domain **ignored** on the GPU (wrong colours, silently) while the CPU oracle
-remaps correctly. Closing this — either passing the six domain floats through
-`LutParams` into the shader per §2, or refusing non-default-domain cubes at
-load as a labelled no-op — is an open follow-up; until then the oracle test
-only exercises default-domain cubes.
+Status (closed, K-271): the domain gap is gone. `LutParams` carries the six
+domain floats (as two padded `vec4`s — a uniform `vec3` is 16-byte aligned
+anyway) and the shader remaps through them operation for operation with
+`axis()`, zero-span guard included: a `DOMAIN_MIN` equal to its `DOMAIN_MAX`
+reads as 0 on both paths rather than dividing. The oracle test now covers a cube
+over an asymmetric non-default domain and a degenerate zero-span one; on the
+shader as it stood before, the first of those missed by 23684 fp16 ULP. (K-114
+shipped assuming `0..1`, so such a cube rendered silently wrong while the CPU
+reference was right.)
 
 ## 4. Caching by path (never re-parse per frame)
 
@@ -108,11 +107,14 @@ frame; parse+upload only on a miss (path changed, or the file was edited on
 disk). Bound the cache (a handful of entries — a comp rarely references many
 LUTs at once) and evict LRU. The parse cost is then paid once per distinct file.
 
-Status (shipped, K-114): the shipped caches (`GpuViewer::load_luts`,
-`Renderer::layer_luts`) key by **path only** — no mtime, no LRU bound — so a
-`.cube` edited on disk keeps showing its old grade until the app restarts, and
-distinct paths accumulate uploads for the session. Upgrading both to the
-`(path, mtime)` key with an LRU bound as specified here is an open follow-up.
+Status (closed, K-271): one `LutCache` (`lumit-render::fxops`) behind the one
+`Realiser::load_luts` both preview and export drive, keyed by `(path, mtime)`
+and bounded to eight entries, most recently used first. An edited `.cube` is
+re-parsed and re-uploaded on the next frame, and a stale entry for that path is
+replaced rather than kept beside the new one. A path that cannot be stat'd keys
+as `None`, which still matches itself, so such a file is cached by path exactly
+as before rather than re-read every frame. (K-114 shipped keyed by path alone,
+so a re-exported grade never appeared until the app was restarted.)
 
 ## 5. Animating which file is live (the File parameter)
 


### PR DESCRIPTION
Fourth in the stack (base is #45). Both of `docs/impl/lut.md`'s recorded K-114 gaps, closed together because they are the same effect's two ways of showing you the wrong grade.

## 1. The domain

`fx_lut.wgsl` assumed the default `0..1` input domain and skipped the `(c - lo) / (hi - lo)` remap that `Lut3d::sample` applies. So a `.cube` declaring a `DOMAIN_MIN`/`DOMAIN_MAX` — the log and display-referred cubes a grading tool exports — rendered **silently wrong** on the GPU while the CPU oracle was right.

`LutParams` now carries the six floats (two padded `vec4`s; a uniform `vec3` is 16-byte aligned regardless) and the shader remaps operation for operation with `axis()`, zero-span guard included: a `DOMAIN_MIN` equal to its `DOMAIN_MAX` reads as 0 on both paths rather than dividing.

Chosen over the recorded alternative — refusing non-default-domain cubes as a labelled no-op — because the maths was already written down in §2 and the file is not wrong; Lumit was.

## 2. The cache

Keyed by path alone, unbounded. Grading is iterative: export the cube, look at it, adjust, export again over the same path — and the second export never appeared until the application restarted, with nothing on screen to say the file and the picture had parted company.

One `LutCache` keyed by `(path, mtime)`, bounded to eight entries, most recently used first, behind the one `load_luts` both preview and export drive. A stale entry for a path is replaced rather than kept beside the new one; a path that cannot be stat'd keys as `None`, which still matches itself, so it is cached by path exactly as before rather than re-read every frame.

## Tests

- The WGSL/CPU oracle gains an **asymmetric non-default-domain cube** and a **degenerate zero-span** one. On the shader as it stood, the first misses by **23684 fp16 ULP** (the tolerance is 2) — verified by stashing the shader change.
- Three cache tests: an edited cube is read again (with a deliberate 20 ms wait, since two writes inside one filesystem timestamp tick are indistinguishable — that is the thing being keyed on), the declared domain travels with the cube, and the bound holds while what was used again survives.

Full workspace suite, `cargo fmt --check` and `cargo clippy --workspace --all-targets` green locally (GPU tests on lavapipe, with `LUMIT_REQUIRE_GPU=1` from #44 so none of them could skip).

Docs in the same commit: both `Status (shipped, K-114)` paragraphs in `impl/lut.md` become `Status (closed, K-271)`, **K-271** appended to `02-DECISIONS.md`, the TODO entry deleted, and a plain-English pair of paragraphs added to `GUIDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u)_