### PR TITLE
Pin the toolchain, and make dependency hygiene a CI job (K-272)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 # CI: every push re-proves every promise (docs/14-ENGINEERING-RULES.md §tests).
 name: ci
 
+# Every job below installs "stable" and then lets rust-toolchain.toml decide
+# which version that actually is (docs/14 §9): rustup reads the file and fetches
+# exactly the pinned toolchain, so a compiler released mid-week cannot turn a
+# new warning into a red build on a commit that changed nothing.
+
 on:
   push:
     branches: [main]
@@ -534,6 +539,29 @@ jobs:
   # the FFI boundary. This grep covers the blind spot until the lints see
   # through the macro; every call there must return Result<_, BridgeError> or
   # degrade deliberately.
+  # Dependency hygiene (docs/14-ENGINEERING-RULES.md §9). Four questions, all
+  # of them about code nobody here wrote: is a dependency's licence one a GPLv3
+  # program may carry, does any of them have a published advisory, is anything
+  # pinned by a wildcard, and does any of it come from somewhere other than
+  # crates.io. The rules and the reasoning live in deny.toml — including the
+  # three unmaintained-crate advisories that are deliberately ignored, each with
+  # what it would take to leave it.
+  #
+  # No FFmpeg or desktop libraries are installed here on purpose: cargo-deny
+  # reads Cargo.lock and the crate manifests, never the C libraries a build
+  # would link, so this job stays a fast one.
+  cargo-deny:
+    name: dependency hygiene (licences, advisories, sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # The upstream action rather than `cargo install cargo-deny`: it ships the
+      # binary and caches the advisory database, so this job is seconds rather
+      # than a three-minute build of a tool that checks a lock file.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   no-panics-in-frb-api:
     name: bridge lint (no panic paths in the frb API surface)
     runs-on: ubuntu-latest

--- a/crates/lumit-audio/Cargo.toml
+++ b/crates/lumit-audio/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-audio"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 cpal = "0.15"

--- a/crates/lumit-bridge/Cargo.toml
+++ b/crates/lumit-bridge/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit_bridge"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 # A cdylib the Flutter desktop runners load over dart:ffi, plus a staticlib for
 # the platforms cargokit links statically (iOS, and Android's release builds).

--- a/crates/lumit-cache/Cargo.toml
+++ b/crates/lumit-cache/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-cache"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 lz4_flex = "0.11"

--- a/crates/lumit-core/Cargo.toml
+++ b/crates/lumit-core/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-core"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 arc-swap = "1"

--- a/crates/lumit-eval/Cargo.toml
+++ b/crates/lumit-eval/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-eval"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 lumit-core = { path = "../lumit-core" }

--- a/crates/lumit-flow/Cargo.toml
+++ b/crates/lumit-flow/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-flow"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/lumit-gpu/Cargo.toml
+++ b/crates/lumit-gpu/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-gpu"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/lumit-keymap/Cargo.toml
+++ b/crates/lumit-keymap/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-keymap"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/lumit-media/Cargo.toml
+++ b/crates/lumit-media/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-media"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [features]
 # Exposes the ffmpeg-CLI test-fixture generator to downstream crates' tests.

--- a/crates/lumit-project/Cargo.toml
+++ b/crates/lumit-project/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-project"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 blake3 = "1"

--- a/crates/lumit-render/Cargo.toml
+++ b/crates/lumit-render/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-render"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 # The pixel pass: decode planning, per-layer decoding, draw-list building, GPU
 # compositing, the frame-cache tiers, the headless render seam and export. An

--- a/crates/lumit-text/Cargo.toml
+++ b/crates/lumit-text/Cargo.toml
@@ -3,6 +3,9 @@ name = "lumit-text"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
+# Never goes to crates.io: these crates are the application, and they
+# reference each other by path (docs/05-ARCHITECTURE.md).
+publish = false
 
 [dependencies]
 fontdue = "0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,87 @@
+# Dependency hygiene (docs/14-ENGINEERING-RULES.md §9), enforced by
+# `cargo deny check` in CI.
+#
+# In plain terms: Lumit is GPLv3, and a GPLv3 program may only carry libraries
+# whose licences the GPL can absorb. It also should not quietly pick up a
+# library with a published security advisory, or one whose author has said they
+# have stopped maintaining it. Nobody can hold four hundred transitive
+# dependencies in their head, so this file states the rules and a robot checks
+# them on every push.
+
+[graph]
+# Every desktop Lumit ships for, so a dependency that only appears on one of
+# them is still checked (docs/05-ARCHITECTURE.md).
+targets = [
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+]
+all-features = true
+
+[advisories]
+# A published vulnerability fails the build; there is no version of "ship it
+# anyway" that survives contact with a user's project file.
+yanked = "deny"
+# Unmaintained is a different question from vulnerable: three of the crates in
+# this tree are transitively unmaintained with no safe upgrade, and failing
+# every build over a dependency nobody here can update would train people to
+# ignore the job. Each is listed below with what it would take to leave it —
+# which is the honest form of "we know".
+ignore = [
+    # RUSTSEC-2026-0192 — ttf-parser, via fontdue, via lumit-text. The
+    # replacement is `skrifa`; swapping the font rasteriser is its own piece of
+    # work with its own glyph-metric tests, tracked in docs/TODO.md.
+    "RUSTSEC-2026-0192",
+    # RUSTSEC-2025-0141 — bincode 1.x, reached through rsmpeg's own tree in
+    # lumit-media. Unmaintained, not vulnerable; it leaves when that dependency
+    # moves to bincode 2.
+    "RUSTSEC-2025-0141",
+    # RUSTSEC-2024-0436 — paste, a build-time macro crate pulled in by several
+    # dependencies. No runtime surface at all.
+    "RUSTSEC-2024-0436",
+]
+
+[licenses]
+# GPLv3-compatible permissive licences, plus Lumit's own GPL-3.0-only. A
+# dependency whose licence is not on this list stops the build until someone
+# decides deliberately — which is exactly the conversation §9 asks for in the
+# pull request description.
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "CC0-1.0",
+    "Unlicense",
+    "Unicode-3.0",
+    # Weak copyleft, per-file, and explicitly GPL-compatible upstream.
+    "MPL-2.0",
+    "GPL-3.0-only",
+]
+# A dual-licensed crate satisfies this list by either half, which is how
+# "MIT OR Apache-2.0" resolves without preferring one by hand.
+confidence-threshold = 0.9
+
+[bans]
+# Two versions of the same crate is a build-size and behaviour smell, not a
+# defect: wgpu and rsmpeg both bring their own stacks and some overlap is
+# unavoidable. Warn, so it stays visible, and let a person judge.
+multiple-versions = "warn"
+# A wildcard version on a crates.io dependency means "any version at all",
+# which is unreproducible. Lumit's own crates reference each other by `path`,
+# which cargo records as a wildcard and which is not that problem at all — the
+# code is in this repository, at this commit.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+# crates.io only. A git dependency is a version nobody can reproduce a year
+# later, which is the opposite of what a project file promises (docs/10 §1.1).
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5588,3 +5588,26 @@ on screen to say the file and the picture had parted company. A stale entry for 
 replaced rather than kept beside the new one; a path that cannot be stat'd keys as `None`,
 which still matches itself, so it is cached by path exactly as before instead of being
 re-read every frame.
