### PR TITLE
One selection wherever it is made, and layers/effects copy as documents (K-275)

### DIFF
--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -1027,6 +1027,78 @@ impl CompositionReference {
         })
     }
 
+    /// Paste a layer copied by [`crate::api::layer::LayerReference::copy_layer`]
+    /// into this composition, at the top of the stack (K-275).
+    ///
+    /// `at_frame` is where the layer's **in point** lands: the playhead, in the
+    /// ordinary case. `None` keeps the time it was copied at, which is the
+    /// setting for putting the same layer at the same moment in a second comp —
+    /// the two paste behaviours the owner asked for, decided by the caller
+    /// rather than by a mode this end has to remember.
+    ///
+    /// Whichever is chosen, the layer moves as one: in point, out point and
+    /// `start_offset` all shift together (`lumit_core::edit_layer_span`'s
+    /// `MoveIn`, the same rule the `[` key follows), so its keyframes and the
+    /// source frames it shows travel with it rather than sliding against it.
+    ///
+    /// **What is not copied is a reference to something that is not here.** The
+    /// pasted layer gets a fresh id and fresh effect ids — two layers sharing an
+    /// id would make every op that names one ambiguous — and its parent and
+    /// track matte are kept only when they still name a layer in *this* comp.
+    /// A parent that came from another composition is dropped rather than left
+    /// dangling: a layer parented to nothing visible would be a puzzle, and
+    /// re-parenting is one drag.
+    #[frb(sync)]
+    pub fn paste_layer(
+        &self,
+        text: String,
+        at_frame: Option<i64>,
+    ) -> Result<LayerReference, BridgeError> {
+        #[derive(serde::Deserialize)]
+        struct Copied {
+            comp: Uuid,
+            layer: lumit_core::model::Layer,
+        }
+        let copied: Copied = serde_json::from_str(&text).map_err(|_| BridgeError::InvalidItem)?;
+        let mut layer = copied.layer;
+        let comp = self.composition()?;
+
+        layer.id = Uuid::now_v7();
+        for effect in &mut layer.effects {
+            effect.id = Uuid::now_v7();
+        }
+        // A reference only survives if what it names is here. Pasting back into
+        // the comp it was copied from keeps both; pasting elsewhere keeps
+        // neither, because neither id means anything there.
+        let here = |id: Uuid| copied.comp == self.id && comp.layers.iter().any(|l| l.id == id);
+        if layer.parent.is_some_and(|p| !here(p)) {
+            layer.parent = None;
+        }
+        if layer.matte.as_ref().is_some_and(|m| !here(m.layer)) {
+            layer.matte = None;
+        }
+
+        if let Some(frame) = at_frame {
+            let at = comp
+                .frame_rate
+                .time_of_frame(frame.max(0))
+                .map_err(|_| BridgeError::InvalidTime)?;
+            let (in_point, out_point, start_offset) = lumit_core::ops::edit_layer_span(
+                layer.in_point,
+                layer.out_point,
+                layer.start_offset,
+                at,
+                lumit_core::ops::SpanEdit::MoveIn,
+            )
+            .ok_or(BridgeError::InvalidTime)?;
+            layer.in_point = in_point;
+            layer.out_point = out_point;
+            layer.start_offset = start_offset;
+        }
+
+        self.add_at_top(layer)
+    }
+
     /// Insert `layer` at the top of the stack.
     #[frb(ignore)]
     fn add_at_top(&self, layer: lumit_core::model::Layer) -> Result<LayerReference, BridgeError> {

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -885,6 +885,99 @@ impl LayerReference {
         Ok(())
     }
 
+    /// This layer as text, for [`crate::api::composition::CompositionReference::
+    /// paste_layer`] — the clipboard's payload (K-275).
+    ///
+    /// The whole layer: its kind and source, its transform with every keyframe,
+    /// its masks, paint, effects, switches, markers and retime. It is the
+    /// document's own `Layer`, serialised, so anything the file format carries
+    /// travels — including fields a newer Lumit added, which ride in the
+    /// `extra` maps exactly as they do through a save (docs/10 §1.1).
+    ///
+    /// A *reference* it holds to another layer — its parent, its track matte —
+    /// is copied as it stands and resolved at the paste, which is the only end
+    /// that knows whether the layer being pointed at is there.
+    #[frb(sync)]
+    pub fn copy_layer(&self) -> Result<String, BridgeError> {
+        let layer = self.item()?;
+        serde_json::to_string(&serde_json::json!({
+            "format": 1,
+            "kind": "layer",
+            // Informational: which comp it left, so a paste into that same comp
+            // can keep a parent or matte reference that would otherwise dangle.
+            "comp": self.comp_id,
+            "layer": layer,
+        }))
+        .map_err(|_| BridgeError::InvalidItem)
+    }
+
+    /// This layer's effects as a `.lumfx` document, for [`Self::paste_effects`]
+    /// (K-275). `effect` copies that one; `None` copies the whole stack.
+    ///
+    /// Deliberately the **same document a preset is**, so an effect copied from
+    /// one layer can be saved as a preset and a preset can be pasted as an
+    /// effect — one shape, not two that drift.
+    #[frb(sync)]
+    pub fn copy_effects(&self, effect: Option<Uuid>) -> Result<String, BridgeError> {
+        let stack = self.item()?.effects;
+        let taken: Vec<_> = match effect {
+            Some(id) => stack.into_iter().filter(|e| e.id == id).collect(),
+            None => stack,
+        };
+        if taken.is_empty() {
+            return Err(BridgeError::InvalidEffect);
+        }
+        let name = taken
+            .first()
+            .map(|e| e.effect.match_name.clone())
+            .unwrap_or_default();
+        lumit_core::preset::to_json(&name, &taken).map_err(|_| BridgeError::InvalidPreset)
+    }
+
+    /// Append copied effects to this layer's stack, **timed to the playhead**
+    /// (K-275): whatever the earliest keyframe among them was, it lands at
+    /// `at_frame` and the rest keep their spacing.
+    ///
+    /// The owner's rule, and the one that makes a copied animation useful: an
+    /// effect copied from a layer that flashes at 4 s and pasted while the
+    /// playhead sits at 12 s flashes at 12 s, not off the end of the comp.
+    /// Effects with no keyframes at all paste unchanged — there is no timing to
+    /// place. Each arrives with a fresh instance id, exactly as a preset does.
+    ///
+    /// `at_frame` is a **comp** frame; the shift is worked out in the target
+    /// layer's own local time, so pasting onto a layer that starts later does
+    /// not double-count its offset.
+    #[frb(sync)]
+    pub fn paste_effects(&self, text: String, at_frame: i64) -> Result<(), BridgeError> {
+        let preset =
+            lumit_core::preset::from_json(&text).map_err(|_| BridgeError::InvalidPreset)?;
+        let mut fresh = lumit_core::preset::instantiated(&preset);
+
+        // Comp frame -> the layer's own clock, the space keyframes live in.
+        let comp = self.composition()?;
+        let layer = self.item()?;
+        let at_comp = comp
+            .frame_rate
+            .time_of_frame(at_frame.max(0))
+            .map_err(|_| BridgeError::InvalidTime)?;
+        let at_local = at_comp
+            .delta(layer.start_offset)
+            .map_err(|_| BridgeError::InvalidTime)?;
+
+        if let Some(first) = lumit_core::preset::first_key_time(&fresh) {
+            let delta = at_local
+                .0
+                .checked_sub(first)
+                .map_err(|_| BridgeError::InvalidTime)?;
+            lumit_core::preset::shift_keys(&mut fresh, delta);
+        }
+
+        self.with_effects(move |effects| {
+            effects.extend(fresh);
+            Ok(())
+        })
+    }
+
     /// Serialise this layer's whole effect stack to `.lumfx` JSON.
     ///
     /// Returns the text rather than writing a file: choosing where something

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -1543,6 +1543,194 @@ fn an_effect_on_a_null_layer_keeps_its_animated_value() {
     );
 }
 
