### PR TITLE
The feature-less build builds, and an observer attaches to a shared store (K-273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,19 @@ jobs:
       # nothing about the kernels.
       - name: GPU oracle tests (lavapipe software Vulkan)
         run: cargo test -p lumit-gpu -- --test-threads=1
+      # The `media` feature turned off (K-273): the bridge's own decode paths
+      # compile out and its tests still pass. Deliberately NOT advertised as a
+      # build without FFmpeg — `lumit-render` and `lumit-audio` depend on
+      # `lumit-media` unconditionally and the bridge depends on both, so FFmpeg
+      # is still linked. What this guards is the feature gates inside the
+      # bridge, which had rotted until nothing built at all; making the whole
+      # dependency tree media-optional is a separate piece of work
+      # (docs/TODO.md). It rides in this job rather than its own because this
+      # runner already has FFmpeg, libclang and a warm cache.
+      - name: The bridge with its media feature off
+        run: |
+          cargo clippy -p lumit_bridge --no-default-features --all-targets -- -D warnings
+          cargo test -p lumit_bridge --no-default-features
       - name: Release-mode compile check
         run: cargo check --workspace --release
 
@@ -550,29 +563,6 @@ jobs:
   # No FFmpeg or desktop libraries are installed here on purpose: cargo-deny
   # reads Cargo.lock and the crate manifests, never the C libraries a build
   # would link, so this job stays a fast one.
-  # The media-less build, proven on a runner with no FFmpeg at all (K-273).
-  # That absence is the point: `--no-default-features` exists so the bridge can
-  # be built without a decoder, and a job that had FFmpeg installed anyway
-  # could not tell whether the feature gates still held. It went un-run for
-  # long enough to stop building, so it is a job now rather than a note.
-  bridge-no-media:
-    name: bridge builds and tests without FFmpeg (--no-default-features)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      # ALSA only: cpal is not behind the media feature. No FFmpeg, no LLVM —
-      # if either turns out to be needed, this job is the one that says so.
-      - name: Install the one system library a media-less build needs
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends pkg-config libasound2-dev
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -p lumit_bridge --no-default-features --all-targets -- -D warnings
-      - run: cargo test -p lumit_bridge --no-default-features
-
   cargo-deny:
     name: dependency hygiene (licences, advisories, sources)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,29 @@ jobs:
   # No FFmpeg or desktop libraries are installed here on purpose: cargo-deny
   # reads Cargo.lock and the crate manifests, never the C libraries a build
   # would link, so this job stays a fast one.
+  # The media-less build, proven on a runner with no FFmpeg at all (K-273).
+  # That absence is the point: `--no-default-features` exists so the bridge can
+  # be built without a decoder, and a job that had FFmpeg installed anyway
+  # could not tell whether the feature gates still held. It went un-run for
+  # long enough to stop building, so it is a job now rather than a note.
+  bridge-no-media:
+    name: bridge builds and tests without FFmpeg (--no-default-features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      # ALSA only: cpal is not behind the media feature. No FFmpeg, no LLVM —
+      # if either turns out to be needed, this job is the one that says so.
+      - name: Install the one system library a media-less build needs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libasound2-dev
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -p lumit_bridge --no-default-features --all-targets -- -D warnings
+      - run: cargo test -p lumit_bridge --no-default-features
+
   cargo-deny:
     name: dependency hygiene (licences, advisories, sources)
     runs-on: ubuntu-latest

--- a/crates/lumit-bridge/src/api.rs
+++ b/crates/lumit-bridge/src/api.rs
@@ -4,7 +4,11 @@ use lumit_core::OpError;
 
 pub mod assets;
 pub mod audio;
-#[cfg(feature = "media")]
+// Always compiled, feature or no feature: the generated Dart is one shape
+// whatever the build (docs/17 §Feature gates), so an API function that
+// disappears with a feature breaks `--no-default-features` at the generated
+// call site rather than at anything a person wrote (K-273). Detection itself
+// needs the audio pipeline and says so calmly when the build has none.
 pub mod beats;
 pub mod cache;
 pub mod composition;

--- a/crates/lumit-bridge/src/api/footage.rs
+++ b/crates/lumit-bridge/src/api/footage.rs
@@ -295,18 +295,25 @@ impl FootageReference {
             lumit_core::model::ProjectItem::Footage(footage_item) => {
                 // An unresolvable path is missing media, same as one that
                 // resolves but no longer decodes.
-                let Some(_path) = Self::resolve_path(&proj, footage_item) else {
+                let Some(path) = Self::resolve_path(&proj, footage_item) else {
                     return Ok(LumitMediaStatus::Missing);
                 };
+                // Whether a file is *there* is not a question for the decoder,
+                // and a media-less build used to answer "ready" for a path that
+                // plainly was not on disk (K-273). Asking the filesystem costs
+                // one stat and gives both builds the same answer.
+                if !path.exists() {
+                    return Ok(LumitMediaStatus::Missing);
+                }
 
-                // The file is there; whether it *decodes* takes a prober. A
-                // build without one answers that it resolved, because reporting
+                // It is there; whether it *decodes* takes a prober. A build
+                // without one answers that it resolved, because reporting
                 // "missing" for a file plainly on disk would send the user to
                 // relink something that is not lost.
                 #[cfg(not(feature = "media"))]
                 let probe: Result<(), ()> = Ok(());
                 #[cfg(feature = "media")]
-                let probe = lumit_media::probe::probe(&_path);
+                let probe = lumit_media::probe::probe(&path);
 
                 match probe {
                     Ok(_) => Ok(LumitMediaStatus::Ready),

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -2247,7 +2247,10 @@ impl LayerReference {
 
         #[cfg(not(feature = "media"))]
         {
-            let _ = buckets;
+            // Nothing decodes without FFmpeg, so the peaks are empty and the
+            // lane draws a flat line — the documented shape of a media-less
+            // build, not a failure (docs/17 §Feature gates).
+            let _ = (buckets, footage);
             Ok(empty)
         }
     }

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -338,7 +338,7 @@ impl LumitBridgeState {
         let document = Document::new();
         let journal = journal_for(&document);
         let store = DocumentStore::new(document);
-        let mut state = LumitBridgeState {
+        let state = LumitBridgeState {
             saved_revision: store.revision(),
             store,
             path: None,
@@ -447,7 +447,7 @@ impl LumitBridgeState {
 
         let journal = journal_for(&doc);
         let store = DocumentStore::new(doc);
-        let mut state = LumitBridgeState {
+        let state = LumitBridgeState {
             saved_revision: store.revision(),
             store,
             path: Some(path),

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -282,6 +282,9 @@ fn a_footage_item_pointing_at_nothing_reports_missing() {
         .expect("imported");
 
     let status = footage.get_status().expect("status");
+    // The same answer in every build: whether a file is on disk is a question
+    // for the filesystem, not for the decoder (K-273). Before that, a
+    // media-less build called this path Ready.
     assert!(matches!(status, LumitMediaStatus::Missing));
 }
 

--- a/crates/lumit-bridge/src/media.rs
+++ b/crates/lumit-bridge/src/media.rs
@@ -40,9 +40,11 @@ pub(crate) struct MediaCache {
 
 /// What a cached thumbnail is of: the item, the size asked for, and which
 /// frame of it.
+#[cfg(feature = "media")]
 type ThumbKey = (Uuid, u32, i64);
 
 /// A decoded thumbnail: width, height, and tightly packed RGBA8.
+#[cfg(feature = "media")]
 type Thumb = (u32, u32, Vec<u8>);
 
 impl MediaCache {
@@ -147,6 +149,7 @@ pub(crate) fn thumb_store(
     );
 }
 
+#[cfg(feature = "media")]
 pub(crate) fn thumbnail_from_path(
     cache: &mut MediaCache,
     id: Uuid,

--- a/crates/lumit-bridge/src/prefetch.rs
+++ b/crates/lumit-bridge/src/prefetch.rs
@@ -19,6 +19,7 @@
 //! and filing it is a favour to the next visit, never a hazard.
 
 use lumit_render::PrefetchWant;
+#[cfg(feature = "media")]
 use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use uuid::Uuid;
@@ -70,6 +71,7 @@ impl Prefetcher {
 /// for frames in playing order, so the decoders run sequentially — the cheap
 /// direction. A job that fails to decode is skipped: the render will try it
 /// inline and surface the error through the path that already knows how.
+#[cfg(feature = "media")]
 fn run(jobs: Receiver<PrefetchWant>, done: Sender<Done>) {
     let mut decoders: HashMap<Uuid, lumit_media::VideoDecoder> = HashMap::new();
     while let Ok(want) = jobs.recv() {
@@ -103,4 +105,15 @@ fn run(jobs: Receiver<PrefetchWant>, done: Sender<Done>) {
             return;
         }
     }
+}
+
+/// Without the decoder there is nothing to decode ahead (K-273). The thread
+/// still exists and still drains its queue, so the worker's request/drain
+/// calls need no feature gate of their own — it simply never produces a
+/// result, and every frame decodes inline exactly as it did before prefetch
+/// existed. `--no-default-features` is a build without FFmpeg, not a build
+/// with a different scheduler.
+#[cfg(not(feature = "media"))]
+fn run(jobs: Receiver<PrefetchWant>, _done: Sender<Done>) {
+    while jobs.recv().is_ok() {}
 }

--- a/crates/lumit-core/src/store.rs
+++ b/crates/lumit-core/src/store.rs
@@ -54,7 +54,14 @@ type ChangeCallback = Arc<dyn Fn(DocumentChange) + Send + Sync>;
 pub struct DocumentStore {
     current: ArcSwap<Document>,
     journal: Mutex<Journal>,
-    on_change: Option<ChangeCallback>,
+    /// The change observer. Behind a `Mutex` rather than owned outright so it
+    /// can be attached to a store that is **already shared** (K-273): a
+    /// `&mut self` setter meant the observer had to be registered before the
+    /// store went into its `Arc`, which is an ordering rule no type enforced
+    /// and one every caller had to remember. The lock is only ever held to
+    /// clone the `Arc` out or to swap it — never across the callback itself,
+    /// which crosses into the frontend (docs/14 §3: no locks across FFI).
+    on_change: Mutex<Option<ChangeCallback>>,
     /// Bumped once per published snapshot (commit, undo, redo, replace).
     /// A reader that remembers the number it last saw can ask "has anything
     /// changed?" for the cost of one atomic load — the frontend's read model
@@ -67,7 +74,7 @@ impl DocumentStore {
         Self {
             current: ArcSwap::from_pointee(doc),
             journal: Mutex::new(Journal::default()),
-            on_change: None,
+            on_change: Mutex::new(None),
             revision: std::sync::atomic::AtomicU64::new(0),
         }
     }
@@ -84,11 +91,16 @@ impl DocumentStore {
             .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 
-    /// Register the change observer. Optional by construction: the egui shell
-    /// never sets one and reads snapshots directly, so every commit/undo/redo
-    /// path must stay a no-op when it is absent.
-    pub fn set_callback(&mut self, callback: ChangeCallback) {
-        self.on_change = Some(callback);
+    /// Register the change observer. Optional by construction: a frontend that
+    /// reads snapshots directly never sets one, so every commit/undo/redo path
+    /// must stay a no-op when it is absent.
+    ///
+    /// Takes `&self`, so it can be called on a store that is already shared —
+    /// the observer usually wants to refer back to the thing that owns the
+    /// store, which is impossible if it has to be attached first (K-273).
+    /// Registering a second observer replaces the first; there is one.
+    pub fn set_callback(&self, callback: ChangeCallback) {
+        *self.on_change.lock() = Some(callback);
     }
 
     /// Tell the observer, if there is one. Callers must drop the journal lock
@@ -97,7 +109,12 @@ impl DocumentStore {
     /// across FFI. Dropping it also lets the observer re-enter the store —
     /// notifying under the lock would deadlock on its first `commit`.
     fn notify(&self, op: Op) {
-        if let Some(callback) = &self.on_change {
+        // Cloned out under the lock and called after it is released: the
+        // callback re-enters the store (the bridge commits from inside it) and
+        // crosses FFI, and either under the lock would be a deadlock or a
+        // rule broken.
+        let callback = self.on_change.lock().clone();
+        if let Some(callback) = callback {
             callback(DocumentChange { op });
         }
     }
@@ -467,7 +484,7 @@ mod tests {
         let store = Arc::new(Mutex::new(Vec::<Op>::new()));
         let seen = store.clone();
 
-        let mut doc_store = DocumentStore::new(Document::new());
+        let doc_store = DocumentStore::new(Document::new());
         doc_store.set_callback(Arc::new(move |change| {
             seen.lock().push(change.op);
         }));
@@ -487,6 +504,52 @@ mod tests {
         );
     }
 
+    /// **An observer can be attached to a store that is already shared**
+    /// (K-273).
+    ///
+    /// The setter used to take `&mut self`, so the observer had to be
+    /// registered before the store went into its `Arc` — an ordering rule that
+    /// no type enforced and every caller had to remember, and one that the
+    /// natural shape of the thing fights: an observer usually wants to talk
+    /// about the object that *owns* the store, which does not exist yet at
+    /// that point. (`Arc::new_cyclic` is the workaround the test below still
+    /// uses for its own reason; it should not be the only way in.)
+    #[test]
+    fn an_observer_attaches_to_a_store_that_is_already_shared() {
+        let store = Arc::new(DocumentStore::new(Document::new()));
+        // Shared first, and shared *widely* — a second handle, as a frontend
+        // would hold.
+        let elsewhere = Arc::clone(&store);
+
+        let seen = Arc::new(Mutex::new(0usize));
+        let count = Arc::clone(&seen);
+        elsewhere.set_callback(Arc::new(move |_| {
+            *count.lock() += 1;
+        }));
+
+        let (ops, _) = scripted_ops(&store.snapshot());
+        let committed = ops.len();
+        for op in ops {
+            store.commit(op).unwrap();
+        }
+        assert_eq!(
+            *seen.lock(),
+            committed,
+            "an observer registered through a shared handle still hears every op"
+        );
+
+        // And registering a second one replaces the first: there is one
+        // observer, not a list.
+        let later = Arc::new(Mutex::new(0usize));
+        let count = Arc::clone(&later);
+        store.set_callback(Arc::new(move |_| {
+            *count.lock() += 1;
+        }));
+        store.undo().unwrap();
+        assert_eq!(*later.lock(), 1, "the new observer hears it");
+        assert_eq!(*seen.lock(), committed, "and the old one does not");
+    }
+
     /// An observer that reads back into the store must not deadlock.
     ///
     /// `journal_ops` takes the very mutex `commit` holds, and `parking_lot`'s
@@ -500,7 +563,7 @@ mod tests {
         let count = observed.clone();
 
         let store = Arc::new_cyclic(|weak: &std::sync::Weak<DocumentStore>| {
-            let mut store = DocumentStore::new(Document::new());
+            let store = DocumentStore::new(Document::new());
             let weak = weak.clone();
             store.set_callback(Arc::new(move |_| {
                 if let Some(store) = weak.upgrade() {

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5628,8 +5628,13 @@ function that did not exist — while `prefetch` and the thumbnail cache leaked
 `lumit_media` types past their gates. Beats is now always compiled and its detection asks
 the audio pipeline, answering `NoAudioPipeline` where a build has none, which is the shape
 every other feature-sensitive call already uses. The decode-ahead thread still exists and
-still drains its queue without the decoder; a build without FFmpeg is a build that does not
-*decode*, not one with a different scheduler. Chosen over the recorded alternative — dropping
+still drains its queue without the decoder; a build with the feature off is one that does not
+*decode*, not one with a different scheduler. **What it is not**, and what the first version
+of this entry wrongly claimed: a build without FFmpeg. `lumit-render` and `lumit-audio`
+depend on `lumit-media` unconditionally and the bridge depends on both, so FFmpeg is still
+linked — the feature governs the bridge's own decode paths, not the dependency tree. CI
+caught the overstatement immediately, on a runner deliberately given no FFmpeg. Making the
+tree genuinely media-optional is its own piece of work, TODO'd rather than implied. Chosen over the recorded alternative — dropping
 the pretence that the features are independent — because the contract's promise is the
 valuable half and only the code had lapsed. One behaviour change fell out of it: a footage
 item whose file is not on disk now reports **Missing** in a media-less build too. Whether a

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5617,3 +5617,27 @@ ignore the job, and an unmaintained crate is a different question from a vulnera
 rsmpeg each bring their own stack). Every workspace crate gains `publish = false`, which is
 both true — they are the application, not libraries — and what lets the wildcard rule see a
 `path` dependency between our own crates as the non-problem it is.
+
+**K-273 · DECIDED · The feature-less build builds, and an observer attaches to a store that
+is already shared.** Two of the bridge's recorded rough edges. **(1)
+`cargo build -p lumit_bridge --no-default-features` builds and tests again.** The rule was
+already written down (docs/17 §Feature gates: the API surface is one shape whatever the
+features, so the generated Dart is one shape everywhere) and the code had drifted from it in
+three places: `api::beats` was gated *away* — so the checked-in generated code called a
+function that did not exist — while `prefetch` and the thumbnail cache leaked
+`lumit_media` types past their gates. Beats is now always compiled and its detection asks
+the audio pipeline, answering `NoAudioPipeline` where a build has none, which is the shape
+every other feature-sensitive call already uses. The decode-ahead thread still exists and
+still drains its queue without the decoder; a build without FFmpeg is a build that does not
+*decode*, not one with a different scheduler. Chosen over the recorded alternative — dropping
+the pretence that the features are independent — because the contract's promise is the
+valuable half and only the code had lapsed. One behaviour change fell out of it: a footage
+item whose file is not on disk now reports **Missing** in a media-less build too. Whether a
+file exists is a question for the filesystem, not the decoder; it used to answer "ready".
+**(2) `DocumentStore::set_callback` takes `&self`.** The observer had to be registered
+before the store went into its `Arc`, which no type enforced and which fights the natural
+shape of the thing: an observer usually wants to refer back to the object that owns the
+store, and that object does not exist yet at that point. The callback lives behind a
+`parking_lot::Mutex`, locked only to clone the `Arc` out or swap it and never across the
+call itself — the existing no-locks-across-FFI and re-entrancy rules (docs/14 §3) are
+unchanged, and their tests still pass.

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -218,7 +218,10 @@ path, documented beside the types in
 
 - **`media`** (default on) pulls `lumit-media` (FFmpeg) for probing and decoding.
     Without it, footage does not probe and thumbnails are absent.
-- **Note.** `--no-default-features` builds and tests (K-273). The API surface is
+- **Note.** `--no-default-features` builds and tests (K-273). It is **not** a
+    build without FFmpeg: `lumit-render` and `lumit-audio` depend on
+    `lumit-media` unconditionally and the bridge depends on both, so the library
+    is still linked. The feature governs the bridge's own decode paths. The API surface is
     identical whatever the features are — the generated Dart is one shape
     everywhere — so a function never *disappears* with a feature: it stays
     compiled and its body degrades. Beat detection is the shape to copy: always

--- a/docs/17-BRIDGE-CONTRACT.md
+++ b/docs/17-BRIDGE-CONTRACT.md
@@ -218,10 +218,14 @@ path, documented beside the types in
 
 - **`media`** (default on) pulls `lumit-media` (FFmpeg) for probing and decoding.
     Without it, footage does not probe and thumbnails are absent.
-- **Note.** `--no-default-features` does **not** currently build: the render
-    worker is part of the API surface, which is deliberately identical whatever
-    the features are so the generated Dart is one shape everywhere. Recorded in
-    [TODO.md](TODO.md).
+- **Note.** `--no-default-features` builds and tests (K-273). The API surface is
+    identical whatever the features are — the generated Dart is one shape
+    everywhere — so a function never *disappears* with a feature: it stays
+    compiled and its body degrades. Beat detection is the shape to copy: always
+    present, and `NoAudioPipeline` on a build with no audio pipeline. What a
+    media-less build actually loses is decoding — no probe, no thumbnails, no
+    waveform peaks, and the decode-ahead thread drains its queue without
+    producing anything — never a call that is not there.
 - **`render`** (default on) enables the composited-comp Viewer path and export
 through the headless seam.
 - **`shared-texture`**, **`shared-texture-linux`**, **`shared-texture-macos`**

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2966,6 +2966,19 @@ it unset and keeps the friendly skip. The macOS and Windows jobs deliberately do
 yet: nobody has confirmed those runners offer an adapter at all, and a gate is only worth
 having where it has been checked.
 
+**A build with no FFmpeg is a real build again (K-273).** Lumit can be compiled without the
+video decoder — useful for anyone who wants to work on the editing model without installing
+FFmpeg first, and it is why the Windows job used to be quick. Nobody had built it that way
+for a while, and it had stopped compiling. The rule it broke is worth knowing, because it is
+easy to break again: **the list of functions Dart can call is the same in every build.** The
+Dart side of the bridge is generated from that list, so a function that *vanishes* when a
+feature is off leaves generated code calling something that is not there. What may change is
+what a function *does*: beat detection is always present and simply answers "this build has
+no audio pipeline". A media-less build loses decoding — no probing, no thumbnails, no
+waveform peaks, and the decode-ahead thread quietly does nothing — never a call that is
+missing. There is now a CI job that builds and tests it **on a runner with no FFmpeg at
+all**, which is the only way to prove the thing actually stands on its own.
+
 **Two more robots joined in K-272, both about things nobody here writes.** The first is a
 *pinned compiler*: "stable Rust" means whatever version your machine last downloaded, and
 because Lumit treats every compiler warning as an error, a new Rust released on a Tuesday

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2976,8 +2976,14 @@ feature is off leaves generated code calling something that is not there. What m
 what a function *does*: beat detection is always present and simply answers "this build has
 no audio pipeline". A media-less build loses decoding — no probing, no thumbnails, no
 waveform peaks, and the decode-ahead thread quietly does nothing — never a call that is
-missing. There is now a CI job that builds and tests it **on a runner with no FFmpeg at
-all**, which is the only way to prove the thing actually stands on its own.
+missing. CI now builds and tests it on every push, so it cannot rot again.
+
+One honest correction, because the first version of this said otherwise: turning the
+feature off does **not** give you a build with no FFmpeg in it. Two other parts of the
+engine — the renderer and the audio mixer — depend on the decoder unconditionally, and the
+bridge depends on both, so FFmpeg is still linked either way. What the feature governs is
+the bridge's *own* decode paths. Making the whole dependency tree media-optional is a
+separate job, and it is written down as one rather than implied by a feature flag.
 
 **Two more robots joined in K-272, both about things nobody here writes.** The first is a
 *pinned compiler*: "stable Rust" means whatever version your machine last downloaded, and

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -178,8 +178,6 @@ The Timeline matters most - it is zoomed constantly while cutting.
 - **`ProjectReference::state()` hands the raw `Arc<RwLock<…>>` out**, so a caller
     can hold a project lock as long as it likes and in any order. The order is
     written down and tested; nothing enforces it at the type level.
-- **`DocumentStore::set_callback` takes `&mut self`**, so the observer can only be
-    attached before the store is shared.
 - **The macOS IOSurface Viewer path is unproven** - CI links the bundle but
     nobody has launched the .app (K-033).
 - **The macOS .app is not relocatable** - the podspec links keg-only FFmpeg by
@@ -204,11 +202,6 @@ The Timeline matters most - it is zoomed constantly while cutting.
 - **The Linux DMA-BUF path has never run on a Linux machine with a GPU** (K-033).
     It fails calmly on the adapter-less CI runner, which proves the failure is
     calm and nothing about the path working.
-- **`cargo build -p lumit_bridge --no-default-features` does not build** - the
-    render worker is part of the API surface, which is deliberately one shape
-    whatever the features ([17-BRIDGE-CONTRACT.md](17-BRIDGE-CONTRACT.md) §Feature
-    gates). Either make the worker feature-clean or drop the pretence that the
-    features are independent.
 - **frb's SSE codec encodes `Vec<u8>` one byte at a time** - now taxes only
     thumbnails and scope traces, but worth the bulk codec if traces feel late.
 - **Engine subsystems with no frb API** - masks (`add_mask`,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -399,6 +399,12 @@ move** (§9 - the toolchain pin landed in K-272, the edition did not); the
 the rasteriser to `skrifa` is its own piece of work with its own glyph-metric tests.
 `bincode` 1.x and `paste` leave when the dependencies that pull them update.
 
+**A genuinely FFmpeg-free build is not possible yet (K-273).** `lumit_bridge
+--no-default-features` compiles the bridge's own decode paths out, but `lumit-render` and
+`lumit-audio` depend on `lumit-media` unconditionally, so the library is still linked and
+the build still needs it installed. Making those two deps optional — and the render/audio
+paths that use them — is what "builds without FFmpeg" would actually take.
+
 **The performance harness and its CI gates are not built**
 ([13-PERFORMANCE-RULES.md](13-PERFORMANCE-RULES.md) §7.3): no reference comp in the
 repository, no headless benchmark scenarios, no budget gates per merge. The per-node


### PR DESCRIPTION
Sixth in the stack (base is #47). Two of the bridge's recorded rough edges from `docs/TODO.md`.

> **Corrected after CI.** The first version of this PR claimed `--no-default-features` gives a build with no FFmpeg, and added a job on a runner with none to prove it. That job failed, and it was right to: `lumit-render` and `lumit-audio` depend on `lumit-media` **unconditionally** and the bridge depends on both, so FFmpeg is still linked whatever the bridge's own feature says. What the feature governs is the bridge's own decode paths — which is the thing that had rotted. The standalone job is gone; the check now rides in the Linux job (which already has FFmpeg, libclang and a warm cache) as clippy + tests for `-p lumit_bridge --no-default-features`. K-273, `GUIDE.md` and the bridge contract are corrected in the same commit, and "make the dependency tree genuinely media-optional" is now its own TODO entry rather than something a feature flag implies.

## 1. `--no-default-features` builds and tests again

The rule was already written down — docs/17 §Feature gates: **the API surface is one shape whatever the features**, so the generated Dart is one shape everywhere — and the code had drifted from it in three places:

- `api::beats` was gated *away*, so the checked-in generated code called a function that did not exist;
- `prefetch` and the thumbnail cache leaked `lumit_media` types past their gates.

Beats is now always compiled and its detection answers `NoAudioPipeline` where a build has none — the shape every other feature-sensitive call already uses. The decode-ahead thread still exists and still drains its queue without the decoder.

**One behaviour change fell out**, worth calling out: a footage item whose file is not on disk now reports **Missing** with the feature off too. Whether a file exists is a question for the filesystem, not the decoder — it used to answer `Ready`.

## 2. `DocumentStore::set_callback` takes `&self`

The observer had to be registered before the store went into its `Arc` — an ordering rule no type enforced, and one that fights the natural shape of the thing: an observer usually wants to refer back to the object that *owns* the store, which does not exist yet at that point.

The callback now lives behind a `parking_lot::Mutex`, locked only to clone the `Arc` out or swap it, never across the call itself — so the no-locks-across-FFI rule (docs/14 §3) and the re-entrancy behaviour are unchanged, and their existing tests (including the deadlock one) still pass. New test attaches an observer through a *second handle* to an already-shared store, and checks that registering a second one replaces the first.

## Verification

Both feature sets green: `cargo test --workspace` and `cargo test -p lumit_bridge --no-default-features` (179 passing), clippy clean on both, `cargo fmt --check`, and the GPU suite on lavapipe.

Docs: **K-273** in `02-DECISIONS.md` (including the correction above); the §Feature gates note in `17-BRIDGE-CONTRACT.md` saying what a media-off build actually loses and what it does not; both TODO entries deleted; a plain-English paragraph in `GUIDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u