### PR TITLE
An effect on a Null is labelled inert, not refused (K-274)

### DIFF
--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -1486,6 +1486,63 @@ fn the_pixel_less_kinds_report_no_picture() {
     assert!(adjustment.has_picture().expect("has_picture"));
 }
 
+/// **An effect on a Null keeps its values, animation and all** (K-274).
+///
+/// A Null draws nothing, so an image effect on one changes no picture — which
+/// is why the drop is *labelled inert* rather than refused. The parameters are
+/// the point: a control put on a Null is how a value is meant to be published
+/// for other layers to read (a Slider driving an expression, once expressions
+/// land). So the stack must survive a commit, keep its keyframes, and sample
+/// like any other curve — nothing may quietly strip an effect from a layer that
+/// has no pixels.
+#[test]
+fn an_effect_on_a_null_layer_keeps_its_animated_value() {
+    use crate::api::effect::{sample_scalar, BridgeEffectValue, BridgeRational, BridgeScalar};
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    let null = comp.add_null_layer().expect("null added");
+
+    null.add_effect("blur".into())
+        .expect("the drop is accepted");
+    assert_eq!(
+        null.get_effects().expect("effects").len(),
+        1,
+        "an effect on a Null is stored like any other"
+    );
+
+    // Animate it, and commit through the ordinary staged-copy path.
+    let mut staged = null.get_effects().expect("effects");
+    let key = |num: i64, value: f64| crate::api::effect::BridgeKeyframe {
+        time: BridgeRational { num, den: 1 },
+        value,
+        interp_in: crate::api::effect::BridgeSideInterp::Linear,
+        interp_out: crate::api::effect::BridgeSideInterp::Linear,
+    };
+    let keys = BridgeScalar::Keyframed(vec![key(0, 0.0), key(1, 10.0)]);
+    staged[0]
+        .set_value("radius".into(), BridgeEffectValue::Float(keys))
+        .expect("a Null's parameter takes a value like any other");
+    null.set_effects(staged).expect("committed");
+
+    // Read it back and sample it: halfway along the ramp is five, on a layer
+    // that will never draw a pixel.
+    let Ok(BridgeEffectValue::Float(scalar)) = null
+        .get_effects()
+        .expect("effects")
+        .first()
+        .expect("the effect survived the commit")
+        .get_value("radius".into())
+    else {
+        panic!("a Null's effect parameter must read back as the Float it is");
+    };
+    let half = sample_scalar(scalar, BridgeRational { num: 1, den: 2 });
+    assert!(
+        (half - 5.0).abs() < 1e-9,
+        "the curve on a Null evaluates like any other: got {half}"
+    );
+}
+
 /// Each switch is its own op, so a click is one undo step and toggling one
 /// switch never disturbs another.
 #[test]

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5646,3 +5646,24 @@ store, and that object does not exist yet at that point. The callback lives behi
 `parking_lot::Mutex`, locked only to clone the `Arc` out or swap it and never across the
 call itself — the existing no-locks-across-FFI and re-entrancy rules (docs/14 §3) are
 unchanged, and their tests still pass.
+
+**K-274 · DECIDED · An effect on a Null is labelled inert, never refused — and
+anti-aliasing is a project property, on by default.** Two owner decisions on open
+questions (2026-08-05). **(1) Effects on a Null layer.** The recorded choice was "either
+refuse the drop or say plainly that the stack is inert"; the owner chose *inert*, with the
+reason that decides the shape of it: **a Null is where a control lives when it is meant to
+drive something else.** A Slider (or any parameter) on a Null is how a value gets published
+for another layer's expression to read, so refusing the drop would remove a feature rather
+than prevent a mistake — and this holds for every effect, not just the expression-control
+family. So: the drop is accepted, the stack is stored, keyframed and sampled exactly as on
+any other layer (pinned by `an_effect_on_a_null_layer_keeps_its_animated_value`), nothing
+strips it, and the Effect controls panel says once, calmly, that a Null draws nothing so an
+effect here changes no picture while its parameters stay live. When expressions land
+(Phase 4, [12-PLUGINS.md](12-PLUGINS.md)) they read those parameters like any other; nothing
+about this decision is deferred to them. **(2) Anti-aliasing** is a **project property, on
+by default, with one value shared by preview and export** — it changes what a comp looks
+like, so it must travel with the file and match on another machine, and a preview that
+anti-aliases differently from the export would break the K-031 identity. That answers both
+of the recorded open questions; the work itself (MSAA targets and resolve in the composite
+pass, the setting through the bridge, and an adapter capability check — a sample count is
+asked for, never assumed) stays in [TODO.md](TODO.md).

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2140,7 +2140,16 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   (it emits no node, so it costs no drawing pass), the renderer returns no pixels for it,
   and it answers "no" when asked whether it has a picture — so it is never offered as a
   matte source or as a layer-valued effect parameter, where picking it would have quietly