+/// **A copied layer arrives whole, and lands where the playhead is** (K-275).
+///
+/// Copy and paste is the one edit that has to carry *everything* — the transform
+/// with its keyframes, the effects with theirs, the switches, the name — because
+/// a paste that quietly dropped a property would be found much later, on a shot
+/// that looked almost right. So the payload is the document's own `Layer`, and
+/// this checks the pieces most likely to be lost by a hand-written conversion.
+#[test]
+fn a_copied_layer_pastes_whole_and_lands_at_the_playhead() {
+    use crate::api::effect::{BridgeEffectValue, BridgeRational, BridgeScalar};
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    let source = comp.add_solid_layer().expect("a layer to copy");
+    source.rename("Hero".into()).expect("named");
+    source.add_effect("blur".into()).expect("an effect on it");
+
+    // An animated parameter, so the keyframes have something to lose.
+    let mut staged = source.get_effects().expect("effects");
+    let key = |num: i64, value: f64| crate::api::effect::BridgeKeyframe {
+        time: BridgeRational { num, den: 1 },
+        value,
+        interp_in: crate::api::effect::BridgeSideInterp::Linear,
+        interp_out: crate::api::effect::BridgeSideInterp::Linear,
+    };
+    staged[0]
+        .set_value(
+            "radius".into(),
+            BridgeEffectValue::Float(BridgeScalar::Keyframed(vec![key(0, 0.0), key(2, 40.0)])),
+        )
+        .expect("animated");
+    source.set_effects(staged).expect("committed");
+
+    let text = source.copy_layer().expect("copied");
+
+    // Pasted into the same comp at frame 30 (one second at 30 fps).
+    let pasted = comp.paste_layer(text.clone(), Some(30)).expect("pasted");
+    assert_ne!(
+        pasted.layer_id, source.layer_id,
+        "a paste is a new layer, not a second name for the old one"
+    );
+    assert_eq!(pasted.get_name().expect("name"), "Hero", "the name travels");
+
+    let span = pasted.get_span().expect("span");
+    assert_eq!(
+        (span.in_point.num, span.in_point.den),
+        (1, 1),
+        "the in point lands on the playhead — frame 30 of a 30 fps comp is 1 s"
+    );
+
+    // The effect came too, animated, with an id of its own.
+    let fx = pasted.get_effects().expect("effects");
+    assert_eq!(fx.len(), 1, "the stack travels");
+    assert_ne!(
+        fx[0].id(),
+        source.get_effects().expect("effects")[0].id(),
+        "with a fresh instance id, so no op is ambiguous"
+    );
+    let Ok(BridgeEffectValue::Float(BridgeScalar::Keyframed(keys))) =
+        fx[0].get_value("radius".into())
+    else {
+        panic!("the animation must survive the round trip");
+    };
+    assert_eq!(keys.len(), 2, "both keys, unshifted — a layer moves as one");
+
+    // And the original is untouched by any of it.
+    assert_eq!(
+        source.get_span().expect("span").in_point,
+        BridgeRational { num: 0, den: 1 }
+    );
+}
+
+/// A layer pasted into **another** composition keeps everything that is its own
+/// and drops what pointed at the comp it left (K-275).
+#[test]
+fn a_layer_pasted_into_another_comp_drops_the_references_it_left_behind() {
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    let parent = comp.add_null_layer().expect("a parent");
+    let source = comp.add_solid_layer().expect("a layer to copy");
+    source.set_parent(Some(parent.layer_id)).expect("parented");
+
+    let text = source.copy_layer().expect("copied");
+
+    // Back into its own comp: the parent is still there, so it is kept.
+    let same = comp.paste_layer(text.clone(), None).expect("pasted");
+    assert_eq!(
+        same.get_parent().expect("parent"),
+        Some(parent.layer_id),
+        "pasting where the parent lives keeps the parenting"
+    );
+    assert_eq!(
+        same.get_span().expect("span").in_point,
+        source.get_span().expect("span").in_point,
+        "None keeps the time it was copied at"
+    );
+
+    // Into a different comp: the parent means nothing there, so it goes.
+    let elsewhere = project
+        .new_composition("Second".into(), None)
+        .expect("another comp");
+    let there = elsewhere.paste_layer(text, Some(0)).expect("pasted");
+    assert_eq!(
+        there.get_parent().expect("parent"),
+        None,
+        "a parent from another comp is dropped, not left dangling"
+    );
+    assert_eq!(
+        elsewhere.get_layers().expect("layers").len(),
+        1,
+        "and the layer itself did arrive"
+    );
+}
+
+/// **A pasted effect lands with its first keyframe under the playhead** (K-275,
+/// the owner's rule). An effect copied from a layer that flashes at 4 s and
+/// pasted while the playhead sits at 12 s must flash at 12 s.
+#[test]
+fn a_pasted_effect_starts_its_animation_at_the_playhead() {
+    use crate::api::effect::{BridgeEffectValue, BridgeRational, BridgeScalar};
+
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    let source = comp.add_solid_layer().expect("a layer");
+    source.add_effect("blur".into()).expect("an effect");
+
+    let key = |num: i64, value: f64| crate::api::effect::BridgeKeyframe {
+        time: BridgeRational { num, den: 1 },
+        value,
+        interp_in: crate::api::effect::BridgeSideInterp::Linear,
+        interp_out: crate::api::effect::BridgeSideInterp::Linear,
+    };
+    let mut staged = source.get_effects().expect("effects");
+    staged[0]
+        .set_value(
+            "radius".into(),
+            // Two keys a second apart, starting at 4 s.
+            BridgeEffectValue::Float(BridgeScalar::Keyframed(vec![key(4, 0.0), key(5, 40.0)])),
+        )
+        .expect("animated");
+    source.set_effects(staged).expect("committed");
+
+    let text = source.copy_effects(None).expect("copied");
+    let target = comp.add_solid_layer().expect("somewhere to paste");
+    // 12 seconds at 30 fps.
+    target.paste_effects(text, 360).expect("pasted");
+
+    let fx = target.get_effects().expect("effects");
+    assert_eq!(fx.len(), 1);
+    let Ok(BridgeEffectValue::Float(BridgeScalar::Keyframed(keys))) =
+        fx[0].get_value("radius".into())
+    else {
+        panic!("the pasted effect must still be animated");
+    };
+    assert_eq!(
+        keys[0].time,
+        BridgeRational { num: 12, den: 1 },
+        "the first key sits under the playhead"
+    );
+    assert_eq!(
+        keys[1].time,
+        BridgeRational { num: 13, den: 1 },
+        "and the rest keep their spacing"
+    );
+}
+
+/// An effect with no animation at all pastes unchanged — there is no timing to
+/// place, and inventing one would move a look that was never in motion (K-275).
+#[test]
+fn a_pasted_effect_with_no_keyframes_is_left_where_it_is() {
+    let (project, layer) = project_with_layer();
+    let comp = CompositionReference::new(project.id, layer.comp_id());
+    let source = comp.add_solid_layer().expect("a layer");
+    source.add_effect("blur".into()).expect("an effect");
+    let before = source.get_effects().expect("effects")[0]
+        .get_value("radius".into())
+        .expect("radius");
+
+    let text = source.copy_effects(None).expect("copied");
+    let target = comp.add_solid_layer().expect("somewhere to paste");
+    target.paste_effects(text, 120).expect("pasted");
+
+    let after = target.get_effects().expect("effects")[0]
+        .get_value("radius".into())
+        .expect("radius");
+    assert_eq!(format!("{before:?}"), format!("{after:?}"));
+}
+
 /// Each switch is its own op, so a click is one undo step and toggling one
 /// switch never disturbs another.
 #[test]

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1395644184;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1539249759;
 
 // Section: executor
 
@@ -1672,6 +1672,43 @@ fn wire__crate__api__composition__composition_reference_get_work_area_impl(
             transform_result_sse::<_, BridgeError>((move || {
                 let output_ok =
                     crate::api::composition::CompositionReference::get_work_area(&api_that)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__composition__composition_reference_paste_layer_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "composition_reference_paste_layer",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that =
+                <crate::api::composition::CompositionReference>::sse_decode(&mut deserializer);
+            let api_text = <String>::sse_decode(&mut deserializer);
+            let api_at_frame = <Option<i64>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::composition::CompositionReference::paste_layer(
+                    &api_that,
+                    api_text,
+                    api_at_frame,
+                )?;
                 Ok(output_ok)
             })())
         },
@@ -3471,6 +3508,68 @@ fn wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(
         },
     )
 }
+fn wire__crate__api__layer__layer_reference_copy_effects_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "layer_reference_copy_effects",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::layer::LayerReference>::sse_decode(&mut deserializer);
+            let api_effect = <Option<uuid::Uuid>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok =
+                    crate::api::layer::LayerReference::copy_effects(&api_that, api_effect)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__layer__layer_reference_copy_layer_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "layer_reference_copy_layer",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::layer::LayerReference>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::layer::LayerReference::copy_layer(&api_that)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__layer__layer_reference_copy_sequence_shape_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -4565,6 +4664,42 @@ fn wire__crate__api__layer__layer_reference_load_preset_impl(
             transform_result_sse::<_, BridgeError>((move || {
                 let output_ok =
                     crate::api::layer::LayerReference::load_preset(&api_that, api_text)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__layer__layer_reference_paste_effects_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "layer_reference_paste_effects",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <crate::api::layer::LayerReference>::sse_decode(&mut deserializer);
+            let api_text = <String>::sse_decode(&mut deserializer);
+            let api_at_frame = <i64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::layer::LayerReference::paste_effects(
+                    &api_that,
+                    api_text,
+                    api_at_frame,
+                )?;
                 Ok(output_ok)
             })())
         },