+
+**K-272 · DECIDED · The toolchain is pinned and dependency hygiene is a CI job.** Two of
+[14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md) §9's owed tools, which are the same
+promise from two directions: what this repository is built *with*, and what it is built
+*from*. **(1) `rust-toolchain.toml` pins 1.94.1** (with rustfmt and clippy). Without it,
+"stable" means whatever each machine happens to have, and `-D warnings` turns a compiler
+released mid-week into a red build on a commit that changed nothing. Every CI job installs
+stable and then lets the file decide, so there is one place to raise it — deliberately,
+with the suite run and the changelog written, never incidentally. **(2) `cargo deny check`
+runs on every push** over licences, advisories, wildcards and sources, through the upstream
+action (it ships the binary and caches the advisory database, so the job is seconds rather
+than a three-minute build of a tool that reads a lock file). The allowed-licence list is the
+GPLv3-compatible permissive set plus Lumit's own GPL-3.0-only, so a dependency with any
+other licence stops the build until someone decides deliberately — which is exactly the
+conversation §9 already asks for in the pull request. Three unmaintained-crate advisories
+are ignored **by id, each with what it would take to leave it** (`ttf-parser` via fontdue
+wants the `skrifa` migration; `bincode` 1.x and `paste` leave when their parents update):
+failing every build over a transitive dependency nobody here can update trains people to
+ignore the job, and an unmaintained crate is a different question from a vulnerable one —
+`yanked` and real advisories still deny. Duplicate versions warn rather than fail (wgpu and
+rsmpeg each bring their own stack). Every workspace crate gains `publish = false`, which is
+both true — they are the application, not libraries — and what lets the wildcard rule see a
+`path` dependency between our own crates as the non-problem it is.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5592,7 +5592,13 @@ re-read every frame.
 **K-272 · DECIDED · The toolchain is pinned and dependency hygiene is a CI job.** Two of
 [14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md) §9's owed tools, which are the same
 promise from two directions: what this repository is built *with*, and what it is built