-  produced nothing. It is *not* invisible to the frame cache, though, and that distinction
+  produced nothing.
+
+  You *can* still drop an effect on a null, and Lumit deliberately lets you (K-274). Nothing
+  is drawn — there is no picture for an effect to change — so the Effect controls panel says
+  so once, quietly, rather than refusing the drop. The reason is that an effect is not only
+  a picture operation: its parameters are values, animatable like any other, and a null is
+  the natural home for a value that is meant to drive *other* layers. Put a slider on a null,
+  animate it, and point another layer's expression at it, and the fact that the null itself
+  renders nothing is exactly the point. So the stack on a null is stored, keyframed and
+  sampled like any other; only the drawing is absent. It is *not* invisible to the frame cache, though, and that distinction
   matters: the transform still feeds the key that decides which cached frames are still
   good, so nudging a null correctly throws away the cached frames of everything hanging off
   it. A null draws a grabbable 100×100 wireframe box in the Viewer (K-230 — After Effects'

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -290,8 +290,6 @@ colour individually; only the two Timeline tokens default from the mode.
     suspend mid-drag).
 - **Volume keyframes draw no lane diamonds and no graph curve** - volume is not
     in the comp read model; fold it into `BridgeLayerInfo` if either matters.
-- **Effects on a Null are accepted and never run** - either refuse the drop or
-    say plainly that the stack is inert.
 
 **Layer and effect render-time indicator.** Per-layer total render time in ms on
 the layer row, and per-effect time on each effect's title row, both as a Timeline
@@ -324,12 +322,13 @@ migration** from the grandfathered % of frame to px@comp (K-260 convention), and
 writes for a paired keyframe toggle (two ops today).
 
 **Anti-aliasing in the renderer.** Edges of transformed layers, shape strokes and
-text stair-step, worst on a slow rotation. Two questions decide where the setting
-lives: whether the sample count is a **project** property (it changes what a comp
-looks like, so it must match on another machine and in export) or a
-**preference** (it trades quality for speed on this machine), and whether preview
-and export share one value. Sample counts must be checked against the adapter
-rather than assumed.
+text stair-step, worst on a slow rotation. **Decided (owner, 2026-08-05, K-274): a
+project property, on by default, one value shared by preview and export** — it
+changes what a comp looks like, so it must travel with the file and match on
+another machine. Still to build: the MSAA render targets and resolve in the
+composite pass, the project setting through the bridge and its Settings row, and
+the adapter capability check (a sample count must be asked for, never assumed —
+the flare's pooled MSAA in K-265 is the nearest existing shape).
 
 **The stale-fd race on a Linux Viewer resize** (`lumit-render/src/headless.rs`'s
 `shared_dmabuf` re-create, with `lumit-gpu/src/shared_linux.rs`'s `Drop`). The

--- a/flutter_ui/lib/panels/effect_controls_panel_frb.dart
+++ b/flutter_ui/lib/panels/effect_controls_panel_frb.dart
@@ -210,6 +210,24 @@ class _EffectControlsPanelFrbState extends State<EffectControlsPanelFrb> {
                       onToggle: () => _toggle('transform'),
                     ),
                   ],
+                  // A null layer has no picture, so nothing here changes one
+                  // — but the parameters are real, animatable values, which is
+                  // exactly what a null is for once expressions can read them
+                  // (K-274). Said plainly, once, rather than refusing the drop.
+                  if (info.kind == BridgeLayerKind.nullLayer &&
+                      info.effects.isNotEmpty)
+                    Padding(
+                      key: const ValueKey('fx-null-inert'),
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                      child: Text(
+                        'A null layer draws nothing, so an effect here changes '
+                        'no picture. Its parameters stay live — a null is '
+                        'where a control lives when it is meant to drive other '
+                        'layers.',
+                        style: t.small.copyWith(color: t.textMuted),
+                      ),
+                    ),
                   if (info.effects.isEmpty)
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 18),