@@ -9238,50 +9373,50 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__api__footage__footage_reference_get_status_impl(
+        73 => wire__crate__api__footage__footage_reference_get_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__footage__footage_reference_media_info_impl(
+        74 => wire__crate__api__footage__footage_reference_media_info_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        75 => wire__crate__api__footage__footage_reference_thumbnail_impl(
+        76 => wire__crate__api__footage__footage_reference_thumbnail_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        83 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
-        88 => {
+        84 => wire__crate__api__keymap__keymap_from_json_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__keymap__keymap_load_preset_impl(port, ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__keymap__keymap_rebind_impl(port, ptr, rust_vec_len, data_len),
+        89 => {
             wire__crate__api__keymap__keymap_reset_binding_impl(port, ptr, rust_vec_len, data_len)
         }
-        91 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
+        92 => wire__crate__api__keymap__keymap_unbind_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__layer__layer_reference_audio_peaks_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        97 => wire__crate__api__layer__layer_reference_clip_thumbnail_impl(
+        98 => wire__crate__api__layer__layer_reference_clip_thumbnail_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        132 => wire__crate__api__layer__layer_reference_has_audio_impl(
+        135 => wire__crate__api__layer__layer_reference_has_audio_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        188 => wire__crate__api__project__project_reference_save_impl(
+        192 => wire__crate__api__project__project_reference_save_impl(
             port,
             ptr,
             rust_vec_len,
@@ -9344,155 +9479,159 @@ fn pde_ffi_dispatcher_sync_impl(
 44 => wire__crate__api__composition__composition_reference_get_settings_impl(ptr, rust_vec_len, data_len),
 45 => wire__crate__api__composition__composition_reference_get_size_impl(ptr, rust_vec_len, data_len),
 46 => wire__crate__api__composition__composition_reference_get_work_area_impl(ptr, rust_vec_len, data_len),
-47 => wire__crate__api__composition__composition_reference_play_impl(ptr, rust_vec_len, data_len),
-48 => wire__crate__api__composition__composition_reference_playback_tier_impl(ptr, rust_vec_len, data_len),
-49 => wire__crate__api__composition__composition_reference_precompose_impl(ptr, rust_vec_len, data_len),
-50 => wire__crate__api__composition__composition_reference_render_frame_impl(ptr, rust_vec_len, data_len),
-51 => wire__crate__api__composition__composition_reference_render_frame_with_clip_retime_impl(ptr, rust_vec_len, data_len),
-52 => wire__crate__api__composition__composition_reference_render_frame_with_mask_preview_impl(ptr, rust_vec_len, data_len),
-53 => wire__crate__api__composition__composition_reference_render_frame_with_paint_preview_impl(ptr, rust_vec_len, data_len),
-54 => wire__crate__api__composition__composition_reference_render_frame_with_preview_impl(ptr, rust_vec_len, data_len),
-55 => wire__crate__api__composition__composition_reference_render_frame_with_shape_preview_impl(ptr, rust_vec_len, data_len),
-56 => wire__crate__api__composition__composition_reference_render_frame_with_text_preview_impl(ptr, rust_vec_len, data_len),
-57 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
-58 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
-59 => wire__crate__api__composition__composition_reference_sample_pixels_impl(ptr, rust_vec_len, data_len),
-60 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
-61 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
-62 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
-63 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
-64 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
-65 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
-66 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
-67 => wire__crate__api__cache__disk_cache_stats_impl(ptr, rust_vec_len, data_len),
-68 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
-69 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
-70 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
-71 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
-74 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
-76 => wire__crate__api__system__freeze_cursor_impl(ptr, rust_vec_len, data_len),
-77 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
-78 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
-79 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
-80 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
-81 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
-82 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
-84 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
-86 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
-89 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
-90 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
-92 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
-93 => wire__crate__api__layer__layer_reference_add_mask_impl(ptr, rust_vec_len, data_len),
-94 => wire__crate__api__layer__layer_reference_add_shape_item_impl(ptr, rust_vec_len, data_len),
-95 => wire__crate__api__layer__layer_reference_add_stroke_impl(ptr, rust_vec_len, data_len),
-98 => wire__crate__api__layer__layer_reference_convert_from_sequenced_impl(ptr, rust_vec_len, data_len),
-99 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
-100 => wire__crate__api__layer__layer_reference_copy_sequence_shape_impl(ptr, rust_vec_len, data_len),
-101 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
-102 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
-103 => wire__crate__api__layer__layer_reference_delete_clip_impl(ptr, rust_vec_len, data_len),
-104 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
-105 => wire__crate__api__layer__layer_reference_delete_last_stroke_impl(ptr, rust_vec_len, data_len),
-106 => wire__crate__api__layer__layer_reference_delete_mask_impl(ptr, rust_vec_len, data_len),
-107 => wire__crate__api__layer__layer_reference_delete_stroke_impl(ptr, rust_vec_len, data_len),
-108 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
-109 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
-110 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
-111 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
-112 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
-113 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
-114 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
-115 => wire__crate__api__layer__layer_reference_get_interpolation_impl(ptr, rust_vec_len, data_len),
-116 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
-117 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
-118 => wire__crate__api__layer__layer_reference_get_markers_impl(ptr, rust_vec_len, data_len),
-119 => wire__crate__api__layer__layer_reference_get_masks_impl(ptr, rust_vec_len, data_len),
-120 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
-121 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
-122 => wire__crate__api__layer__layer_reference_get_paint_impl(ptr, rust_vec_len, data_len),
-123 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
-124 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
-125 => wire__crate__api__layer__layer_reference_get_shape_contents_impl(ptr, rust_vec_len, data_len),
-126 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
-127 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
-128 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
-129 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
-130 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
-131 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
-133 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
-134 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
-135 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
-136 => wire__crate__api__layer__layer_reference_paste_sequence_shape_impl(ptr, rust_vec_len, data_len),
-137 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
-138 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
-139 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
-140 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
-141 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
-142 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
-143 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
-144 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
-145 => wire__crate__api__layer__layer_reference_set_clip_retime_impl(ptr, rust_vec_len, data_len),
-146 => wire__crate__api__layer__layer_reference_set_clip_speed_impl(ptr, rust_vec_len, data_len),
-147 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
-148 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
-149 => wire__crate__api__layer__layer_reference_set_interpolation_impl(ptr, rust_vec_len, data_len),
-150 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
-151 => wire__crate__api__layer__layer_reference_set_markers_impl(ptr, rust_vec_len, data_len),
-152 => wire__crate__api__layer__layer_reference_set_mask_impl(ptr, rust_vec_len, data_len),
-153 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
-154 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
-155 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
-156 => wire__crate__api__layer__layer_reference_set_shape_contents_impl(ptr, rust_vec_len, data_len),
-157 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
-158 => wire__crate__api__layer__layer_reference_set_stroke_impl(ptr, rust_vec_len, data_len),
-159 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
-160 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
-161 => wire__crate__api__layer__layer_reference_set_text_placed_impl(ptr, rust_vec_len, data_len),
-162 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
-163 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
-164 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
-165 => wire__crate__api__layer__layer_reference_slide_clip_impl(ptr, rust_vec_len, data_len),
-166 => wire__crate__api__layer__layer_reference_split_at_impl(ptr, rust_vec_len, data_len),
-167 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
-168 => wire__crate__api__layer__layer_reference_trim_clip_impl(ptr, rust_vec_len, data_len),
-169 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
-170 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
-171 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
-172 => wire__crate__api__effect__list_parameter_groups_impl(ptr, rust_vec_len, data_len),
-173 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
-174 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
-175 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
-176 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
-177 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
-178 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
-179 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
-180 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
-181 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
-182 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
-183 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
-184 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
-185 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
-186 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
-187 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
-189 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
-190 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
-191 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
-192 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
-193 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
-194 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
-195 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
-196 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
-197 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
-198 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
-199 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
-200 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
-201 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
-202 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
-203 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
-204 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
-205 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
-206 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
-207 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
+47 => wire__crate__api__composition__composition_reference_paste_layer_impl(ptr, rust_vec_len, data_len),
+48 => wire__crate__api__composition__composition_reference_play_impl(ptr, rust_vec_len, data_len),
+49 => wire__crate__api__composition__composition_reference_playback_tier_impl(ptr, rust_vec_len, data_len),
+50 => wire__crate__api__composition__composition_reference_precompose_impl(ptr, rust_vec_len, data_len),
+51 => wire__crate__api__composition__composition_reference_render_frame_impl(ptr, rust_vec_len, data_len),
+52 => wire__crate__api__composition__composition_reference_render_frame_with_clip_retime_impl(ptr, rust_vec_len, data_len),
+53 => wire__crate__api__composition__composition_reference_render_frame_with_mask_preview_impl(ptr, rust_vec_len, data_len),
+54 => wire__crate__api__composition__composition_reference_render_frame_with_paint_preview_impl(ptr, rust_vec_len, data_len),
+55 => wire__crate__api__composition__composition_reference_render_frame_with_preview_impl(ptr, rust_vec_len, data_len),
+56 => wire__crate__api__composition__composition_reference_render_frame_with_shape_preview_impl(ptr, rust_vec_len, data_len),
+57 => wire__crate__api__composition__composition_reference_render_frame_with_text_preview_impl(ptr, rust_vec_len, data_len),
+58 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
+59 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
+60 => wire__crate__api__composition__composition_reference_sample_pixels_impl(ptr, rust_vec_len, data_len),
+61 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+62 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
+63 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
+64 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
+65 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
+66 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),
+67 => wire__crate__api__composition__composition_reference_time_of_frame_impl(ptr, rust_vec_len, data_len),
+68 => wire__crate__api__cache__disk_cache_stats_impl(ptr, rust_vec_len, data_len),
+69 => wire__crate__api__export__export_cancel_impl(ptr, rust_vec_len, data_len),
+70 => wire__crate__api__export__export_poll_impl(ptr, rust_vec_len, data_len),
+71 => wire__crate__api__export__export_preset_impl(ptr, rust_vec_len, data_len),
+72 => wire__crate__api__folder__folder_reference_get_children_impl(ptr, rust_vec_len, data_len),
+75 => wire__crate__api__footage__footage_reference_relink_impl(ptr, rust_vec_len, data_len),
+77 => wire__crate__api__system__freeze_cursor_impl(ptr, rust_vec_len, data_len),
+78 => wire__crate__api__project_item__item_reference_delete_impl(ptr, rust_vec_len, data_len),
+79 => wire__crate__api__project_item__item_reference_equals_impl(ptr, rust_vec_len, data_len),
+80 => wire__crate__api__project_item__item_reference_move_to_root_impl(ptr, rust_vec_len, data_len),
+81 => wire__crate__api__project_item__item_reference_name_impl(ptr, rust_vec_len, data_len),
+82 => wire__crate__api__project_item__item_reference_rename_impl(ptr, rust_vec_len, data_len),
+83 => wire__crate__api__keymap__keymap_conflicts_impl(ptr, rust_vec_len, data_len),
+85 => wire__crate__api__keymap__keymap_groups_impl(ptr, rust_vec_len, data_len),
+87 => wire__crate__api__keymap__keymap_lookup_impl(ptr, rust_vec_len, data_len),
+90 => wire__crate__api__keymap__keymap_search_impl(ptr, rust_vec_len, data_len),
+91 => wire__crate__api__keymap__keymap_to_json_impl(ptr, rust_vec_len, data_len),
+93 => wire__crate__api__layer__layer_reference_add_effect_impl(ptr, rust_vec_len, data_len),
+94 => wire__crate__api__layer__layer_reference_add_mask_impl(ptr, rust_vec_len, data_len),
+95 => wire__crate__api__layer__layer_reference_add_shape_item_impl(ptr, rust_vec_len, data_len),
+96 => wire__crate__api__layer__layer_reference_add_stroke_impl(ptr, rust_vec_len, data_len),
+99 => wire__crate__api__layer__layer_reference_convert_from_sequenced_impl(ptr, rust_vec_len, data_len),
+100 => wire__crate__api__layer__layer_reference_convert_to_sequenced_impl(ptr, rust_vec_len, data_len),
+101 => wire__crate__api__layer__layer_reference_copy_effects_impl(ptr, rust_vec_len, data_len),
+102 => wire__crate__api__layer__layer_reference_copy_layer_impl(ptr, rust_vec_len, data_len),
+103 => wire__crate__api__layer__layer_reference_copy_sequence_shape_impl(ptr, rust_vec_len, data_len),
+104 => wire__crate__api__layer__layer_reference_cut_clip_at_impl(ptr, rust_vec_len, data_len),
+105 => wire__crate__api__layer__layer_reference_delete_impl(ptr, rust_vec_len, data_len),
+106 => wire__crate__api__layer__layer_reference_delete_clip_impl(ptr, rust_vec_len, data_len),
+107 => wire__crate__api__layer__layer_reference_delete_clip_at_impl(ptr, rust_vec_len, data_len),
+108 => wire__crate__api__layer__layer_reference_delete_last_stroke_impl(ptr, rust_vec_len, data_len),
+109 => wire__crate__api__layer__layer_reference_delete_mask_impl(ptr, rust_vec_len, data_len),
+110 => wire__crate__api__layer__layer_reference_delete_stroke_impl(ptr, rust_vec_len, data_len),
+111 => wire__crate__api__layer__layer_reference_duplicate_impl(ptr, rust_vec_len, data_len),
+112 => wire__crate__api__layer__layer_reference_equals_impl(ptr, rust_vec_len, data_len),
+113 => wire__crate__api__layer__layer_reference_get_blend_impl(ptr, rust_vec_len, data_len),
+114 => wire__crate__api__layer__layer_reference_get_camera_zoom_impl(ptr, rust_vec_len, data_len),
+115 => wire__crate__api__layer__layer_reference_get_clips_impl(ptr, rust_vec_len, data_len),
+116 => wire__crate__api__layer__layer_reference_get_effects_impl(ptr, rust_vec_len, data_len),
+117 => wire__crate__api__layer__layer_reference_get_info_impl(ptr, rust_vec_len, data_len),
+118 => wire__crate__api__layer__layer_reference_get_interpolation_impl(ptr, rust_vec_len, data_len),
+119 => wire__crate__api__layer__layer_reference_get_kind_impl(ptr, rust_vec_len, data_len),
+120 => wire__crate__api__layer__layer_reference_get_label_impl(ptr, rust_vec_len, data_len),
+121 => wire__crate__api__layer__layer_reference_get_markers_impl(ptr, rust_vec_len, data_len),
+122 => wire__crate__api__layer__layer_reference_get_masks_impl(ptr, rust_vec_len, data_len),
+123 => wire__crate__api__layer__layer_reference_get_matte_impl(ptr, rust_vec_len, data_len),
+124 => wire__crate__api__layer__layer_reference_get_name_impl(ptr, rust_vec_len, data_len),
+125 => wire__crate__api__layer__layer_reference_get_paint_impl(ptr, rust_vec_len, data_len),
+126 => wire__crate__api__layer__layer_reference_get_parent_impl(ptr, rust_vec_len, data_len),
+127 => wire__crate__api__layer__layer_reference_get_retime_property_impl(ptr, rust_vec_len, data_len),
+128 => wire__crate__api__layer__layer_reference_get_shape_contents_impl(ptr, rust_vec_len, data_len),
+129 => wire__crate__api__layer__layer_reference_get_source_item_impl(ptr, rust_vec_len, data_len),
+130 => wire__crate__api__layer__layer_reference_get_span_impl(ptr, rust_vec_len, data_len),
+131 => wire__crate__api__layer__layer_reference_get_switches_impl(ptr, rust_vec_len, data_len),
+132 => wire__crate__api__layer__layer_reference_get_text_impl(ptr, rust_vec_len, data_len),
+133 => wire__crate__api__layer__layer_reference_get_transform_impl(ptr, rust_vec_len, data_len),
+134 => wire__crate__api__layer__layer_reference_get_volume_db_impl(ptr, rust_vec_len, data_len),
+136 => wire__crate__api__layer__layer_reference_has_picture_impl(ptr, rust_vec_len, data_len),
+137 => wire__crate__api__layer__layer_reference_is_three_d_impl(ptr, rust_vec_len, data_len),
+138 => wire__crate__api__layer__layer_reference_load_preset_impl(ptr, rust_vec_len, data_len),
+139 => wire__crate__api__layer__layer_reference_paste_effects_impl(ptr, rust_vec_len, data_len),
+140 => wire__crate__api__layer__layer_reference_paste_sequence_shape_impl(ptr, rust_vec_len, data_len),
+141 => wire__crate__api__layer__layer_reference_remove_effect_impl(ptr, rust_vec_len, data_len),
+142 => wire__crate__api__layer__layer_reference_rename_impl(ptr, rust_vec_len, data_len),
+143 => wire__crate__api__layer__layer_reference_reorder_impl(ptr, rust_vec_len, data_len),
+144 => wire__crate__api__layer__layer_reference_reorder_effect_impl(ptr, rust_vec_len, data_len),
+145 => wire__crate__api__layer__layer_reference_reveal_groups_impl(ptr, rust_vec_len, data_len),
+146 => wire__crate__api__layer__layer_reference_save_preset_impl(ptr, rust_vec_len, data_len),
+147 => wire__crate__api__layer__layer_reference_set_blend_impl(ptr, rust_vec_len, data_len),
+148 => wire__crate__api__layer__layer_reference_set_camera_zoom_impl(ptr, rust_vec_len, data_len),
+149 => wire__crate__api__layer__layer_reference_set_clip_retime_impl(ptr, rust_vec_len, data_len),
+150 => wire__crate__api__layer__layer_reference_set_clip_speed_impl(ptr, rust_vec_len, data_len),
+151 => wire__crate__api__layer__layer_reference_set_effect_enabled_impl(ptr, rust_vec_len, data_len),
+152 => wire__crate__api__layer__layer_reference_set_effects_impl(ptr, rust_vec_len, data_len),
+153 => wire__crate__api__layer__layer_reference_set_interpolation_impl(ptr, rust_vec_len, data_len),
+154 => wire__crate__api__layer__layer_reference_set_label_impl(ptr, rust_vec_len, data_len),
+155 => wire__crate__api__layer__layer_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+156 => wire__crate__api__layer__layer_reference_set_mask_impl(ptr, rust_vec_len, data_len),
+157 => wire__crate__api__layer__layer_reference_set_matte_impl(ptr, rust_vec_len, data_len),
+158 => wire__crate__api__layer__layer_reference_set_parent_impl(ptr, rust_vec_len, data_len),
+159 => wire__crate__api__layer__layer_reference_set_retime_property_impl(ptr, rust_vec_len, data_len),
+160 => wire__crate__api__layer__layer_reference_set_shape_contents_impl(ptr, rust_vec_len, data_len),
+161 => wire__crate__api__layer__layer_reference_set_span_impl(ptr, rust_vec_len, data_len),
+162 => wire__crate__api__layer__layer_reference_set_stroke_impl(ptr, rust_vec_len, data_len),
+163 => wire__crate__api__layer__layer_reference_set_switch_impl(ptr, rust_vec_len, data_len),
+164 => wire__crate__api__layer__layer_reference_set_text_impl(ptr, rust_vec_len, data_len),
+165 => wire__crate__api__layer__layer_reference_set_text_placed_impl(ptr, rust_vec_len, data_len),
+166 => wire__crate__api__layer__layer_reference_set_transform_impl(ptr, rust_vec_len, data_len),
+167 => wire__crate__api__layer__layer_reference_set_transforms_impl(ptr, rust_vec_len, data_len),
+168 => wire__crate__api__layer__layer_reference_set_volume_db_impl(ptr, rust_vec_len, data_len),
+169 => wire__crate__api__layer__layer_reference_slide_clip_impl(ptr, rust_vec_len, data_len),
+170 => wire__crate__api__layer__layer_reference_split_at_impl(ptr, rust_vec_len, data_len),
+171 => wire__crate__api__layer__layer_reference_toggle_retime_property_impl(ptr, rust_vec_len, data_len),
+172 => wire__crate__api__layer__layer_reference_trim_clip_impl(ptr, rust_vec_len, data_len),
+173 => wire__crate__api__shell__list_autosaves_impl(ptr, rust_vec_len, data_len),
+174 => wire__crate__api__composition__list_blend_modes_impl(ptr, rust_vec_len, data_len),
+175 => wire__crate__api__effect__list_effects_impl(ptr, rust_vec_len, data_len),
+176 => wire__crate__api__effect__list_parameter_groups_impl(ptr, rust_vec_len, data_len),
+177 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
+178 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
+179 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
+180 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
+181 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
+182 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
+183 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
+184 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
+185 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
+186 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
+187 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
+188 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
+189 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
+190 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
+191 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
+193 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
+194 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
+195 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
+196 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
+197 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
+198 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
+199 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
+200 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
+201 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
+202 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
+203 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
+204 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
+205 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
+206 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
+207 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
+208 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
+209 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
+210 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
+211 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }

--- a/crates/lumit-core/src/preset.rs
+++ b/crates/lumit-core/src/preset.rs
@@ -56,6 +56,107 @@ pub fn instantiated(preset: &EffectPreset) -> Vec<EffectInstance> {
         .collect()
 }
 
+/// The earliest keyframe time across `effects`, in **layer-local** seconds, or
+/// `None` when nothing in them is animated (K-275).
+///
+/// Copying an effect and pasting it somewhere else is copying a piece of
+/// *timing* as much as a look, so the paste has to know where that timing
+/// starts before it can land it under the playhead.
+#[must_use]
+pub fn first_key_time(effects: &[EffectInstance]) -> Option<crate::time::Rational> {
+    let mut earliest: Option<crate::time::Rational> = None;
+    for_each_property(effects, &mut |property| {
+        if let crate::anim::Animation::Keyframed(keys) = &property.animation {
+            if let Some(first) = keys.first() {
+                earliest = Some(match earliest {
+                    Some(held) if held <= first.time => held,
+                    _ => first.time,
+                });
+            }
+        }
+    });
+    earliest
+}
+
+/// Shift every keyframe in `effects` by `delta` layer-local seconds (K-275).
+///
+/// A key whose time cannot be moved without overflowing is left where it is
+/// rather than wrapping — an engine crate does not panic, and a paste that
+/// silently misplaced one key would be worse than one that refused to move it.
+pub fn shift_keys(effects: &mut [EffectInstance], delta: crate::time::Rational) {
+    if delta.is_zero() {
+        return;
+    }
+    for_each_property_mut(effects, &mut |property| {
+        if let crate::anim::Animation::Keyframed(keys) = &mut property.animation {
+            for key in keys.iter_mut() {
+                if let Ok(moved) = key.time.checked_add(delta) {
+                    key.time = moved;
+                }
+            }
+        }
+    });
+}
+
+/// Visit every animatable [`crate::anim::Property`] in `effects`.
+///
+/// **Exhaustive on purpose**, like `fx::rescale_px`: a new `EffectValue`
+/// variant must decide here whether it carries animation, so a parameter added
+/// later cannot quietly stop being shifted by a paste.
+fn for_each_property(effects: &[EffectInstance], visit: &mut impl FnMut(&crate::anim::Property)) {
+    for effect in effects {
+        for param in &effect.params {
+            match &param.value {
+                crate::model::EffectValue::Float(p) => visit(p),
+                crate::model::EffectValue::Point(x, y) => {
+                    visit(x);
+                    visit(y);
+                }
+                crate::model::EffectValue::Colour(channels) => {
+                    for channel in channels {
+                        visit(channel);
+                    }
+                }
+                crate::model::EffectValue::File(f) => visit(&f.index),
+                // Carry no animation: a bool, a dropdown choice, a random
+                // seed and a layer reference are all static in v1 (docs/03 §8).
+                crate::model::EffectValue::Bool(_)
+                | crate::model::EffectValue::Choice(_)
+                | crate::model::EffectValue::Seed(_)
+                | crate::model::EffectValue::Layer(_) => {}
+            }
+        }
+    }
+}
+
+/// The mutable twin of [`for_each_property`], same exhaustive match.
+fn for_each_property_mut(
+    effects: &mut [EffectInstance],
+    visit: &mut impl FnMut(&mut crate::anim::Property),
+) {
+    for effect in effects {
+        for param in &mut effect.params {
+            match &mut param.value {
+                crate::model::EffectValue::Float(p) => visit(p),
+                crate::model::EffectValue::Point(x, y) => {
+                    visit(x);
+                    visit(y);
+                }
+                crate::model::EffectValue::Colour(channels) => {
+                    for channel in channels {
+                        visit(channel);
+                    }
+                }
+                crate::model::EffectValue::File(f) => visit(&mut f.index),
+                crate::model::EffectValue::Bool(_)
+                | crate::model::EffectValue::Choice(_)
+                | crate::model::EffectValue::Seed(_)
+                | crate::model::EffectValue::Layer(_) => {}
+            }
+        }
+    }
+}
+
 /// One preset shown in the Effects & Presets browser (docs/07-UI-SPEC.md §7):
 /// its file path and the name to display — the preset's own `name` when the
 /// file parses, otherwise the file stem, so a hand-copied or partly written

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5667,3 +5667,32 @@ anti-aliases differently from the export would break the K-031 identity. That an
 of the recorded open questions; the work itself (MSAA targets and resolve in the composite
 pass, the setting through the bridge, and an adapter capability check — a sample count is
 asked for, never assumed) stays in [TODO.md](TODO.md).
+
+**K-275 · DECIDED · Selecting a layer means the same thing wherever it happens, and
+layers and effects copy as documents.** Two owner requests (2026-08-05). **(1) The
+selection is the shell's, and the Timeline must follow it.** Picking a layer on the
+picture already replaced the whole selection, but the Timeline kept its *own* per-layer
+state — the property selection, the graph's key selection, the row highlight — and cleared
+it only in its own click path. So a pick in the Viewer left the previous layer's rows lit:
+two layers appearing chosen at once, the exact ambiguity K-203 set out to remove. The panel
+now listens to `selectedLayer` and drops that state wherever the choosing happened, through
+the one helper its own click path uses. The Effect controls panel already followed the
+shell; a test now pins that a Viewer-shaped selection change switches it, so it cannot
+quietly stop. **(2) Copy and paste carry the document, not a summary.** A copied layer is
+the model's own `Layer`, serialised — transform and keyframes, masks, paint, effects,
+switches, markers, retime, and any field a newer Lumit added riding in `extra` — because a
+paste that dropped a property would be found much later, on a shot that looked almost
+right. The paste gives fresh layer and effect ids, and keeps a parent or track matte
+reference **only when it still names a layer in the target comp**: pasting back where it
+came from keeps both, pasting elsewhere keeps neither rather than leaving a dangling
+pointer. Time: `at_frame` lands the in point there and moves in point, out point and
+`start_offset` together (`edit_layer_span`'s `MoveIn`, the `[` key's own rule), so
+keyframes and source frames travel with the layer; `None` keeps the copied time, which is
+the owner's setting for rebuilding a moment in a second composition — **default at the
+playhead**, the other behind a preference. Effects copy as the **same `.lumfx` document a
+preset is**, so a copied effect can be saved as a preset and a preset pasted as an effect,
+and they always paste with their **first keyframe at the playhead** whatever the layer
+setting says: what is being placed is an animation, not a position. An effect with no
+keyframes pastes unmoved — there is no timing to place. The panels' wiring (the clipboard,
+the Edit menu, the copy-effect commands, the settings row) is TODO'd: it needs the bridge
+bindings regenerated, which needs a Flutter toolchain.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -5693,6 +5693,10 @@ playhead**, the other behind a preference. Effects copy as the **same `.lumfx` d
 preset is**, so a copied effect can be saved as a preset and a preset pasted as an effect,
 and they always paste with their **first keyframe at the playhead** whatever the layer
 setting says: what is being placed is an animation, not a position. An effect with no
-keyframes pastes unmoved — there is no timing to place. The panels' wiring (the clipboard,
-the Edit menu, the copy-effect commands, the settings row) is TODO'd: it needs the bridge
-bindings regenerated, which needs a Flutter toolchain.
+keyframes pastes unmoved — there is no timing to place. The panel wiring landed with it: a session clipboard on
+`LumitUiState` (written through methods that notify, because Paste greys out while it is
+empty and a menu that never hears about the copy stays greyed — which is how it behaved
+before those methods existed), **Edit → Cut / Copy / Paste**, and the *Paste layers at
+their original time* row in Settings → Interface. Still owed, and TODO'd: **Copy effect**
+on an effect's heading in the Effect controls panel and on its Timeline row, which is
+where an effect is picked rather than a layer.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -211,6 +211,26 @@ The Timeline matters most - it is zoomed constantly while cutting.
 - **The audio mix is rebuilt from scratch** whenever the comp's audio signature
     changes, rather than patched.
 
+**Copy and paste: the panels' half is still to wire (K-275).** The engine side is
+built and tested — `LayerReference::copy_layer`, `CompositionReference::paste_layer`
+(at a frame, or `None` to keep the copied time), `copy_effects` (one effect or the
+whole stack, in the `.lumfx` shape a preset already uses) and `paste_effects` (first
+keyframe lands on the playhead). What is owed is Dart, and it needs
+`flutter_rust_bridge_codegen generate` run on a machine with the Flutter toolchain
+before any of it compiles:
+- a session clipboard holding the copied text and its kind, on `LumitUiState`;
+- **Edit → Cut / Copy / Paste** wired to it (they are `MenuEntry.todo` today,
+    K-244), pasting a layer into the comp on screen and effects onto the selected
+    layer, and selecting what was just pasted;
+- **Copy effect** on an effect's heading in the Effect controls panel and on its
+    row in the Timeline — both call `copy_effects(Some(id))`;
+- a **Settings → Interface** toggle, *Paste layers at their original time*
+    (default off — paste lands at the playhead; on is for rebuilding a moment in a
+    second comp). Effects ignore it by design: a copied animation is placed by its
+    first keyframe, always.
+- Copying between two running Lumit windows wants the system clipboard rather
+    than the in-app one; decide when it is asked for.
+
 **Retime follow-up after K-249.** **The eased ramp shapes are gone from
 clips** — `Clip::with_ramp` takes two speeds and runs straight between them,
 which is what the envelope authors. Slow/Fast/Smooth/Sharp come back with the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -211,25 +211,14 @@ The Timeline matters most - it is zoomed constantly while cutting.
 - **The audio mix is rebuilt from scratch** whenever the comp's audio signature
     changes, rather than patched.
 
-**Copy and paste: the panels' half is still to wire (K-275).** The engine side is
-built and tested — `LayerReference::copy_layer`, `CompositionReference::paste_layer`
-(at a frame, or `None` to keep the copied time), `copy_effects` (one effect or the
-whole stack, in the `.lumfx` shape a preset already uses) and `paste_effects` (first
-keyframe lands on the playhead). What is owed is Dart, and it needs
-`flutter_rust_bridge_codegen generate` run on a machine with the Flutter toolchain
-before any of it compiles:
-- a session clipboard holding the copied text and its kind, on `LumitUiState`;
-- **Edit → Cut / Copy / Paste** wired to it (they are `MenuEntry.todo` today,
-    K-244), pasting a layer into the comp on screen and effects onto the selected
-    layer, and selecting what was just pasted;
-- **Copy effect** on an effect's heading in the Effect controls panel and on its
-    row in the Timeline — both call `copy_effects(Some(id))`;
-- a **Settings → Interface** toggle, *Paste layers at their original time*
-    (default off — paste lands at the playhead; on is for rebuilding a moment in a
-    second comp). Effects ignore it by design: a copied animation is placed by its
-    first keyframe, always.
-- Copying between two running Lumit windows wants the system clipboard rather
-    than the in-app one; decide when it is asked for.
+**Copy and paste: the effect-header commands are still to wire (K-275).** Layers copy
+and paste from the **Edit** menu (Cut/Copy/Paste, with *Paste layers at their original
+time* in Settings → Interface), and the engine takes one effect or a whole stack
+(`copy_effects`/`paste_effects`). What is owed is the two places an effect is *picked*:
+**Copy effect** on an effect's heading in the Effect controls panel and on its row in the
+Timeline, both calling `copy_effects(Some(id))` and putting it on the same clipboard.
+Copying between two running Lumit windows wants the system clipboard rather than the
+in-app one; decide when it is asked for.
 
 **Retime follow-up after K-249.** **The eased ramp shapes are gone from
 clips** — `Clip::with_ramp` takes two speeds and runs straight between them,

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:lumit_flutter/src/rust/api/project_item.dart';
 import 'package:lumit_flutter/src/rust/api/state.dart';
 import 'package:lumit_flutter/src/rust/frb_generated.dart';
 import 'package:lumit_flutter/state/comp_model.dart';
+import 'package:lumit_flutter/state/clipboard.dart';
 import 'package:lumit_flutter/state/comp_time.dart';
 import 'package:lumit_flutter/state/dock.dart';
 import 'package:lumit_flutter/state/dropper.dart';
@@ -690,6 +691,27 @@ class LumitUiState extends ChangeNotifier {
   /// The layer everything single-layer works on: Effect controls, the keyboard
   /// commands, the Timeline's fold-out. The *primary* of the selection below.
   ValueNotifier<LayerReference?> selectedLayer = ValueNotifier(null);
+
+  /// What Copy put down, for Paste to pick up (K-275). One tray for the
+  /// session, shared by the Edit menu and the panels.
+  ///
+  /// Read directly; **written through the two methods below**, because Paste is
+  /// greyed out while it is empty and a menu that never hears about the copy
+  /// stays greyed until something else happens to repaint it. That is exactly
+  /// how it behaved before those methods existed.
+  final LumitClipboard clipboard = LumitClipboard();
+
+  /// Copy a layer, and tell the interface so Paste ungreys.
+  void copyLayerToClipboard(String text) {
+    clipboard.putLayer(text);
+    notifyListeners();
+  }
+
+  /// Copy one effect or a whole stack, same repaint.
+  void copyEffectsToClipboard(String text) {
+    clipboard.putEffects(text);
+    notifyListeners();
+  }
 
   /// The whole selection, primary first (K-217).
   ///

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -495,13 +495,12 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
           {List<BridgeLayerEntry> among = const []}) =>
       setState(() {
         if (ui.selectedLayer.value?.internallayerId != layer?.internallayerId) {
-          _selectedProperties.clear();
-          _graphKeySelection.clear();
-          // The highlight belongs to the property selection just cleared, so
-          // it goes with it. Left behind, the previous layer's row stayed lit
-          // after a click on a different layer — two layers appearing chosen
-          // at once, which is the ambiguity K-203 set out to remove.
-          _highlighted = null;
+          // The one place this is decided, shared with the listener that
+          // catches a selection made in the Viewer (K-275). The highlight goes
+          // with the property selection it belongs to: left behind, the
+          // previous layer's row stayed lit after a click on a different
+          // layer.
+          _dropLayerLocalSelection();
         }
         if (layer == null) {
           ui.clearSelection();
@@ -972,6 +971,37 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
     // deactivated, where an ancestor lookup is no longer safe.
     _ui = Provider.of<LumitUiState>(context, listen: false);
     _ui!.deleteClaim = _deleteSelectedMasks;
+    // The selection can change from outside this panel — a click on the
+    // picture in the Viewer is the everyday case (K-275). The property
+    // selection, the graph's key selection and the row highlight all belong to
+    // whichever layer was chosen, so they are cleared wherever the choosing
+    // happened rather than only in this panel's own click path. Without this,
+    // picking a different layer on the picture left the *previous* layer's
+    // rows lit in the Timeline: two layers appearing chosen at once, which is
+    // the ambiguity K-203 set out to remove.
+    _primary = _ui!.selectedLayer.value?.internallayerId;
+    _ui!.selectedLayer.addListener(_onPrimaryChanged);
+  }
+
+  /// The layer the panel's local selections belong to, so a change of primary
+  /// can be told from a rebuild.
+  UuidValue? _primary;
+
+  void _onPrimaryChanged() {
+    final now = _ui?.selectedLayer.value?.internallayerId;
+    if (now == _primary) return;
+    _primary = now;
+    if (!mounted) return;
+    setState(_dropLayerLocalSelection);
+  }
+
+  /// Everything the panel holds that belongs to one layer. Called whenever the
+  /// primary changes, from here or from anywhere else.
+  void _dropLayerLocalSelection() {
+    _selectedProperties.clear();
+    _graphKeySelection.clear();
+    _laneKeySelection.clear();
+    _highlighted = null;
   }
 
   /// The shell state this panel claimed Delete on, so the claim can be dropped
@@ -1306,6 +1336,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
   @override
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_onKey);
+    _ui?.selectedLayer.removeListener(_onPrimaryChanged);
     if (_ui?.deleteClaim == _deleteSelectedMasks) _ui!.deleteClaim = null;
     _boundTools?.removeListener(_onToolChanged);
     _barDrag.dispose();

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -32,6 +32,7 @@ import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
 
 import '../panels/timeline_extras_frb.dart';
+import '../state/clipboard.dart';
 import '../state/dock.dart';
 import '../state/file_dialogs.dart';
 import '../state/keymap.dart';
@@ -364,9 +365,28 @@ List<MenuSection> lumitMenus(
           action: 'edit.redo'),
       const MenuEntry.todo('History'),
       const MenuEntry.divider(),
-      const MenuEntry.todo('Cut'),
-      const MenuEntry.todo('Copy'),
-      const MenuEntry.todo('Paste'),
+      // Copy takes the selected layer whole — transform, keyframes, masks,
+      // paint, effects and switches — as the document text the engine hands
+      // back (K-275). Cut is that plus the delete, so the two can never
+      // disagree about what "the selection" was.
+      MenuEntry(
+          'Cut',
+          onLayer((l) {
+            ui.copyLayerToClipboard(l.copyLayer());
+            l.delete();
+            ui.clearSelection();
+            app.notifyDocumentChanged();
+          }),
+          action: 'edit.cut'),
+      MenuEntry('Copy', onLayer((l) => ui.copyLayerToClipboard(l.copyLayer())),
+          action: 'edit.copy'),
+      // Paste puts a layer at the playhead — or at the time it was copied
+      // from, for the person rebuilding a moment in a second comp (Settings →
+      // Interface). An effect always lands with its first keyframe at the
+      // playhead, whichever way that setting is: what is being placed is an
+      // animation rather than a position.
+      MenuEntry('Paste', _pasteAction(app, ui, comp, layer),
+          action: 'edit.paste'),
       MenuEntry(
           'Delete',
           layers.isEmpty
@@ -728,6 +748,47 @@ void undoFrb(LumitState app) {
 void redoFrb(LumitState app) {
   app.project?.redo();
   app.notifyDocumentChanged();
+}
+
+/// What Paste does with whatever is on the clipboard (K-275), or `null` when
+/// there is nothing to paste — or nowhere to put it.
+///
+/// A layer goes into the composition on screen: at the playhead by default, or
+/// at the time it was copied from when Settings → Interface says so. An effect
+/// goes onto the selected layer, always with its first keyframe at the
+/// playhead.
+VoidCallback? _pasteAction(
+  LumitState app,
+  LumitUiState ui,
+  CompositionReference? comp,
+  LayerReference? layer,
+) {
+  final text = ui.clipboard.text;
+  if (text == null) return null;
+  switch (ui.clipboard.kind) {
+    case ClipboardKind.layer:
+      if (comp == null) return null;
+      return () {
+        final pasted = comp.pasteLayer(
+          text: text,
+          atFrame: ui.workspace.interface.pasteLayersAtOriginalTime
+              ? null
+              : ui.playheadFrame.value,
+        );
+        // Selecting what was just pasted is what every editor does, and it is
+        // also what makes a second paste land somewhere you can see.
+        ui.setSelection([pasted]);
+        app.notifyDocumentChanged();
+      };
+    case ClipboardKind.effects:
+      if (layer == null) return null;
+      return () {
+        layer.pasteEffects(text: text, atFrame: ui.playheadFrame.value);
+        app.notifyDocumentChanged();
+      };
+    case null:
+      return null;
+  }
 }
 
 /// Razor the selected layer at the playhead. Only Sequence layers hold clips,

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -426,6 +426,23 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         ),
         _row(
           t,
+          'Paste layers at their original time',
+          'A pasted layer keeps the timecode it was copied at, instead of '
+              'starting at the playhead. For rebuilding the same moment in a '
+              'second composition; leave it off for the everyday "put one '
+              'here". Effects always paste with their first keyframe at the '
+              'playhead, whichever way this is set.',
+          HouseCheckbox(
+            key: const ValueKey('settings-paste-at-original-time'),
+            value: settings.pasteLayersAtOriginalTime,
+            onChanged: (on) => setState(() {
+              settings.pasteLayersAtOriginalTime = on;
+              ui.workspace.settingsChanged();
+            }),
+          ),
+        ),
+        _row(
+          t,
           'Playhead stays where playback stopped',
           'Leave the playhead on the frame that was on screen when playback '
               'stopped, instead of putting it back where playing started. '

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -512,6 +512,31 @@ class CompositionReference {
         that: this,
       );
 
+  /// Paste a layer copied by [`crate::api::layer::LayerReference::copy_layer`]
+  /// into this composition, at the top of the stack (K-275).
+  ///
+  /// `at_frame` is where the layer's **in point** lands: the playhead, in the
+  /// ordinary case. `None` keeps the time it was copied at, which is the
+  /// setting for putting the same layer at the same moment in a second comp —
+  /// the two paste behaviours the owner asked for, decided by the caller
+  /// rather than by a mode this end has to remember.
+  ///
+  /// Whichever is chosen, the layer moves as one: in point, out point and
+  /// `start_offset` all shift together (`lumit_core::edit_layer_span`'s
+  /// `MoveIn`, the same rule the `[` key follows), so its keyframes and the
+  /// source frames it shows travel with it rather than sliding against it.
+  ///
+  /// **What is not copied is a reference to something that is not here.** The
+  /// pasted layer gets a fresh id and fresh effect ids — two layers sharing an
+  /// id would make every op that names one ambiguous — and its parent and
+  /// track matte are kept only when they still name a layer in *this* comp.
+  /// A parent that came from another composition is dropped rather than left
+  /// dangling: a layer parented to nothing visible would be a puzzle, and
+  /// re-parenting is one drag.
+  LayerReference pasteLayer({required String text, PlatformInt64? atFrame}) =>
+      BridgeLib.instance.api.crateApiCompositionCompositionReferencePasteLayer(
+          that: this, text: text, atFrame: atFrame);
+
   /// Play from `from` at this comp's own rate, with sound.
   ///
   /// The frontend calls this and then paints whatever frames arrive: each one

--- a/flutter_ui/lib/src/rust/api/layer.dart
+++ b/flutter_ui/lib/src/rust/api/layer.dart
@@ -981,6 +981,32 @@ class LayerReference {
         that: this,
       );
 
+  /// This layer's effects as a `.lumfx` document, for [`Self::paste_effects`]
+  /// (K-275). `effect` copies that one; `None` copies the whole stack.
+  ///
+  /// Deliberately the **same document a preset is**, so an effect copied from
+  /// one layer can be saved as a preset and a preset can be pasted as an
+  /// effect — one shape, not two that drift.
+  String copyEffects({UuidValue? effect}) => BridgeLib.instance.api
+      .crateApiLayerLayerReferenceCopyEffects(that: this, effect: effect);
+
+  /// This layer as text, for [`crate::api::composition::CompositionReference::
+  /// paste_layer`] — the clipboard's payload (K-275).
+  ///
+  /// The whole layer: its kind and source, its transform with every keyframe,
+  /// its masks, paint, effects, switches, markers and retime. It is the
+  /// document's own `Layer`, serialised, so anything the file format carries
+  /// travels — including fields a newer Lumit added, which ride in the
+  /// `extra` maps exactly as they do through a save (docs/10 §1.1).
+  ///
+  /// A *reference* it holds to another layer — its parent, its track matte —
+  /// is copied as it stands and resolved at the paste, which is the only end
+  /// that knows whether the layer being pointed at is there.
+  String copyLayer() =>
+      BridgeLib.instance.api.crateApiLayerLayerReferenceCopyLayer(
+        that: this,
+      );
+
   /// The shape of this Sequence layer — where its cuts fall and how each
   /// piece is ramped — as text, for [`Self::paste_sequence_shape`] (K-248).
   ///
@@ -1250,6 +1276,23 @@ class LayerReference {
   /// additions. Only text that is not a preset at all is refused.
   void loadPreset({required String text}) => BridgeLib.instance.api
       .crateApiLayerLayerReferenceLoadPreset(that: this, text: text);
+
+  /// Append copied effects to this layer's stack, **timed to the playhead**
+  /// (K-275): whatever the earliest keyframe among them was, it lands at
+  /// `at_frame` and the rest keep their spacing.
+  ///
+  /// The owner's rule, and the one that makes a copied animation useful: an
+  /// effect copied from a layer that flashes at 4 s and pasted while the
+  /// playhead sits at 12 s flashes at 12 s, not off the end of the comp.
+  /// Effects with no keyframes at all paste unchanged — there is no timing to
+  /// place. Each arrives with a fresh instance id, exactly as a preset does.
+  ///
+  /// `at_frame` is a **comp** frame; the shift is worked out in the target
+  /// layer's own local time, so pasting onto a layer that starts later does
+  /// not double-count its offset.
+  void pasteEffects({required String text, required PlatformInt64 atFrame}) =>
+      BridgeLib.instance.api.crateApiLayerLayerReferencePasteEffects(
+          that: this, text: text, atFrame: atFrame);
 
   /// Cut and ramp this Sequence layer to the shape in `text`, keeping its
   /// own media (K-248).

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -87,7 +87,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1395644184;
+  int get rustContentHash => 1539249759;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -236,6 +236,11 @@ abstract class BridgeLibApi extends BaseApi {
 
   BridgeSpan? crateApiCompositionCompositionReferenceGetWorkArea(
       {required CompositionReference that});
+
+  LayerReference crateApiCompositionCompositionReferencePasteLayer(
+      {required CompositionReference that,
+      required String text,
+      PlatformInt64? atFrame});
 
   void crateApiCompositionCompositionReferencePlay(
       {required CompositionReference that,
@@ -445,6 +450,11 @@ abstract class BridgeLibApi extends BaseApi {
   void crateApiLayerLayerReferenceConvertToSequenced(
       {required LayerReference that});
 
+  String crateApiLayerLayerReferenceCopyEffects(
+      {required LayerReference that, UuidValue? effect});
+
+  String crateApiLayerLayerReferenceCopyLayer({required LayerReference that});
+
   String crateApiLayerLayerReferenceCopySequenceShape(
       {required LayerReference that, UuidValue? clip});
 
@@ -545,6 +555,11 @@ abstract class BridgeLibApi extends BaseApi {
 
   void crateApiLayerLayerReferenceLoadPreset(
       {required LayerReference that, required String text});
+
+  void crateApiLayerLayerReferencePasteEffects(
+      {required LayerReference that,
+      required String text,
+      required PlatformInt64 atFrame});
 
   void crateApiLayerLayerReferencePasteSequenceShape(
       {required LayerReference that, required String text});
@@ -2028,6 +2043,37 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           );
 
   @override
+  LayerReference crateApiCompositionCompositionReferencePasteLayer(
+      {required CompositionReference that,
+      required String text,
+      PlatformInt64? atFrame}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_composition_reference(that, serializer);
+        sse_encode_String(text, serializer);
+        sse_encode_opt_box_autoadd_i_64(atFrame, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_layer_reference,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiCompositionCompositionReferencePasteLayerConstMeta,
+      argValues: [that, text, atFrame],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiCompositionCompositionReferencePasteLayerConstMeta =>
+          const TaskConstMeta(
+            debugName: "composition_reference_paste_layer",
+            argNames: ["that", "text", "atFrame"],
+          );
+
+  @override
   void crateApiCompositionCompositionReferencePlay(
       {required CompositionReference that,
       required BigInt from,
@@ -2040,7 +2086,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_64(from, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_bridge_playback_mode(mode, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2066,7 +2112,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -2100,7 +2146,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(name, serializer);
         sse_encode_bool(leaveAttributes, serializer);
         sse_encode_bool(adjustDuration, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -2139,7 +2185,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_64(frame, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_bridge_playback_mode(mode, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2176,7 +2222,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_Uuid(clip, serializer);
         sse_encode_box_autoadd_bridge_scalar(retime, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2212,7 +2258,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_list_bridge_mask(masks, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2248,7 +2294,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_list_bridge_stroke(strokes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2285,7 +2331,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2321,7 +2367,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_list_bridge_shape_item(contents, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2357,7 +2403,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_box_autoadd_bridge_text_document(document, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2393,7 +2439,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
         sse_encode_box_autoadd_bridge_transform(transform, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2430,7 +2476,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_32(scale, serializer);
         sse_encode_u_32(kind, serializer);
         sse_encode_list_list_prim_u_8_strict(colours, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2469,7 +2515,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_u_32(window, serializer);
         sse_encode_f_32(scale, serializer);
         sse_encode_opt_box_autoadd_layer_reference(layer, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2498,7 +2544,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_list_bridge_marker(markers, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2526,7 +2572,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2556,7 +2602,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2584,7 +2630,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2615,7 +2661,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_export_spec(spec, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2642,7 +2688,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2670,7 +2716,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_rational,
@@ -2695,7 +2741,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -2718,7 +2764,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2740,7 +2786,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_state,
@@ -2768,7 +2814,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(preset, serializer);
         sse_encode_String(compName, serializer);
         sse_encode_String(template, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_export_preset,
@@ -2792,7 +2838,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_folder_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -2819,7 +2865,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 72, port: port_);
+            funcId: 73, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_lumit_media_status,
@@ -2846,7 +2892,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 73, port: port_);
+            funcId: 74, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_media_info,
@@ -2873,7 +2919,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2901,7 +2947,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_footage_reference(that, serializer);
         sse_encode_u_32(maxEdge, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 75, port: port_);
+            funcId: 76, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_rendered_frame,
@@ -2925,7 +2971,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2948,7 +2994,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2975,7 +3021,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_box_autoadd_item_reference(item, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3000,7 +3046,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3025,7 +3071,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3052,7 +3098,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_item_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3076,7 +3122,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_conflict,
@@ -3102,7 +3148,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(json, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 83, port: port_);
+            funcId: 84, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3126,7 +3172,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3151,7 +3197,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_keymap_preset(preset, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 85, port: port_);
+            funcId: 86, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3177,7 +3223,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(chord, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -3206,7 +3252,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_String(action, serializer);
         sse_encode_String(chord, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 87, port: port_);
+            funcId: 88, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3233,7 +3279,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 88, port: port_);
+            funcId: 89, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3257,7 +3303,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(query, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_key_binding,
@@ -3279,7 +3325,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3305,7 +3351,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_bridge_key_context(context, serializer);
         sse_encode_String(action, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 91, port: port_);
+            funcId: 92, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_keymap_group,
@@ -3330,7 +3376,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3357,7 +3403,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_mask(mask, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3384,7 +3430,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_shape_item(item, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3411,7 +3457,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_stroke(stroke, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3439,7 +3485,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(buckets, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 96, port: port_);
+            funcId: 97, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_audio_peaks,
@@ -3470,7 +3516,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Uuid(clip, serializer);
         sse_encode_u_32(maxEdge, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 97, port: port_);
+            funcId: 98, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_rendered_frame,
@@ -3496,7 +3542,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3522,7 +3568,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3542,6 +3588,58 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
+  String crateApiLayerLayerReferenceCopyEffects(
+      {required LayerReference that, UuidValue? effect}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_layer_reference(that, serializer);
+        sse_encode_opt_Uuid(effect, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiLayerLayerReferenceCopyEffectsConstMeta,
+      argValues: [that, effect],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiLayerLayerReferenceCopyEffectsConstMeta =>
+      const TaskConstMeta(
+        debugName: "layer_reference_copy_effects",
+        argNames: ["that", "effect"],
+      );
+
+  @override
+  String crateApiLayerLayerReferenceCopyLayer({required LayerReference that}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_layer_reference(that, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiLayerLayerReferenceCopyLayerConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiLayerLayerReferenceCopyLayerConstMeta =>
+      const TaskConstMeta(
+        debugName: "layer_reference_copy_layer",
+        argNames: ["that"],
+      );
+
+  @override
   String crateApiLayerLayerReferenceCopySequenceShape(
       {required LayerReference that, UuidValue? clip}) {
     return handler.executeSync(SyncTask(
@@ -3549,7 +3647,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_Uuid(clip, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 100)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -3576,7 +3674,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 101)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3601,7 +3699,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 102)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3628,7 +3726,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(clip, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 103)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3655,7 +3753,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 104)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3681,7 +3779,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 105)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3708,7 +3806,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(id, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 106)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3735,7 +3833,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(id, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 107)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3761,7 +3859,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 108)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_layer_reference,
@@ -3788,7 +3886,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_layer_reference(layer, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 109)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -3812,7 +3910,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 110)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -3838,7 +3936,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 111)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -3864,7 +3962,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 112)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_clip,
@@ -3890,7 +3988,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 113)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -3917,7 +4015,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 114)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_info,
@@ -3943,7 +4041,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 115)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_retime_interp,
@@ -3969,7 +4067,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 116)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_kind,
@@ -3994,7 +4092,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 117)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_8,
@@ -4020,7 +4118,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 118)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_marker,
@@ -4046,7 +4144,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 119)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_mask,
@@ -4072,7 +4170,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 120)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_matte,
@@ -4097,7 +4195,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 121)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4123,7 +4221,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 122)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_stroke,
@@ -4149,7 +4247,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 123)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_Uuid,
@@ -4175,7 +4273,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 124)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_scalar,
@@ -4201,7 +4299,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 125)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_shape_item,
@@ -4227,7 +4325,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 126)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_item_reference,
@@ -4253,7 +4351,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 127)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_span,
@@ -4279,7 +4377,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 128)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_layer_switches,
@@ -4305,7 +4403,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 129)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 132)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_bridge_text_document,
@@ -4331,7 +4429,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 130)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_transform,
@@ -4357,7 +4455,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 131)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_scalar,
@@ -4384,7 +4482,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 132, port: port_);
+            funcId: 135, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4409,7 +4507,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 133)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4434,7 +4532,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 134)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -4461,7 +4559,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 135)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4481,6 +4579,36 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
+  void crateApiLayerLayerReferencePasteEffects(
+      {required LayerReference that,
+      required String text,
+      required PlatformInt64 atFrame}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_layer_reference(that, serializer);
+        sse_encode_String(text, serializer);
+        sse_encode_i_64(atFrame, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiLayerLayerReferencePasteEffectsConstMeta,
+      argValues: [that, text, atFrame],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiLayerLayerReferencePasteEffectsConstMeta =>
+      const TaskConstMeta(
+        debugName: "layer_reference_paste_effects",
+        argNames: ["that", "text", "atFrame"],
+      );
+
+  @override
   void crateApiLayerLayerReferencePasteSequenceShape(
       {required LayerReference that, required String text}) {
     return handler.executeSync(SyncTask(
@@ -4488,7 +4616,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(text, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 136)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4516,7 +4644,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 137)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4543,7 +4671,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 138)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4570,7 +4698,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_usize(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 139)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4601,7 +4729,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_i_64(newIndex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 140)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4628,7 +4756,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_reveal_kind(kind, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 141)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_reveal_groups,
@@ -4655,7 +4783,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_String(name, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 142)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -4682,7 +4810,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_32(index, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 143)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4709,7 +4837,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(zoom, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 144)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4739,7 +4867,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(clip, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 145)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4771,7 +4899,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Uuid(clip, serializer);
         sse_encode_f_64(percent, serializer);
         sse_encode_f_64(endPercent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 146)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4802,7 +4930,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effect, serializer);
         sse_encode_bool(enabled, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 147)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4831,7 +4959,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeEffectInstance(
             effects, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 148)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4859,7 +4987,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_retime_interp(interpolation, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 149)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4886,7 +5014,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_u_8(label, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 150)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4913,7 +5041,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_marker(markers, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 151)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4940,7 +5068,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_mask(mask, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 152)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4967,7 +5095,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_matte(matte, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 153)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -4994,7 +5122,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_opt_Uuid(parent, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 154)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5021,7 +5149,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 155)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5048,7 +5176,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_shape_item(contents, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 156)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5075,7 +5203,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_span(span, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 157)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5102,7 +5230,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_stroke(stroke, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 158)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5132,7 +5260,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_layer_switch(switch_, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 159)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5159,7 +5287,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_text_document(document, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 160)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5195,7 +5323,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_f_64(anchorY, serializer);
         sse_encode_f_64(positionX, serializer);
         sse_encode_f_64(positionY, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 161)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5232,7 +5360,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_bridge_transform_prop(prop, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 162)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5262,7 +5390,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_list_bridge_transform_prop(props, serializer);
         sse_encode_list_bridge_scalar(values, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 163)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5289,7 +5417,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_box_autoadd_bridge_scalar(value, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 164)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5319,7 +5447,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_Uuid(clip, serializer);
         sse_encode_i_64(toFrame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 165)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5346,7 +5474,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
         sse_encode_i_64(frame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 166)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5372,7 +5500,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_layer_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 167)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -5404,7 +5532,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_Uuid(clip, serializer);
         sse_encode_i_64(startFrame, serializer);
         sse_encode_i_64(endFrame, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 168)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 172)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5429,7 +5557,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(project, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 169)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 173)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_autosave,
@@ -5451,7 +5579,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 170)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 174)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -5474,7 +5602,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 171)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 175)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_effect_info,
@@ -5498,7 +5626,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 172)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 176)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_param_group,
@@ -5522,7 +5650,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(effect, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 173)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 177)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_param_info,
@@ -5545,7 +5673,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 174)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 178)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_bridge_preset_info,
@@ -5567,7 +5695,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 175)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 179)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -5589,7 +5717,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 176)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 180)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5618,7 +5746,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
         sse_encode_u_32(keep, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 177)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 181)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5644,7 +5772,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 178)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -5671,7 +5799,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 179)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -5697,7 +5825,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 180)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_history,