-*from*. **(1) `rust-toolchain.toml` pins 1.94.1** (with rustfmt and clippy). Without it,
+*from*. **(1) `rust-toolchain.toml` pins 1.97.1** (with rustfmt and clippy) — the version the
+repository was already building on. **A pin must name the version the repository is already
+on**: the first attempt here named an older one, which is a downgrade in disguise, and CI
+said so twice — an `objc` macro tripped `unexpected_cfgs` in the macOS-only Metal path, and
+the bridge's generated code came out naming a different derive-expansion helper
+(`assert_receiver_is_total_eq` for `assert_fields_are_eq`), so two jobs failed for reasons
+that had nothing to do with what was being pinned. Without the pin at all,
 "stable" means whatever each machine happens to have, and `-D warnings` turns a compiler
 released mid-week into a red build on a commit that changed nothing. Every CI job installs
 stable and then lets the file decide, so there is one place to raise it — deliberately,

--- a/docs/14-ENGINEERING-RULES.md
+++ b/docs/14-ENGINEERING-RULES.md
@@ -215,14 +215,19 @@ machine". Exceptions require a decision entry in [02-DECISIONS.md](02-DECISIONS.
 
 - New workspace dependencies require justification in the PR description: what it does, why
   not std/an existing dep, licence (GPLv3-compatible), maintenance signal. `cargo deny`
-  for licences, advisories, and duplicate versions is intended for CI but not yet wired
-  ([TODO.md](TODO.md)).
+  runs in CI over licences, advisories, wildcards and sources (K-272); `deny.toml` carries
+  the allowed-licence list and the reasoning, including every deliberately ignored
+  unmaintained-crate advisory and what it would take to leave it. Duplicate versions warn
+  rather than fail — wgpu and rsmpeg each bring their own stack — so the count stays
+  visible without failing builds nobody here can fix.
 - FFI-heavy and slow-to-compile crates (wgpu, rsmpeg, cudarc, QuickJS bindings) stay in
   their one owning leaf crate ([05-ARCHITECTURE.md](05-ARCHITECTURE.md) §1.1) so incremental
   builds of app-level crates stay in seconds.