--- a/flutter_ui/test/frb/effect_controls_frb_test.dart
+++ b/flutter_ui/test/frb/effect_controls_frb_test.dart
@@ -113,6 +113,44 @@ void main() {
           reason: 'a row per declared parameter, labelled from the schema');
     });
 
+    testWidgets(
+        'a null layer says its effects change no picture, and keeps their values',
+        (tester) async {
+      // K-274: effects on a null are ACCEPTED and labelled inert rather than
+      // refused. A null draws nothing, so nothing here changes a picture — but
+      // the parameters are real, animatable values, which is the whole point
+      // of putting a control on a null.
+      final p = freshProject();
+      final comp = p.state.project!.newComposition(name: 'Scene');
+      final nul = comp.addNullLayer();
+      p.uiState
+        ..setSelectedComp(comp)
+        ..selectedLayer.value = nul;
+
+      await tester.pumpWidget(hostPanel(
+        child: const EffectControlsPanelFrb(),
+        state: p.state,
+        uiState: p.uiState,
+      ));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('fx-null-inert')), findsNothing,
+          reason: 'nothing to say about a stack that is empty');
+
+      nul.addEffect(name: 'blur');
+      p.uiState.model.refresh();
+      await tester.pump();
+      expect(find.byKey(const ValueKey('fx-null-inert')), findsOneWidget,
+          reason: 'the drop is accepted, and the panel says what it does');
+
+      // And the effect is genuinely on the layer, with a readable value — the
+      // difference between "inert" and "refused". (That those values stay
+      // live and animatable is pinned engine-side, where the commit is:
+      // `an_effect_on_a_null_layer_keeps_its_animated_value`.)
+      expect(nul.getEffects().length, 1);
+      expect(find.text('Gaussian blur'), findsOneWidget,
+          reason: 'the stack draws as it does on any other layer');
+    });
+
     testWidgets('a parameter edit commits, and reading it back is exact',
         (tester) async {
       final p = withLayer();


### PR DESCRIPTION
Seventh in the stack (base is #48). Your decision on a recorded open question, plus the anti-aliasing one written down while it is fresh.

## Effects on a Null

The TODO offered "refuse the drop or say plainly that the stack is inert". You chose inert, and gave the reason that decides the shape of it: **a Null is where a control lives when it is meant to drive something else.** A slider on a Null is how a value gets published for another layer's expression to read — so refusing the drop would remove a feature rather than prevent a mistake, and that holds for *every* effect, not only the expression-control family.

So:
- the drop is accepted, exactly as before;
- the stack is stored, keyframed and sampled like any other layer's — nothing strips it;
- the Effect controls panel says once, quietly: *"A null layer draws nothing, so an effect here changes no picture. Its parameters stay live — a null is where a control lives when it is meant to drive other layers."*

**Tests.** Engine-side: an effect added to a Null keeps its keyframed radius across the staged-copy commit and samples to 5.0 at the halfway point — on a layer that will never draw a pixel. That is the guarantee expressions will lean on, pinned now rather than when they land. Panel-side: the note appears only when a Null actually has effects, and the stack draws as it does anywhere else.

When expressions arrive (Phase 4) they read those parameters like any other property; nothing here is deferred to them.

## Anti-aliasing, recorded

Also in this commit, since it answers both of that entry's open questions: **a project property, on by default, one value shared by preview and export.** It changes what a comp looks like, so it must travel with the file and match on another machine — and a preview that anti-aliased differently from the export would break the K-031 identity.

No code for it here. The TODO entry now carries the decision above what is still to build: MSAA targets and resolve in the composite pass, the setting through the bridge and its Settings row, and an adapter capability check (a sample count is asked for, never assumed — K-265's pooled MSAA for the flare is the nearest existing shape).

## Notes

`cargo test -p lumit_bridge` 184 passing, clippy and fmt clean. The Dart test could not be run here — no Flutter toolchain in this environment — so the `flutter-linux` job is its first real run, as agreed.

Docs: **K-274** in `02-DECISIONS.md`, the Null TODO entry deleted, the anti-aliasing entry rewritten around the decision, and the null-layer paragraph in `GUIDE.md` extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u)_