@@ -5724,7 +5852,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 181)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 185)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_footage_reference,
@@ -5750,7 +5878,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -5780,7 +5908,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(name, serializer);
         sse_encode_opt_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 187)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_composition_reference,
@@ -5806,7 +5934,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 188)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5832,7 +5960,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 185)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5857,7 +5985,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5884,7 +6012,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 187)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_recovery,
@@ -5912,7 +6040,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 188, port: port_);
+            funcId: 192, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5940,7 +6068,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_project_cache_location(
             location, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5967,7 +6095,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_String(uiState, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -5995,7 +6123,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_StreamSink_worker_response_Sse(onReponse, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6021,7 +6149,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 192)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 196)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -6046,7 +6174,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 197)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6070,7 +6198,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -6092,7 +6220,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6118,7 +6246,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_bridge_scalar(scalar, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 196)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -6141,7 +6269,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 197)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -6166,7 +6294,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6192,7 +6320,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_cache_location(location, serializer);
         sse_encode_String(folder, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6217,7 +6345,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -6242,7 +6370,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 205)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_solid_def,
@@ -6269,7 +6397,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
         sse_encode_box_autoadd_bridge_solid_def(definition, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 206)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6293,7 +6421,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 207)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6316,7 +6444,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 208)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6338,7 +6466,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 205)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 209)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6361,7 +6489,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 206)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 210)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_viewer_transport,