-- The workspace is edition 2021 today; a `rust-toolchain.toml` pin and the edition-2024
-  move are owed ([TODO.md](TODO.md)). MSRV bumps are deliberate, logged in the changelog,
-  never incidental.
+- The workspace is edition 2021 today; the edition-2024 move is still owed
+  ([TODO.md](TODO.md)). The toolchain **is** pinned: `rust-toolchain.toml` names the one
+  version every machine and every CI job builds with (K-272), so a compiler released
+  mid-week cannot turn a new warning into a red build on a commit that changed nothing.
+  Raising it is deliberate — bump the file, run the full suite, log it in the changelog.
 
 ## 10. Definition of done
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2966,6 +2966,20 @@ it unset and keeps the friendly skip. The macOS and Windows jobs deliberately do
 yet: nobody has confirmed those runners offer an adapter at all, and a gate is only worth
 having where it has been checked.
 
+**Two more robots joined in K-272, both about things nobody here writes.** The first is a
+*pinned compiler*: "stable Rust" means whatever version your machine last downloaded, and
+because Lumit treats every compiler warning as an error, a new Rust released on a Tuesday
+could turn a build red on a commit that changed nothing. A small file at the top of the
+repository (`rust-toolchain.toml`) names the one version everything is built with, and Rust
+fetches exactly that on every machine including CI. Raising it is then a deliberate act
+rather than a surprise. The second is a *dependency check* (`cargo deny`): Lumit is GPLv3,
+which means it may only carry libraries whose licences the GPL can absorb, and it should
+not quietly pick up one with a published security hole or one whose author has stopped
+maintaining it. Four hundred-odd libraries arrive indirectly, so `deny.toml` writes the
+rules down and CI checks them — including three abandoned libraries we knowingly live with
+for now, each recorded with what it would take to leave it, because pretending they are not
+there would be worse than saying so.
+
 **The no-hex rule was being enforced on the wrong language.** Every colour is supposed to
 come from the theme, so the schemes and any custom theme actually reach every pixel — and
 CI was grepping for stray colour values in the *Rust* code, which is where the old frontend

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -396,10 +396,15 @@ template). Each lands wired to the engine through the bridge, not as a Dart-side
 setting nothing reads.
 
 **Engineering-rules tooling still owed** ([14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md)):
-`cargo deny` in CI (§9); fuzz targets for the `.lum` deserialiser and journal replayer (§6);
-a `rust-toolchain.toml` pin and the edition-2024 move (§9); the `indexing_slicing` /
-`arithmetic_side_effects` clippy denies after a hot-path sweep (§4); `clippy::pedantic`
-with curated allows (§7); the golden-frame EXR export corpus (§6).
+fuzz targets for the `.lum` deserialiser and journal replayer (§6); the **edition-2024
+move** (§9 - the toolchain pin landed in K-272, the edition did not); the
+`indexing_slicing` / `arithmetic_side_effects` clippy denies after a hot-path sweep (§4);
+`clippy::pedantic` with curated allows (§7); the golden-frame EXR export corpus (§6).
+
+**Three unmaintained dependencies are deliberately ignored in `deny.toml`** (K-272).
+`ttf-parser` (via fontdue, via `lumit-text`) is the one with a real successor: moving
+the rasteriser to `skrifa` is its own piece of work with its own glyph-metric tests.
+`bincode` 1.x and `paste` leave when the dependencies that pull them update.
 
 **The performance harness and its CI gates are not built**
 ([13-PERFORMANCE-RULES.md](13-PERFORMANCE-RULES.md) §7.3): no reference comp in the

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,6 +11,13 @@
 # Raising it is a deliberate act: bump the version, run the full suite, and say
 # so in the changelog. The CI workflows install stable and then let this file
 # govern, so there is one place to change.
+#
+# It must name the version the repository is ALREADY on, not merely one that
+# works: pinning below it is a downgrade in disguise, and the first attempt here
+# did exactly that. On the older compiler an `objc` macro tripped
+# `unexpected_cfgs` in the macOS-only Metal path, and the bridge's generated
+# code came out naming a different derive-expansion helper, so two jobs failed
+# for reasons that had nothing to do with what was being pinned.
 [toolchain]
-channel = "1.94.1"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,16 @@
+# The one Rust version this repository is built and tested with
+# (docs/14-ENGINEERING-RULES.md §9: "MSRV bumps are deliberate, logged in the
+# changelog, never incidental").
+#
+# In plain terms: without this file, "stable" means whatever version each
+# machine happens to have — so a warning that is an error under
+# `-D warnings` can appear in CI on a Tuesday because a new compiler shipped,
+# on a commit that changed nothing. rustup reads this file and uses exactly the
+# version named here, on every machine, including CI.
+#
+# Raising it is a deliberate act: bump the version, run the full suite, and say
+# so in the changelog. The CI workflows install stable and then let this file
+# govern, so there is one place to change.
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Fifth in the stack (base is #46). Two of `docs/14-ENGINEERING-RULES.md` §9's owed tools — the same promise from two directions: what this repository is built *with*, and what it is built *from*.

> **Corrected after CI.** The pin first named **1.94.1**, which is *older* than the stable this repository has been building on — a downgrade in disguise, and CI failed twice for it. On the older compiler an `objc` macro tripped `unexpected_cfgs` in the macOS-only Metal path (a lint the newer compiler does not raise, on code nobody here wrote), and the bridge's generated code names helpers from the compiler's own derive expansion — 1.94.1 emits `assert_receiver_is_total_eq` where the checked-in tree has `assert_fields_are_eq` — so the codegen-fresh job would have failed on every branch carrying the pin. It now names **1.97.1**, the version the repo was already on, and `rust-toolchain.toml` records the rule the mistake taught: a pin names the version you are already on, never merely one that works.

## 1. `rust-toolchain.toml`

Pins **1.97.1** with rustfmt and clippy. Without it, "stable" means whatever version each machine last downloaded — and since the workspace builds under `-D warnings`, a compiler released mid-week turns a brand-new lint into a red build on a commit that changed nothing. Every CI job installs stable and then lets the file decide, so there is one place to raise it: deliberately, with the suite run and the changelog written.

## 2. `cargo deny check` in CI

Runs on every push over **licences, advisories, wildcards and sources**, through the upstream action (it ships the binary and caches the advisory DB — the job is seconds rather than a three-minute build of a tool that reads a lock file).

- **Licences**: the GPLv3-compatible permissive set plus Lumit's own `GPL-3.0-only`. Anything else stops the build until someone decides deliberately — which is exactly the conversation §9 already asks for in the PR description.
- **Advisories**: `yanked` and real vulnerabilities deny. Three *unmaintained* crates are ignored **by id, each with what it would take to leave it** — `ttf-parser` (via fontdue, via `lumit-text`) wants the `skrifa` migration; `bincode` 1.x and `paste` leave when their parents update. Failing every build over a transitive dependency nobody here can update trains people to ignore the job, and unmaintained is a different question from vulnerable. The three are now their own TODO entry rather than a silent config line.
- **Duplicate versions** warn rather than fail: wgpu and rsmpeg each bring their own stack (10 today).
- **Sources**: crates.io only — a git dependency is a version nobody can reproduce a year later.

Every workspace crate gains `publish = false`. That is both true — they are the application, not libraries — and what lets the wildcard rule read a `path` dependency between our own crates as the non-problem it is.

## Verification

`cargo deny check` → **advisories ok, bans ok, licenses ok, sources ok** against the real lock file. `cargo fmt --check`, `cargo clippy --workspace --all-targets` and the full suite (GPU oracles included, on lavapipe) all green **on 1.97.1**, the pinned version.

Docs: **K-272** in `02-DECISIONS.md`, including the pin-version correction; §9 of the rulebook rewritten to say what is now enforced instead of what is intended; the TODO entry narrowed to what is genuinely still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u