@@ -6384,7 +6512,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 207)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 211)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,

--- a/flutter_ui/lib/state/clipboard.dart
+++ b/flutter_ui/lib/state/clipboard.dart
@@ -1,0 +1,53 @@
+// What Copy put down, for Paste to pick up (K-275).
+//
+// **In plain terms.** Copying a layer or an effect asks the engine for it as
+// text — the same document a project file is made of, so everything on it
+// travels: keyframes, masks, paint, switches, the lot. This holds that text
+// until something pastes it.
+//
+// **Why the application's own clipboard and not the system one.** The payload
+// is a Lumit document, and the system clipboard is shared with every other
+// application: a stray copy from a text editor would arrive here as something
+// to refuse, and Lumit's own JSON pasted into a chat window is noise. Keeping
+// it here also means Copy in a text field and Copy on a layer never fight over
+// the same tray. The cost is that copying between two running Lumit windows
+// does not work yet; when that is wanted, this is the one place that changes
+// (docs/TODO.md).
+
+/// What kind of thing is on the clipboard, so Paste knows what to do with the
+/// text rather than guessing from its shape.
+enum ClipboardKind { layer, effects }
+
+/// The one tray. Held by the shell state, read by the Edit menu.
+class LumitClipboard {
+  ClipboardKind? _kind;
+  String? _text;
+
+  /// What is on it, or null when nothing has been copied this session.
+  ClipboardKind? get kind => _kind;
+
+  bool get isEmpty => _text == null;
+
+  /// The copied document, or null. Paired with [kind]: a caller reads both or
+  /// neither, which is why they are not two fields to keep in step by hand.
+  String? get text => _text;
+
+  /// Put a layer document down (from `LayerReference.copyLayer`).
+  void putLayer(String text) {
+    _kind = ClipboardKind.layer;
+    _text = text;
+  }
+
+  /// Put an effect document down (from `LayerReference.copyEffects`) — one
+  /// effect or a whole stack; both are the same `.lumfx` shape, so both paste
+  /// the same way.
+  void putEffects(String text) {
+    _kind = ClipboardKind.effects;
+    _text = text;
+  }
+
+  void clear() {
+    _kind = null;
+    _text = null;
+  }
+}

--- a/flutter_ui/lib/state/settings.dart
+++ b/flutter_ui/lib/state/settings.dart
@@ -150,6 +150,16 @@ class InterfaceSettings {
   /// from the default rather than a choice between two equals.
   bool playheadStaysOnStop;
 
+  /// Whether a pasted layer keeps the time it was copied at, rather than
+  /// starting at the playhead (K-275).
+  ///
+  /// Off by default: pasting is nearly always "put one here", and the playhead
+  /// is where *here* is. On is for the other job — rebuilding the same moment
+  /// in a second composition, where a layer that landed anywhere but its own
+  /// timecode would have to be dragged back by hand every time. Effects ignore
+  /// it either way: a copied animation is placed by its first keyframe.
+  bool pasteLayersAtOriginalTime;
+
   InterfaceSettings({
     this.uiScale = 1.0,
     this.showTooltips = true,
@@ -157,6 +167,7 @@ class InterfaceSettings {
     this.retimeOpensToSpeed = false,
     this.videoAsSequenceLayer = false,
     this.playheadStaysOnStop = false,
+    this.pasteLayersAtOriginalTime = false,
   });
 
   Map<String, dynamic> toJson() => {
@@ -166,6 +177,7 @@ class InterfaceSettings {
         'retime_opens_to_speed': retimeOpensToSpeed,
         'video_as_sequence_layer': videoAsSequenceLayer,
         'playhead_stays_on_stop': playheadStaysOnStop,
+        'paste_layers_at_original_time': pasteLayersAtOriginalTime,
       };
   factory InterfaceSettings.fromJson(Map<String, dynamic> j) =>
       InterfaceSettings(
@@ -183,5 +195,9 @@ class InterfaceSettings {
         // before this field existed adopts it rather than being pinned to the
         // old behaviour by its own silence.
         playheadStaysOnStop: j['playhead_stays_on_stop'] as bool? ?? false,
+        // Absent means off: a paste lands at the playhead, which is what a
+        // settings file written before this field existed already did.
+        pasteLayersAtOriginalTime:
+            j['paste_layers_at_original_time'] as bool? ?? false,
       );
 }

--- a/flutter_ui/test/frb/effect_controls_frb_test.dart
+++ b/flutter_ui/test/frb/effect_controls_frb_test.dart
@@ -151,6 +151,27 @@ void main() {
           reason: 'the stack draws as it does on any other layer');
     });
 
+    testWidgets('a selection made in the Viewer switches the panel to it',
+        (tester) async {
+      // The Viewer picks a layer by calling `setSelection` on the shell — it
+      // never goes through the Timeline — so this panel must follow the shell,
+      // not the panel that happens to be next to it (K-275).
+      final p = withLayer();
+      p.layer.addEffect(name: 'blur');
+      final other = p.uiState.selectedComp!.addSolidLayer();
+      other.addEffect(name: 'invert');
+      await mount(tester, p);
+      expect(find.text('Gaussian blur'), findsOneWidget);
+
+      p.uiState.setSelection([other]);
+      await tester.pump();
+
+      expect(find.text('Invert'), findsOneWidget,
+          reason: "the panel shows the newly selected layer's stack");
+      expect(find.text('Gaussian blur'), findsNothing,
+          reason: 'and not the one it was showing before');
+    });
+
     testWidgets('a parameter edit commits, and reading it back is exact',
         (tester) async {
       final p = withLayer();

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -159,6 +159,67 @@ void main() {
       expect(find.text('Composition settings…'), findsOneWidget);
     });
 
+    testWidgets('Copy and Paste carry a layer, landing it at the playhead',
+        (tester) async {
+      // K-275: Copy takes the selected layer whole and Paste puts it in the
+      // comp on screen, at the playhead. The engine does the carrying; what is
+      // tested here is that the menu is wired to it and to the setting.
+      final p = await mount(tester);
+      await makeComp(tester);
+      final comp = p.uiState.selectedComp!;
+      final source = comp.addSolidLayer();
+      source.rename(name: 'Hero');
+      source.addEffect(name: 'blur');
+      p.uiState.setSelection([source]);
+      await tester.pump();
+
+      await choose(tester, 'Edit', 'Copy');
+      p.uiState.playheadFrame.value = 30;
+      await choose(tester, 'Edit', 'Paste');
+      await tester.pump();
+
+      final layers = comp.getLayers();
+      expect(layers.length, 2, reason: 'the paste made a second layer');
+      final pasted = p.uiState.selectedLayer.value!;
+      expect(pasted.internallayerId, isNot(source.internallayerId),
+          reason: 'and selected it, as every editor does');
+      expect(pasted.getName(), 'Hero', reason: 'the name travels');
+      expect(pasted.getEffects().length, 1, reason: 'and so does the stack');
+      // Frame 30 in seconds, on whatever rate the comp actually runs at.
+      final settings = comp.getSettings();
+      final atFrame30 = 30 * settings.fpsDen / settings.fpsNum;
+      final span = pasted.getSpan();
+      expect(span.inPoint.num / span.inPoint.den, closeTo(atFrame30, 1e-9),
+          reason: 'the in point lands on the playhead');
+
+      // The setting sends it to the time it was copied from instead.
+      p.uiState.workspace.interface.pasteLayersAtOriginalTime = true;
+      p.uiState.playheadFrame.value = 60;
+      await choose(tester, 'Edit', 'Paste');
+      await tester.pump();
+      final atOriginal = p.uiState.selectedLayer.value!.getSpan();
+      expect(atOriginal.inPoint.num, 0,
+          reason: 'with the setting on it keeps the time it was copied at');
+    });
+
+    testWidgets('Cut copies the layer before removing it', (tester) async {
+      final p = await mount(tester);
+      await makeComp(tester);
+      final comp = p.uiState.selectedComp!;
+      final source = comp.addSolidLayer();
+      p.uiState.setSelection([source]);
+      await tester.pump();
+
+      await choose(tester, 'Edit', 'Cut');
+      await tester.pump();
+      expect(comp.getLayers(), isEmpty, reason: 'the layer went');
+
+      await choose(tester, 'Edit', 'Paste');
+      await tester.pump();
+      expect(comp.getLayers().length, 1,
+          reason: 'and came back, so Cut did copy before deleting');
+    });
+
     testWidgets('New composition creates one, fronts it, and names it for you',
         (tester) async {
       final p = await mount(tester);

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1367,6 +1367,60 @@ void main() {
           reason: "and so does the property's layer");
     });
 
+    /// **Picking a layer on the picture reaches the Timeline** (K-275).
+    ///
+    /// The Viewer's click goes straight to the shell's selection
+    /// (`setSelection`), never through this panel's own click path — so the
+    /// property selection, the graph's keys and the row highlight, all of which
+    /// belong to the layer that *was* chosen, stayed behind. The previous
+    /// layer's rows kept their fill while a different layer was selected: two
+    /// layers appearing chosen at once, which is what K-203 set out to remove.
+    testWidgets('a selection made outside the panel clears the property one',
+        (tester) async {
+      final p = withComp();
+      final first = p.comp.addSolidLayer();
+      first.addEffect(name: 'blur');
+      final second = p.comp.addSolidLayer();
+      await mount(tester, p);
+      final id = first.internallayerId;
+
+      // Select a property on the first layer, the ordinary way.
+      await tester.tap(find.byKey(ValueKey<String>('tl-twirl-$id')));
+      await tester.pump();
+      await tester.tap(find.text('Effects'));
+      await tester.pump();
+      await tester.tap(find.text('Gaussian blur'));
+      await tester.pump();
+      await tester.tap(find.text('Radius'));
+      await tester.pump();
+
+      final t = LumitTheme.dark();
+      Color? fillOver(String text) {
+        final box = find.ancestor(
+            of: find.text(text), matching: find.byType(Container));
+        return (tester.widget<Container>(box.first).decoration as BoxDecoration)
+            .color;
+      }
+      expect(fillOver('Radius'), t.selectionFill, reason: 'picked to start');
+
+      // Now the Viewer's path: the shell's selection changes under the panel.
+      p.uiState.setSelection([second]);
+      await tester.pump();
+
+      expect(fillOver('Radius'), isNull,
+          reason: 'the property belonged to the layer that was let go of');
+      expect(fillOver('Gaussian blur'), isNull,
+          reason: 'and so did the mark on the effect holding it');
+      expect(
+          (tester
+                  .widget<Container>(
+                      find.byKey(ValueKey<String>('tl-rowbody-$id')))
+                  .decoration as BoxDecoration)
+              .color,
+          isNot(t.selectionFill.withValues(alpha: 0.45)),
+          reason: 'the old layer stops looking chosen');
+    });
+
     /// **The highlight with nowhere to sit (K-203).** A selected property
     /// stayed selected when its layer was twirled shut — invisible, but still
     /// the selection — so it came back lit when the layer reopened, and it


### PR DESCRIPTION
Ninth in the stack (base is #50). Your two requests, now complete on both sides.

## Selection

Your first report was right, and the cause was narrower than it looked: picking a layer on the picture *did* already replace the whole selection, but the Timeline keeps its **own** per-layer state — the property selection, the graph's key selection, the row highlight — and cleared it only in its own click path. So a Viewer pick left the previous layer's rows lit: two layers looking chosen at once, the ambiguity K-203 set out to remove.

The panel now listens to the shell's `selectedLayer` and drops that state wherever the choosing happened, through the one helper its own click path already used. The Effect controls panel already followed the shell — what it lacked was a test saying so. Both have one now.

## Copy and paste — engine and panels

**Engine.** `copy_layer` serialises the model's own `Layer`: transform and keyframes, masks, paint, effects, switches, markers, retime, and any field a newer Lumit added riding in `extra`. `paste_layer(text, at_frame)` gives fresh layer and effect ids, keeps a parent or track matte reference **only when it still names a layer in the target comp**, and lands the in point at `at_frame` by moving in point, out point and `start_offset` together (`edit_layer_span`'s `MoveIn` — the `[` key's own rule), so keyframes and source frames travel with the layer. `None` keeps the copied time. `copy_effects`/`paste_effects` use the **same `.lumfx` document a preset is**, and always land with the **first keyframe at the playhead** — what is being placed is an animation, not a position. An effect with no keyframes pastes unmoved.

`lumit_core::preset` gains `first_key_time` and `shift_keys` over an **exhaustive** match on `EffectValue`, so a parameter kind added later cannot quietly stop being shifted by a paste.

**Panels.** A session clipboard on `LumitUiState`; **Edit → Cut / Copy / Paste**; and *Paste layers at their original time* in Settings → Interface, off by default. Cut copies before deleting, so the two cannot disagree about what the selection was. Paste selects what it just pasted.

One real bug the tests caught: nothing repainted the menu after a copy, so **Paste stayed greyed out** until something else happened to rebuild it. The clipboard is written through two methods that notify, and Paste ungreys the moment you copy.

## Verification

The Dart half is no longer unverified — I got the pinned Flutter (3.44.7 / Dart 3.12.2) into this environment, so: `flutter analyze` clean, **805 Dart tests passing** at `--concurrency=1` (CI's setting), the bridge bindings regenerated by the real `flutter_rust_bridge_codegen`, plus the Rust suite, clippy, fmt and `cargo deny` on the pinned 1.97.1.

Six new tests: four engine (a copied layer arrives whole and lands at the playhead; a layer pasted into another comp drops the parent it left behind and keeps its time under `None`; a pasted effect's first key lands at the playhead with the rest keeping their spacing; an unkeyframed effect is left alone) and two menu (Copy→Paste carries the layer and honours the setting; Cut copies before it deletes, proven by pasting it back).

**Still owed**, and TODO'd: **Copy effect** on an effect's heading in the Effect controls panel and on its Timeline row — the two places an *effect* is picked rather than a layer. The engine call they need (`copy_effects(Some(id))`) is built and tested.

Docs: **K-275** in `02-DECISIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMBpUvXLEAUQjvaBYZt3u