### PR TITLE
Suggestions for the expressions branch: a green build, a 340x evaluator, and the failing test passing

### DIFF
--- a/crates/lumit-bridge/src/api.rs
+++ b/crates/lumit-bridge/src/api.rs
@@ -10,6 +10,7 @@ pub mod cache;
 pub mod composition;
 pub mod effect;
 pub mod export;
+pub mod expressions;
 pub mod folder;
 pub mod footage;
 pub mod keymap;
@@ -21,7 +22,6 @@ pub mod shell;
 pub mod solid;
 pub mod state;
 pub mod system;
-pub mod expressions;
 
 mod worker_thread;
 

--- a/crates/lumit-bridge/src/api/effect.rs
+++ b/crates/lumit-bridge/src/api/effect.rs
@@ -17,7 +17,7 @@
 //! unchanged. That is what lets the panel treat "read the value, change one
 //! field, write it" as safe — the ordinary way every control in it works.
 
-use std::{println, sync::Arc, todo};
+use std::sync::Arc;
 
 use flutter_rust_bridge::frb;
 pub use lumit_core::model::EffectInstance;
@@ -172,10 +172,7 @@ pub fn sample_scalar(scalar: BridgeScalar, time: BridgeRational) -> f64 {
                 .collect();
             lumit_core::anim::evaluate(&keys, seconds).unwrap_or(0.0)
         }
-        BridgeScalar::Expression(expr) => lumit_core::expression::evaluate(
-            &expr,
-            None,
-        ),
+        BridgeScalar::Expression(expr) => lumit_core::expression::evaluate(&expr, None),
     }
 }
 
@@ -205,14 +202,9 @@ pub fn sample_scalar_with_context(
             lumit_core::anim::evaluate(&keys, seconds).unwrap_or(0.0)
         }
         BridgeScalar::Expression(expr) => {
-            let projects = PROJECTS
-                .read()
-                .map_err(|_| BridgeError::ReadFailed)
-                .unwrap();
-            let project = projects.get(&layer.project_id).unwrap();
-
-            let doc = project.read().unwrap();
-            let doc = doc.store.snapshot();
+            let Some(doc) = document_for(&layer) else {
+                return 0.0;
+            };
 
             lumit_core::expression::evaluate(
                 &expr,
@@ -223,11 +215,26 @@ pub fn sample_scalar_with_context(
                     comp_time: Rational::new(time.num, time.den)
                         .unwrap_or(Rational::ZERO)
                         .to_f64(),
-                        current_depth: 0,
+                    current_depth: 0,
                 })),
             )
         }
     }
+}
+
+/// The project document a layer reference points into.
+///
+/// `None` when the project has gone — closed between the panel asking and this
+/// answering, or a lock poisoned by an unrelated panic. Neither is worth taking
+/// the app down for from inside an FFI call, where a panic unwinds across the
+/// language boundary rather than into a handler, so the samplers below fall
+/// back to the un-driven value instead.
+fn document_for(layer: &LayerReference) -> Option<Arc<lumit_core::Document>> {
+    let projects = PROJECTS.read().ok()?;
+    let project = projects.get(&layer.project_id)?.clone();
+    drop(projects);
+    let state = project.read().ok()?;
+    Some(state.store.snapshot())
 }
 
 #[frb(sync)]
@@ -240,14 +247,9 @@ pub fn sample_scalar_range_with_context(
 ) -> Vec<f64> {
     match scalar {
         BridgeScalar::Expression(expr) => {
-            let projects = PROJECTS
-                .read()
-                .map_err(|_| BridgeError::ReadFailed)
-                .unwrap();
-            let project = projects.get(&layer.project_id).unwrap();
-
-            let doc = project.read().unwrap();
-            let doc = doc.store.snapshot();
+            let Some(doc) = document_for(&layer) else {
+                return Vec::new();
+            };
 
             let start = Rational::new(start.num, start.den)
                 .unwrap_or(Rational::ZERO)
@@ -271,9 +273,10 @@ pub fn sample_scalar_range_with_context(
                 samples,
             )
         }
-        _ => {
-            todo!();
-        }
+        // Only an expression needs sampling by evaluation. A static value is
+        // flat and a keyframed one is drawn from its keys, both of which the
+        // graph editor already has without asking the engine.
+        _ => Vec::new(),
     }
 }
 

--- a/crates/lumit-bridge/src/api/expressions.rs
+++ b/crates/lumit-bridge/src/api/expressions.rs
@@ -1,6 +1,5 @@
 use flutter_rust_bridge::frb;
 
-
 #[frb(opaque)]
 pub struct Expressions {}
 

--- a/crates/lumit-core/src/anim.rs
+++ b/crates/lumit-core/src/anim.rs
@@ -9,7 +9,7 @@
 //! note's bracketed-Newton method: fast like Newton, and mathematically
 //! incapable of escaping the valid range like plain Newton can.
 
-use std::{eprintln, sync::Arc};
+use std::sync::Arc;
 
 use crate::{expression::ExpressionContext, time::Rational};
 use serde::{Deserialize, Serialize};
@@ -311,9 +311,7 @@ impl Property {
         match &self.animation {
             Animation::Static(v) => *v,
             Animation::Keyframed(keys) => evaluate(keys, t).unwrap_or(0.0),
-            Animation::Expression(expression) => {
-                crate::expression::evaluate(expression,  None)
-            }
+            Animation::Expression(expression) => crate::expression::evaluate(expression, None),
         }
     }
 

--- a/crates/lumit-core/src/expression.rs
+++ b/crates/lumit-core/src/expression.rs
@@ -1,5 +1,22 @@
+//! Expressions: a small script on a property, evaluated every time that
+//! property is read.
+//!
+//! In plain terms: instead of a number or a row of keyframes, a property can
+//! hold a line of code — `time * 90`, `layer("Sun").x` — and the answer is
+//! worked out afresh at each frame. The language is [Rhai]; the values it can
+//! see (the comp, the layers, `time`) are assembled in
+//! [`apply_context_to_scope`] and [`ExpressionContext`].
+//!
+//! The thing worth knowing before editing this file is that **evaluation is on
+//! the hot path**. Every driven property is re-evaluated for every frame, in
+//! both the renderer and the frame-cache key, so anything done per evaluation
+//! is done tens of thousands of times a second. That is why engines are pooled
+//! rather than built (see [`with_engine`]).
+//!
+//! [Rhai]: https://rhai.rs
+
+use std::cell::RefCell;
 use std::sync::{Arc, OnceLock};
-use std::{eprintln};
 
 use crate::Document;
 use rhai::{exported_module, Dynamic, Engine, Scope};
@@ -19,15 +36,41 @@ pub struct ExpressionContext {
 }
 
 impl ExpressionContext {
+    /// A context that offers nothing but `time` — for evaluations with no comp
+    /// or layer behind them: a standalone preview of an expression, and the
+    /// unit tests. The comp and layer constants are simply absent from the
+    /// scope, so an expression that reads one fails visibly rather than quietly
+    /// reading an invented number.
     pub fn detached() -> ExpressionContext {
-        static EMPTY: OnceLock<Document> = OnceLock::new();
+        // The empty document is shared, not copied. This is called once per
+        // context-less evaluation, and `Document` is the whole project.
+        static EMPTY: OnceLock<Arc<Document>> = OnceLock::new();
         ExpressionContext {
-            document: Arc::new(EMPTY.get_or_init(Document::new).clone()),
+            document: EMPTY.get_or_init(|| Arc::new(Document::new())).clone(),
             comp: None,
             layer: None,
             comp_time: 0.0,
             current_depth: 0,
         }
+    }
+
+    /// The context an expression is running under, read back off the engine
+    /// inside a `layer(…)` or `comp(…)` helper.
+    ///
+    /// Rhai's `clone_cast` **panics** when the tag is absent or of another
+    /// type, and absent is an ordinary case: any evaluation that did not set
+    /// one — a standalone preview, a half-typed expression in the graph
+    /// editor — would take the whole engine down with it. Engine crates do not
+    /// panic (14-ENGINEERING-RULES §4), so a missing context becomes the
+    /// detached one and the helpers report an invalid reference as they
+    /// already do for a name that matches no layer.
+    pub(crate) fn from_call(context: &rhai::NativeCallContext) -> Arc<ExpressionContext> {
+        context
+            .engine()
+            .default_tag()
+            .clone()
+            .try_cast::<Arc<ExpressionContext>>()
+            .unwrap_or_else(|| Arc::new(ExpressionContext::detached()))
     }
 
     pub fn increase_depth(&self) -> ExpressionContext {
@@ -55,132 +98,178 @@ fn make_engine() -> Engine {
     engine
 }
 
+thread_local! {
+    /// Engines that are built but not currently in use, on this thread.
+    ///
+    /// Building an engine means registering three modules' worth of functions,
+    /// which measures at roughly 370µs — about forty times the cost of running
+    /// a typical expression, and enough that a few dozen driven properties
+    /// would eat a whole 60fps frame on engine construction alone. So engines
+    /// are kept and handed out again.
+    ///
+    /// A stack rather than a single shared engine because **expressions nest**:
+    /// `layer("Sun").x` evaluates another property from inside an evaluation
+    /// already in progress, and the inner one needs an engine of its own — the
+    /// context it reads lives on the engine (`set_default_tag`), so the two
+    /// cannot share one. The borrow is held only across the pop and the push,
+    /// never across evaluation, so re-entry finds the cell free.
+    ///
+    /// Thread-local because the pool needs no locking that way, and evaluation
+    /// is synchronous within whichever thread is drawing or keying a frame.
+    static ENGINE_POOL: RefCell<Vec<Engine>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Run `f` with an engine, borrowed from this thread's pool or built if the
+/// pool is empty, and return the engine afterwards for the next evaluation.
+///
+/// An engine that panics its way out is simply not returned; the next call
+/// builds a fresh one.
+fn with_engine<R>(f: impl FnOnce(&mut Engine) -> R) -> R {
+    let mut engine = ENGINE_POOL
+        .with(|pool| pool.borrow_mut().pop())
+        .unwrap_or_else(make_engine);
+
+    let result = f(&mut engine);
+
+    // Drop the context this evaluation put on the engine, so a pooled engine
+    // never carries one comp's document into another comp's evaluation.
+    engine.set_default_tag(Dynamic::UNIT);
+    ENGINE_POOL.with(|pool| pool.borrow_mut().push(engine));
+
+    result
+}
+
 /// Run `expression` at `time` and hand back whatever it produced, untouched.
 /// The typed wrappers below decide what to make of it.
 fn eval_dynamic(
     expression: &str,
     context: Option<Arc<ExpressionContext>>,
 ) -> Result<Dynamic, Box<rhai::EvalAltResult>> {
-    let mut engine = make_engine();
-
     let mut scope = Scope::new();
 
-    match context {
-        Some(context) => {
-            // TODO: figure out how to access context state from engine context
-            // engine.set_default_tag( Dynamic:: Box::new(context));
-
-            if context.current_depth >= MAXIMUM_DEPTH {
-                eprintln!("Expression hit maximum recursion depth");
-                return Err(Box::new(rhai::EvalAltResult::ErrorSystem(
-                    "".into(),
-                    "".into(),
-                )));
-            }
-
-            apply_context_to_scope(&mut scope, &context);
-
-            engine.set_default_tag(Dynamic::from(context.clone()));
+    if let Some(context) = context.as_ref() {
+        if context.current_depth >= MAXIMUM_DEPTH {
+            return Err(Box::new(rhai::EvalAltResult::ErrorSystem(
+                "expression".into(),
+                "expressions nest more than a hundred deep — most likely two \
+                 properties refer to each other"
+                    .into(),
+            )));
         }
-        None => (),
+
+        apply_context_to_scope(&mut scope, context);
     }
 
-    engine.eval_expression_with_scope::<Dynamic>(&mut scope, expression)
+    with_engine(|engine| {
+        if let Some(context) = context {
+            engine.set_default_tag(Dynamic::from(context));
+        }
+
+        engine.eval_expression_with_scope::<Dynamic>(&mut scope, expression)
+    })
 }
 
 const MAXIMUM_DEPTH: u32 = 100;
 
-pub fn evaluate(expression: &String, context: Option<Arc<ExpressionContext>>) -> f64 {
+pub fn evaluate(expression: &str, context: Option<Arc<ExpressionContext>>) -> f64 {
     convert_result(eval_dynamic(expression, context))
 }
 
+/// Evaluate an expression for its **words** rather than its number — what a
+/// text layer whose content is expression-driven shows at `time`.
+///
+/// Every result type is welcome: a number prints as a number, a string as
+/// itself. The point of the feature is putting a value on screen, and refusing
+/// a type would only mean the user has to wrap it in a conversion.
+///
+/// A broken expression prints nothing rather than failing the frame — these are
+/// typed against a live preview, where a half-written expression is invalid for
+/// most of the time it takes to write it.
 pub fn evaluate_text(expression: &str, context: Option<Arc<ExpressionContext>>) -> String {
     match eval_dynamic(expression, context) {
         Ok(val) => val.to_string(),
-        Err(e) => {
-            eprintln!("Expression error: {:?}", e.unwrap_inner());
-            String::new()
-        }
+        Err(_) => String::new(),
     }
 }
 
+/// Sample an expression across a span of time — what the graph editor draws as
+/// a curve.
+///
+/// The expression is compiled once and then run per sample, which is the whole
+/// reason this exists separately from calling [`evaluate`] in a loop.
+///
+/// An expression that does not compile yields **no samples at all**, not a row
+/// of zeroes: the graph has nothing truthful to draw for a line that is still
+/// being typed, and a flat curve at zero would read as a real answer.
 pub fn evaluate_range(
-    expression: &String,
+    expression: &str,
     context: Option<&ExpressionContext>,
     start: f64,
     end: f64,
     samples: i64,
 ) -> Vec<f64> {
-    let engine = make_engine();
+    with_engine(|engine| {
+        let Ok(ast) = engine.compile_expression(expression) else {
+            return Vec::new();
+        };
 
-    let compiled = engine.compile_expression(&expression);
-
-    let mut result: Vec<f64> = Vec::new();
-
-    match compiled {
-        Ok(ast) => {
-            let delta = (end - start) / (samples as f64);
-            for i in 0..samples {
-                let time = start + (delta * (i as f64));
-
+        let delta = (end - start) / (samples as f64);
+        (0..samples)
+            .map(|i| {
                 let mut scope = Scope::new();
                 let mut ctx = context.cloned();
 
-                match ctx.as_mut() {
-                    Some(ctx) => {
-                        ctx.comp_time = time;
-                        apply_context_to_scope(&mut scope, ctx);
-                    }
-                    None => (),
+                if let Some(ctx) = ctx.as_mut() {
+                    ctx.comp_time = start + (delta * (i as f64));
+                    apply_context_to_scope(&mut scope, ctx);
                 }
 
-                let v = engine.eval_ast_with_scope::<Dynamic>(&mut scope, &ast);
-                let v = convert_result(v);
-                result.push(v);
-            }
-        }
-        Err(_) => todo!(),
-    }
+                // The layer and comp helpers read the context off the engine,
+                // so a sampled expression that calls one needs it there too.
+                engine.set_default_tag(match ctx {
+                    Some(ctx) => Dynamic::from(Arc::new(ctx)),
+                    None => Dynamic::UNIT,
+                });
 
-    result
+                convert_result(engine.eval_ast_with_scope::<Dynamic>(&mut scope, &ast))
+            })
+            .collect()
+    })
 }
 
 fn convert_result(result: Result<Dynamic, Box<rhai::EvalAltResult>>) -> f64 {
-    match result {
-        Ok(val) => {
-            if val.is_float() {
-                return val.as_float().unwrap();
-            }
+    let Ok(val) = result else { return -1.0 };
+    as_f64(val).unwrap_or(-1.0)
+}
 
-            if val.is_int() {
-                let val = val.as_int().unwrap();
-                return val as f64;
-            }
-
-            if val.is_bool() {
-                return match val.as_bool().unwrap() {
-                    true => 1.0,
-                    false => 0.0,
-                };
-            }
-
-            eprintln!("Invalid expression result: {:?}", val.type_name());
-
-            -1.0
-        }
-        Err(e) => {
-            eprintln!("Expression error: {:?}", e.unwrap_inner());
-            -1.0
-        }
+/// A Rhai value read as a number, if it is one. Rhai keeps whole numbers and
+/// fractions as separate types, so `2` and `2.0` arrive differently and both
+/// have to be accepted.
+fn as_f64(val: Dynamic) -> Option<f64> {
+    if val.is_float() {
+        return val.as_float().ok();
     }
+    if val.is_int() {
+        return val.as_int().ok().map(|v| v as f64);
+    }
+    if val.is_bool() {
+        return val.as_bool().ok().map(|v| if v { 1.0 } else { 0.0 });
+    }
+    None
 }
 
 pub fn get_api_metadata() -> String {
-    let engine = make_engine();
-    engine.gen_fn_metadata_to_json(false).unwrap()
+    with_engine(|engine| engine.gen_fn_metadata_to_json(false).unwrap_or_default())
 }
 
 fn apply_context_to_scope(scope: &mut Scope<'_>, context: &ExpressionContext) {
+    // `time` comes off the context itself and is pushed unconditionally. It is
+    // the one constant that does not depend on finding a comp in the document,
+    // and every expression that animates reads it — scoping it to a successful
+    // comp lookup silently turns `time * 2` into an error, which resolves to
+    // nothing, which keys every frame the same and freezes the picture.
+    scope.push_constant("time", context.comp_time);
+
     let doc = &context.document;
 
     if let Some(comp_id) = context.comp {
@@ -190,7 +279,6 @@ fn apply_context_to_scope(scope: &mut Scope<'_>, context: &ExpressionContext) {
             scope.push_constant("comp_fps", comp.frame_rate.fps() as i64);
             scope.push_constant("num_markers", comp.markers.len() as i64);
             scope.push_constant("num_layers", comp.layers.len() as i64);
-            scope.push_constant("time", context.comp_time);
 
             if let Some(layer_id) = context.layer {
                 if let Some(layer) = comp.layers.iter().find(|l| l.id == layer_id) {
@@ -199,5 +287,210 @@ fn apply_context_to_scope(scope: &mut Scope<'_>, context: &ExpressionContext) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::model::{LinearColour, TextDocument};
+
+    fn document(expression: Option<&str>) -> TextDocument {
+        TextDocument {
+            text: "typed".into(),
+            expression: expression.map(str::to_owned),
+            size: 48.0,
+            fill: LinearColour([1.0, 1.0, 1.0, 1.0]),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    fn at(time: f64) -> Arc<ExpressionContext> {
+        let mut context = ExpressionContext::detached();
+        context.comp_time = time;
+        Arc::new(context)
+    }
+
+    /// The point of the feature: a number reaches the screen as words.
+    #[test]
+    fn a_number_prints_as_words() {
+        assert_eq!(evaluate_text("1 + 1", Some(at(0.0))), "2");
+        assert_eq!(evaluate_text("time", Some(at(3.0))), "3.0");
+        assert_eq!(evaluate_text("\"frame \" + 7", Some(at(0.0))), "frame 7");
+    }
+
+    /// A broken expression prints nothing rather than failing the frame.
+    #[test]
+    fn a_broken_expression_prints_nothing() {
+        assert_eq!(
+            evaluate_text("this is not an expression", Some(at(0.0))),
+            ""
+        );
+        assert_eq!(evaluate_text("no_such_variable", Some(at(0.0))), "");
+    }
+
+    /// `time` is readable with nothing but a detached context behind it.
+    ///
+    /// This is the regression test for scoping `time` to a successful comp
+    /// lookup: an expression that reads it then errors, resolves to nothing,
+    /// and keys every frame of the comp identically.
+    #[test]
+    fn time_is_readable_without_a_comp() {
+        assert_eq!(evaluate("time * 2.0", Some(at(1.5))), 3.0);
+        assert_ne!(
+            evaluate("time", Some(at(1.0))),
+            evaluate("time", Some(at(2.0)))
+        );
+    }
+
+    /// Without an expression the layer shows exactly what was typed, and the
+    /// typed words survive underneath one that is set.
+    #[test]
+    fn the_typed_words_are_kept_and_restored() {
+        assert_eq!(document(None).resolved_text(at(0.0)), "typed");
+        let driven = document(Some("time * 2"));
+        assert_eq!(driven.resolved_text(at(1.5)), "3.0");
+        assert_eq!(driven.text, "typed");
+    }
+
+    /// The same expression at the same time gives the same answer, on any
+    /// machine and any run — the determinism rule, applied to words.
+    #[test]
+    fn resolution_is_deterministic() {
+        let d = document(Some("noise(time) + time"));
+        assert_eq!(d.resolved_text(at(2.0)), d.resolved_text(at(2.0)));
+        assert_ne!(d.resolved_text(at(2.0)), d.resolved_text(at(3.0)));
+    }
+
+    /// A document written before expressions existed loads with none, and a
+    /// document with one round-trips.
+    #[test]
+    fn the_field_is_optional_on_disk() {
+        let old = r#"{"text":"hi","size":12.0,"fill":[1.0,1.0,1.0,1.0]}"#;
+        let d: TextDocument = serde_json::from_str(old).unwrap();
+        assert_eq!(d.expression, None);
+        // Absent rather than null, so an untouched project file does not grow.
+        assert!(!serde_json::to_string(&d).unwrap().contains("expression"));
+
+        let driven = document(Some("time"));
+        let json = serde_json::to_string(&driven).unwrap();
+        assert_eq!(serde_json::from_str::<TextDocument>(&json).unwrap(), driven);
+    }
+
+    /// An engine handed back to the pool must not carry the last evaluation's
+    /// context into the next one. Reusing engines is only safe because the tag
+    /// is cleared on the way back.
+    #[test]
+    fn a_pooled_engine_does_not_leak_its_context() {
+        assert_eq!(evaluate("time", Some(at(7.0))), 7.0);
+        // No context at all: `time` must be unknown again, not still 7.
+        assert_eq!(evaluate_text("time", None), "");
+    }
+
+    /// A comp holding `layers`, filed in a document — the least scaffolding an
+    /// expression that refers to another layer can be evaluated against.
+    fn doc_with(layers: Vec<crate::model::Layer>) -> (Arc<Document>, Uuid) {
+        use crate::model::{Composition, ProjectItem};
+        use crate::time::{Duration, FrameRate, Rational};
+
+        let comp = Composition {
+            id: Uuid::now_v7(),
+            name: "c".into(),
+            width: 1920,
+            height: 1080,
+            frame_rate: FrameRate::new(60, 1).unwrap(),
+            duration: Duration(Rational::new(10, 1).unwrap()),
+            background: crate::model::LinearColour::BLACK,
+            work_area: None,
+            layers,
+            markers: Vec::new(),
+            motion_blur: Default::default(),
+            extra: serde_json::Map::new(),
+        };
+        let id = comp.id;
+        let mut doc = Document::new();
+        doc.items.push(ProjectItem::Composition(comp));
+        (Arc::new(doc), id)
+    }
+
+    /// A solid layer named `name` whose x position is driven by `expression`.
+    fn driven_layer(name: &str, expression: &str) -> crate::model::Layer {
+        use crate::anim::Animation;
+        use crate::model::{LayerKind, Switches, TransformGroup};
+        use crate::time::{CompTime, Rational};
+
+        let at = |s: i64| CompTime(Rational::new(s, 1).unwrap());
+        let mut transform = TransformGroup::default();
+        transform.position_x.animation = Animation::Expression(expression.into());
+
+        crate::model::Layer {
+            id: Uuid::now_v7(),
+            name: name.into(),
+            kind: LayerKind::Solid {
+                def: Uuid::now_v7(),
+            },
+            in_point: at(0),
+            out_point: at(10),
+            start_offset: at(0),
+            transform,
+            matte: None,
+            parent: None,
+            label: 0,
+            volume_db: crate::anim::Property::zero(),
+            retime: None,
+            blend: Default::default(),
+            masks: Vec::new(),
+            effects: Vec::new(),
+            switches: Switches::default(),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// Expressions nest — a property may read another property that is itself
+    /// an expression — so evaluation has to survive being re-entered while an
+    /// engine is already checked out of the pool. This is the test that fails
+    /// if engines are shared rather than pooled.
+    #[test]
+    fn evaluation_can_re_enter_itself() {
+        let driven = driven_layer("Driven", "time * 3.0");
+        let driven_id = driven.id;
+        let (document, comp) = doc_with(vec![driven]);
+
+        let context = Arc::new(ExpressionContext {
+            document,
+            comp: Some(comp),
+            layer: Some(driven_id),
+            comp_time: 2.0,
+            current_depth: 0,
+        });
+        assert_eq!(evaluate("layer(\"Driven\").x + 1.0", Some(context)), 7.0);
+    }
+
+    /// Two properties that read each other must give up rather than recurse
+    /// until the stack runs out.
+    #[test]
+    fn a_cycle_stops_instead_of_overflowing() {
+        let a = driven_layer("A", "layer(\"B\").x");
+        let a_id = a.id;
+        let (document, comp) = doc_with(vec![a, driven_layer("B", "layer(\"A\").x")]);
+
+        let context = Arc::new(ExpressionContext {
+            document,
+            comp: Some(comp),
+            layer: Some(a_id),
+            comp_time: 0.0,
+            current_depth: 0,
+        });
+        // The value is meaningless; returning at all is the point.
+        let _ = evaluate("layer(\"A\").x", Some(context));
+    }
+
+    /// A graph curve for an expression that does not compile is no curve, not
+    /// a flat line at zero that reads as a real answer.
+    #[test]
+    fn an_uncompilable_expression_samples_to_nothing() {
+        assert!(evaluate_range("this is not (", None, 0.0, 1.0, 8).is_empty());
+        assert_eq!(evaluate_range("time", None, 0.0, 4.0, 4).len(), 4);
     }
 }

--- a/crates/lumit-core/src/expression/comp.rs
+++ b/crates/lumit-core/src/expression/comp.rs
@@ -1,9 +1,14 @@
-use rhai::{plugin::*, TypeBuilder};
+use rhai::plugin::*;
 use uuid::Uuid; // a "prelude" import for macros
 
+// Rhai's `#[export_module]` expands to argument-unwrapping code of its own,
+// which trips `clippy::unwrap_used` on the generated `&mut` receivers. The
+// lint is about *our* unwraps, and there is no way to spell these differently
+// short of dropping the macro, so it is switched off for the generated module
+// only — not for the module's callers, and not for the helpers above.
+#[allow(clippy::unwrap_used)]
 #[export_module]
 pub mod comp {
-    use std::{eprintln, sync::Arc};
 
     use crate::expression::ExpressionContext;
 
@@ -14,9 +19,7 @@ pub mod comp {
 
     /// get the current composition
     pub fn comp(context: NativeCallContext) -> Comp {
-        let tag = context.engine().default_tag();
-
-        let context = tag.clone_cast::<Arc<ExpressionContext>>();
+        let context = ExpressionContext::from_call(&context);
 
         match context.comp {
             Some(comp) => Comp { id: Some(comp) },
@@ -27,15 +30,14 @@ pub mod comp {
     /// get the name of a composition
     #[rhai_fn(get = "name")]
     pub fn name(context: NativeCallContext, this: &mut Comp) -> String {
-        let tag = context.engine().default_tag();
-        let context = tag.clone_cast::<Arc<ExpressionContext>>();
-        
+        let context = ExpressionContext::from_call(&context);
+
         if let Some(id) = this.id {
             if let Some(comp) = context.document.comp(id) {
                 return comp.name.clone();
             }
         }
-        
+
         "Invalid Comp Reference".into()
     }
 }

--- a/crates/lumit-core/src/expression/layer.rs
+++ b/crates/lumit-core/src/expression/layer.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use rhai::{plugin::*, TypeBuilder};
+use rhai::plugin::*;
 use uuid::Uuid;
 
-use crate::{
-    expression::{layer, ExpressionContext},
-    model,
-};
+use crate::{expression::ExpressionContext, model};
 
 #[derive(Clone, CustomType)]
 pub struct Layer {
@@ -15,8 +12,7 @@ pub struct Layer {
 }
 
 fn get_layer(context: &NativeCallContext, this: &Layer) -> Option<model::Layer> {
-    let tag = context.engine().default_tag();
-    let context = tag.clone_cast::<Arc<ExpressionContext>>();
+    let context = ExpressionContext::from_call(context);
 
     if let Some(id) = this.comp_id {
         if let Some(comp) = context.document.comp(id) {
@@ -32,9 +28,8 @@ fn get_layer(context: &NativeCallContext, this: &Layer) -> Option<model::Layer> 
 }
 
 fn _time(context: &NativeCallContext, this: &mut Layer) -> f64 {
-    if let Some(layer) = get_layer(&context, this) {
-        let tag = context.engine().default_tag();
-        let context = tag.clone_cast::<Arc<ExpressionContext>>();
+    if let Some(layer) = get_layer(context, this) {
+        let context = ExpressionContext::from_call(context);
 
         return context.comp_time - layer.in_point.0.to_f64();
     }
@@ -42,18 +37,44 @@ fn _time(context: &NativeCallContext, this: &mut Layer) -> f64 {
     -1.0
 }
 
+/// One of the referenced layer's transform properties, evaluated at that
+/// layer's own time.
+///
+/// Every property getter below is this same handful of steps with a different
+/// field picked out, so they share it: find the layer, work out its local time,
+/// and evaluate the property under a context that has been re-pointed at *that*
+/// layer and stepped one level deeper — the depth is what stops two properties
+/// that refer to each other from recursing forever.
+fn transform_property(
+    call: &NativeCallContext,
+    this: &mut Layer,
+    pick: impl Fn(&model::TransformGroup) -> &crate::anim::Property,
+) -> f64 {
+    let Some(layer) = get_layer(call, this) else {
+        return -1.0;
+    };
+
+    let t = _time(call, this);
+
+    let mut context = ExpressionContext::from_call(call).increase_depth();
+    context.layer = this.layer_id;
+
+    pick(&layer.transform).value_at_with_context(t, Arc::new(context))
+}
+
+// Rhai's `#[export_module]` expands to argument-unwrapping code of its own,
+// which trips `clippy::unwrap_used` on the generated `&mut` receivers. The
+// lint is about *our* unwraps, and there is no way to spell these differently
+// short of dropping the macro, so it is switched off for the generated module
+// only — not for the module's callers, and not for the helpers above.
+#[allow(clippy::unwrap_used)]
 #[export_module]
 pub mod layers {
-    use std::{eprintln, sync::Arc};
-
-
     use Layer;
 
     /// get the current layer
     pub fn layer(context: NativeCallContext) -> Layer {
-        let tag = context.engine().default_tag();
-
-        let context = tag.clone_cast::<Arc<ExpressionContext>>();
+        let context = ExpressionContext::from_call(&context);
 
         match context.comp {
             Some(comp) => match context.layer {
@@ -76,9 +97,7 @@ pub mod layers {
     #[rhai_fn(name = "layer")]
     /// get a layer by name
     pub fn layer_by_name(context: NativeCallContext, name: String) -> Layer {
-        let tag = context.engine().default_tag();
-
-        let context = tag.clone_cast::<Arc<ExpressionContext>>();
+        let context = ExpressionContext::from_call(&context);
 
         match context.comp {
             Some(c) => {
@@ -122,160 +141,48 @@ pub mod layers {
     /// x coordinate of the layer's position
     #[rhai_fn(get = "x")]
     pub fn x(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-
-            let x = layer
-                .transform
-                .position_x
-                .value_at_with_context(t, c.clone());
-            return x;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.position_x)
     }
 
     /// y coordinate of the layer's position
     #[rhai_fn(get = "y")]
     pub fn y(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let y = layer
-                .transform
-                .position_y
-                .value_at_with_context(t, c.clone());
-            return y;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.position_y)
     }
 
     /// value of the layer's rotation
     #[rhai_fn(get = "rotation")]
     pub fn rotation(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let r = layer.transform.rotation.value_at_with_context(t, c.clone());
-            return r;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.rotation)
     }
 
     /// x component of the layer's scale
     #[rhai_fn(get = "scale_x")]
     pub fn scale_x(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let v = layer.transform.scale_x.value_at_with_context(t, c.clone());
-            return v;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.scale_x)
     }
 
     /// y component of the layer's scale
     #[rhai_fn(get = "scale_y")]
     pub fn scale_y(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let v = layer.transform.scale_y.value_at_with_context(t, c.clone());
-            return v;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.scale_y)
     }
 
     /// x coordinate of the layer's anchor
     #[rhai_fn(get = "anchor_x")]
     pub fn anchor_x(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let v = layer.transform.anchor_x.value_at_with_context(t, c.clone());
-            return v;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.anchor_x)
     }
 
-    /// y coordinate of the layer's position
+    /// y coordinate of the layer's anchor
     #[rhai_fn(get = "anchor_y")]
     pub fn anchor_y(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-            let v = layer.transform.anchor_y.value_at_with_context(t, c.clone());
-            return v;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.anchor_y)
     }
 
     /// layer's current opacity
     #[rhai_fn(get = "opacity")]
     pub fn opacity(context: NativeCallContext, this: &mut Layer) -> f64 {
-        if let Some(layer) = get_layer(&context, this) {
-            let t = _time(&context, this);
-
-            let tag = context.engine().default_tag();
-            let context = tag.clone_cast::<Arc<ExpressionContext>>();
-
-            let mut context = context.increase_depth();
-            context.layer = this.layer_id;
-            let c = Arc::new(context);
-
-            let v = layer.transform.opacity.value_at_with_context(t, c.clone());
-            return v;
-        }
-
-        -1.0
+        transform_property(&context, this, |tr| &tr.opacity)
     }
 }

--- a/crates/lumit-core/src/expression/math.rs
+++ b/crates/lumit-core/src/expression/math.rs
@@ -27,28 +27,17 @@ fn noise1d(x: f64) -> f64 {
     n0 * (1.0 - t) + n1 * t
 }
 
-
+// Rhai's `#[export_module]` expands to argument-unwrapping code of its own,
+// which trips `clippy::unwrap_used` on the generated `&mut` receivers. The
+// lint is about *our* unwraps, and there is no way to spell these differently
+// short of dropping the macro, so it is switched off for the generated module
+// only — not for the module's callers, and not for the helpers above.
+#[allow(clippy::unwrap_used)]
 #[export_module]
 pub mod math {
 
     pub fn to_f64(value: Dynamic) -> f64 {
-        if value.is_int() {
-            return value.as_int().unwrap() as f64;
-        }
-
-        if value.is_float() {
-            return value.as_float().unwrap();
-        }
-
-        if value.is_bool() {
-            if value.as_bool().unwrap() {
-                return 1.0;
-            } else {
-                return 0.0;
-            }
-        }
-
-        return -1.0;
+        crate::expression::as_f64(value).unwrap_or(-1.0)
     }
 
     /// compute the sine of a value
@@ -66,7 +55,7 @@ pub mod math {
     }
 
     pub fn cosh(value: Dynamic) -> f64 {
-        to_f64(value).sinh()
+        to_f64(value).cosh()
     }
 
     pub fn floor(value: Dynamic) -> f64 {

--- a/crates/lumit-core/src/fx/resolved.rs
+++ b/crates/lumit-core/src/fx/resolved.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use super::markers::flash_nth;
 use super::*;
-use crate::{expression::ExpressionContext, model::{EffectInstance, EffectNamespace, EffectValue}};
+use crate::{
+    expression::ExpressionContext,
+    model::{EffectInstance, EffectNamespace, EffectValue},
+};
 
 /// The Fast motion blur output view (docs/08 §3.2, FX-19): the finished blurred
 /// picture, or a diagnostic look at the motion field or the confidence that
@@ -704,8 +707,6 @@ fn resolve_one(
     markers: &MarkerContext,
     expression_context: Arc<ExpressionContext>,
 ) -> Option<Resolved> {
-
-
     match e.effect.match_name.as_str() {
         "blur" => {
             // Gaussian blur (docs/08 §3.8, K-137). match_name "blur" is kept,
@@ -714,8 +715,13 @@ fn resolve_one(
             // (its now-unread mode/length/centre params are simply ignored).
             // Fixed Repeat edge (K-137 dropped the Gaussian Edges control; 1 was
             // its default).
-            let radius_pct = e.float_at_with_context("radius", lt, expression_context.clone())? as f32;
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let radius_pct =
+                e.float_at_with_context("radius", lt, expression_context.clone())? as f32;
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Blur {
                 radius_px: (radius_pct / 100.0 * diag_px).max(0.0),
                 edge: 1,
@@ -725,9 +731,17 @@ fn resolve_one(
         "directional_blur" => {
             // Directional blur (docs/08 §3.8, K-137): Length/Angle only, fixed
             // Repeat edge (the Edges control is Radial's alone now).
-            let length_pct = e.float_at_with_context("length", lt, expression_context.clone()).unwrap_or(0.0) as f32;
-            let angle_deg = e.float_at_with_context("angle", lt, expression_context.clone()).unwrap_or(0.0) as f32;
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let length_pct = e
+                .float_at_with_context("length", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32;
+            let angle_deg = e
+                .float_at_with_context("angle", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32;
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::DirBlur {
                 length_px: (length_pct / 100.0 * diag_px).max(0.0),
                 angle_deg,
@@ -738,9 +752,17 @@ fn resolve_one(
         "radial_blur" => {
             // Radial blur (docs/08 §3.8, K-137): Centre/Amount/Type, plus the
             // family's own Edges control (kept only here).
-            let cx = (e.float_at_with_context("centre_x", lt, expression_context.clone()).unwrap_or(50.0) / 100.0) as f32;
-            let cy = (e.float_at_with_context("centre_y", lt, expression_context.clone()).unwrap_or(50.0) / 100.0) as f32;
-            let amount_pct = e.float_at_with_context("amount", lt, expression_context.clone()).unwrap_or(0.0) as f32;
+            let cx = (e
+                .float_at_with_context("centre_x", lt, expression_context.clone())
+                .unwrap_or(50.0)
+                / 100.0) as f32;
+            let cy = (e
+                .float_at_with_context("centre_y", lt, expression_context.clone())
+                .unwrap_or(50.0)
+                / 100.0) as f32;
+            let amount_pct = e
+                .float_at_with_context("amount", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32;
             let spin = !matches!(e.param("radial_type"), Some(EffectValue::Choice(1)));
             // The reusable Edges control (P3, K-145): the stored Choice maps
             // through EdgesMode (clamped to the known set, default Repeat).
@@ -750,7 +772,11 @@ fn resolve_one(
                 }
                 _ => EdgesMode::Repeat,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::RadialBlur {
                 centre_frac: [cx, cy],
                 amount_px: (amount_pct / 100.0 * diag_px).max(0.0),
@@ -760,14 +786,24 @@ fn resolve_one(
             })
         }
         "sharpen" => {
-            let amount = (e.float_at_with_context("amount", lt, expression_context.clone())? as f32 / 100.0).clamp(0.0, 3.0);
-            let radius_pct = e.float_at_with_context("radius", lt, expression_context.clone())? as f32;
-            let threshold = (e.float_at_with_context("threshold", lt, expression_context.clone()).unwrap_or(0.05) as f32).clamp(0.0, 1.0);
+            let amount =
+                (e.float_at_with_context("amount", lt, expression_context.clone())? as f32 / 100.0)
+                    .clamp(0.0, 3.0);
+            let radius_pct =
+                e.float_at_with_context("radius", lt, expression_context.clone())? as f32;
+            let threshold = (e
+                .float_at_with_context("threshold", lt, expression_context.clone())
+                .unwrap_or(0.05) as f32)
+                .clamp(0.0, 1.0);
             let luma_only = match e.param("luminance_only") {
                 Some(EffectValue::Bool(b)) => *b,
                 _ => true,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Sharpen {
                 amount,
                 radius_px: (radius_pct / 100.0 * diag_px).max(0.0),
@@ -779,9 +815,18 @@ fn resolve_one(
         "sharpen_simple" => {
             // The plain 3×3 sharpen (docs/08 §3.9, K-138): Amount is a raw
             // high-pass strength (not a per-cent), clamped ≥ 0.
-            let amount = (e.float_at_with_context("amount", lt, expression_context.clone())? as f32).max(0.0);
-            let radius = (e.float_at_with_context("radius", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(1.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let amount = (e.float_at_with_context("amount", lt, expression_context.clone())?
+                as f32)
+                .max(0.0);
+            let radius = (e
+                .float_at_with_context("radius", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::SharpenSimple {
                 amount,
                 radius,
@@ -789,15 +834,22 @@ fn resolve_one(
             })
         }
         "rgb_split" => {
-            let amount_pct = e.float_at_with_context("amount", lt, expression_context.clone())? as f32;
-            let angle_deg = e.float_at_with_context("angle", lt, expression_context.clone()).unwrap_or(0.0) as f32;
+            let amount_pct =
+                e.float_at_with_context("amount", lt, expression_context.clone())? as f32;
+            let angle_deg = e
+                .float_at_with_context("angle", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32;
             // Instances saved before the Wavelength mode existed carry
             // no such parameter and resolve as the classic split.
             let wavelength = match e.param("wavelength") {
                 Some(EffectValue::Bool(b)) => *b,
                 _ => false,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             let amount_px = (amount_pct / 100.0 * diag_px).max(0.0);
             // The three tap tints (T17/K-161): absent on pre-feature projects →
             // the classic red / green / blue, which reproduce the historical
@@ -818,7 +870,10 @@ fn resolve_one(
                 // default 16, denser than the historical 9). RGB split is now
                 // linear-only (T17), so the spectral sibling is never radial here.
                 // The picker drives the dispersion gradient (A1/K-163).
-                let samples = e.float_at_with_context("samples", lt, expression_context.clone()).unwrap_or(16.0).round() as i32;
+                let samples = e
+                    .float_at_with_context("samples", lt, expression_context.clone())
+                    .unwrap_or(16.0)
+                    .round() as i32;
                 Resolved::SpectralSplit {
                     amount_px,
                     angle_deg,
@@ -830,8 +885,11 @@ fn resolve_one(
             } else {
                 // Per-tap scales (FX-9): per cent → factor. Absent on
                 // pre-feature projects → the classic 1 / 0 / 1 defaults.
-                let scale =
-                    |id: &str, default: f64| (e.float_at_with_context(id, lt, expression_context.clone()).unwrap_or(default) / 100.0) as f32;
+                let scale = |id: &str, default: f64| {
+                    (e.float_at_with_context(id, lt, expression_context.clone())
+                        .unwrap_or(default)
+                        / 100.0) as f32
+                };
                 Resolved::RgbSplit {
                     amount_px,
                     angle_deg,
@@ -848,8 +906,16 @@ fn resolve_one(
             })
         }
         "chromatic_aberration" => {
-            let amount_px = (e.float_at_with_context("amount", lt, expression_context.clone()).unwrap_or(4.0) as f32 * px_scale).max(0.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let amount_px = (e
+                .float_at_with_context("amount", lt, expression_context.clone())
+                .unwrap_or(4.0) as f32
+                * px_scale)
+                .max(0.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             // Wavelength mode (K-144) reuses RGB split's spectral machinery as
             // a radial spectral split; off (and absent on pre-feature
             // projects) keeps the three tinted radial taps.
@@ -868,7 +934,10 @@ fn resolve_one(
                 tint("channel_colour_3", [0.0, 0.0, 1.0, 1.0]),
             ];
             Some(if wavelength {
-                let samples = e.float_at_with_context("samples", lt, expression_context.clone()).unwrap_or(16.0).round() as i32;
+                let samples = e
+                    .float_at_with_context("samples", lt, expression_context.clone())
+                    .unwrap_or(16.0)
+                    .round() as i32;
                 Resolved::SpectralSplit {
                     amount_px,
                     angle_deg: 0.0,
@@ -899,25 +968,42 @@ fn resolve_one(
                 // from the §1.4 context; Strobe thins the beat list to
                 // every Nth.
                 1 | 2 => {
-                    let duration = e.float_at_with_context("duration", lt, expression_context.clone()).unwrap_or(2.0).max(0.0);
+                    let duration = e
+                        .float_at_with_context("duration", lt, expression_context.clone())
+                        .unwrap_or(2.0)
+                        .max(0.0);
                     let fade = matches!(e.param("shape"), Some(EffectValue::Choice(1)));
                     let nth = if mode == 2 { flash_nth(e, lt) } else { 1 };
-                    let phase = e.float_at_with_context("phase", lt, expression_context.clone()).unwrap_or(0.0);
+                    let phase = e
+                        .float_at_with_context("phase", lt, expression_context.clone())
+                        .unwrap_or(0.0);
                     flash_beat_envelope(markers, lt, duration, fade, nth, phase)
                 }
                 // Manual: keyframed hits on Trigger, decaying over
                 // Decay — the original form, untouched.
                 _ => {
-                    let decay_s = (e.float_at_with_context("decay", lt, expression_context.clone()).unwrap_or(120.0) / 1000.0).max(0.0);
+                    let decay_s = (e
+                        .float_at_with_context("decay", lt, expression_context.clone())
+                        .unwrap_or(120.0)
+                        / 1000.0)
+                        .max(0.0);
                     match e.param("trigger") {
                         Some(EffectValue::Float(p)) => flash_envelope(p, lt, decay_s),
                         _ => 0.0,
                     }
                 }
             };
-            let intensity = e.float_at_with_context("intensity", lt, expression_context.clone()).unwrap_or(100.0).max(0.0) / 100.0;
+            let intensity = e
+                .float_at_with_context("intensity", lt, expression_context.clone())
+                .unwrap_or(100.0)
+                .max(0.0)
+                / 100.0;
             let colour = e.colour_at("colour", lt).unwrap_or([1.0; 4]);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Flash {
                 strength: (envelope * intensity).clamp(0.0, 1.0) as f32,
                 colour: colour.map(|c| c as f32),
@@ -929,7 +1015,11 @@ fn resolve_one(
                 let c = e.colour_at(id, lt).unwrap_or([neutral; 4]);
                 [c[0] as f32, c[1] as f32, c[2] as f32]
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::ColourBalance {
                 lift: rgb("lift", 0.0),
                 gamma: rgb("gamma", 1.0).map(|g| g.max(0.01)),
@@ -940,16 +1030,31 @@ fn resolve_one(
         "saturation" => {
             // Floored at 0 (greyscale), open above (K-135): the luma/colour
             // mix extrapolates past 200 % cleanly, so no upper clamp.
-            let saturation =
-                (e.float_at_with_context("saturation", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).max(0.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let saturation = (e
+                .float_at_with_context("saturation", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .max(0.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Saturation { saturation, mix })
         }
         "vibrancy" => {
             // Floored at 0 (neutral), open above (K-135): the per-pixel factor
             // extrapolates cleanly, so no upper clamp.
-            let amount = (e.float_at_with_context("amount", lt, expression_context.clone()).unwrap_or(0.0) as f32 / 100.0).max(0.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let amount = (e
+                .float_at_with_context("amount", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32
+                / 100.0)
+                .max(0.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Vibrancy { amount, mix })
         }
         "matte_key" => {
@@ -969,23 +1074,47 @@ fn resolve_one(
                 Some(EffectValue::Choice(c)) => *c,
                 _ => 0,
             };
-            let gain = (e.float_at_with_context("screen_gain", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).max(0.0);
-            let balance =
-                (e.float_at_with_context("screen_balance", lt, expression_context.clone()).unwrap_or(50.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let gain = (e
+                .float_at_with_context("screen_gain", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .max(0.0);
+            let balance = (e
+                .float_at_with_context("screen_balance", lt, expression_context.clone())
+                .unwrap_or(50.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             // Despill defaults on (Keylight-like); an older instance carrying a
             // Spill value keeps it, an even older one without the param reads 0.
-            let spill = (e.float_at_with_context("spill", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let clip_black =
-                (e.float_at_with_context("clip_black", lt, expression_context.clone()).unwrap_or(0.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let clip_white =
-                (e.float_at_with_context("clip_white", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let clip_rollback =
-                (e.float_at_with_context("clip_rollback", lt, expression_context.clone()).unwrap_or(0.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let spill = (e
+                .float_at_with_context("spill", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let clip_black = (e
+                .float_at_with_context("clip_black", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let clip_white = (e
+                .float_at_with_context("clip_white", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let clip_rollback = (e
+                .float_at_with_context("clip_rollback", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             let replace_method = match e.param("replace_method") {
                 Some(EffectValue::Choice(c)) => ReplaceMethod::from_code(*c).code(),
                 _ => ReplaceMethod::SoftColour.code(),
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::MatteKey(MatteKeyParams {
                 view: MatteKeyView::from_code(view).code(),
                 key: colour("key", [0.0, 0.6, 0.0, 1.0]),
@@ -1003,14 +1132,33 @@ fn resolve_one(
             }))
         }
         "vignette" => {
-            let amount = (e.float_at_with_context("amount", lt, expression_context.clone()).unwrap_or(0.5) as f32).clamp(0.0, 1.0);
-            let radius = (e.float_at_with_context("radius", lt, expression_context.clone()).unwrap_or(0.75) as f32).clamp(0.0, 1.0);
+            let amount = (e
+                .float_at_with_context("amount", lt, expression_context.clone())
+                .unwrap_or(0.5) as f32)
+                .clamp(0.0, 1.0);
+            let radius = (e
+                .float_at_with_context("radius", lt, expression_context.clone())
+                .unwrap_or(0.75) as f32)
+                .clamp(0.0, 1.0);
             // Floored at 0, open above (K-135): softness > 1 is a legal wider
             // feather in the normalised metric, no upper clamp.
-            let softness = (e.float_at_with_context("softness", lt, expression_context.clone()).unwrap_or(0.5) as f32).max(0.0);
-            let roundness = (e.float_at_with_context("roundness", lt, expression_context.clone()).unwrap_or(1.0) as f32).clamp(0.0, 1.0);
-            let ramp = (e.float_at_with_context("ramp", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.05);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let softness = (e
+                .float_at_with_context("softness", lt, expression_context.clone())
+                .unwrap_or(0.5) as f32)
+                .max(0.0);
+            let roundness = (e
+                .float_at_with_context("roundness", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .clamp(0.0, 1.0);
+            let ramp = (e
+                .float_at_with_context("ramp", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.05);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Vignette {
                 amount,
                 radius,
@@ -1021,13 +1169,21 @@ fn resolve_one(
             })
         }
         "exposure" => {
-            let stops = e.float_at_with_context("stops", lt, expression_context.clone()).unwrap_or(0.0);
+            let stops = e
+                .float_at_with_context("stops", lt, expression_context.clone())
+                .unwrap_or(0.0);
             let factor = 2f64.powf(stops) as f32;
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Exposure { factor, mix })
         }
         "hue_shift" => {
-            let angle = e.float_at_with_context("angle", lt, expression_context.clone()).unwrap_or(0.0);
+            let angle = e
+                .float_at_with_context("angle", lt, expression_context.clone())
+                .unwrap_or(0.0);
             // Preserve luminance (K-136): on (default, and absent on old
             // projects) → the Rec.709 constant-luminance rotation; off → the
             // plain-RGB spin about the grey axis. The bool only picks which
@@ -1041,21 +1197,40 @@ fn resolve_one(
             } else {
                 hue_matrix_rgb(angle)
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::HueShift { m, mix })
         }
         "contrast" => {
             // k = contrast_percent / 100; hard min 0 (no inversion),
             // unbounded above — the schema's own honest shape.
-            let k = (e.float_at_with_context("contrast", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).max(0.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let k = (e
+                .float_at_with_context("contrast", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .max(0.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Contrast { k, mix })
         }
         "gamma" => {
             // Hard floor 0.01 keeps 1/gamma finite; no ceiling — the
             // schema's own honest shape.
-            let gamma = (e.float_at_with_context("gamma", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.01);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let gamma = (e
+                .float_at_with_context("gamma", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.01);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Gamma { gamma, mix })
         }
         "temperature" => {
@@ -1066,10 +1241,18 @@ fn resolve_one(
             // WGSL kernel multiply by byte-identical f32 factors (§1.6);
             // Temperature 0 → k 0 → gains exactly (1.0, 1.0), the neutral
             // point (the .max(0.0) leaves 1.0 untouched).
-            let k = (e.float_at_with_context("temperature", lt, expression_context.clone()).unwrap_or(0.0) as f32 / 100.0).clamp(-2.0, 2.0);
+            let k = (e
+                .float_at_with_context("temperature", lt, expression_context.clone())
+                .unwrap_or(0.0) as f32
+                / 100.0)
+                .clamp(-2.0, 2.0);
             let gain_r = (1.0 + 0.75 * k).max(0.0);
             let gain_b = (1.0 - 0.75 * k).max(0.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Temperature {
                 gain_r,
                 gain_b,
@@ -1077,7 +1260,11 @@ fn resolve_one(
             })
         }
         "invert" => {
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Invert { mix })
         }
         "tint" => {
@@ -1088,7 +1275,11 @@ fn resolve_one(
                 let c = e.colour_at(id, lt).unwrap_or(default);
                 [c[0] as f32, c[1] as f32, c[2] as f32]
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Tint {
                 black: rgb("black", [0.0, 0.0, 0.0, 1.0]),
                 white: rgb("white", [1.0, 1.0, 1.0, 1.0]),
@@ -1102,7 +1293,11 @@ fn resolve_one(
             // effect always resolves to exactly one Resolved::Lut, so the
             // ordered enabled-builtin-`lut` list stays 1:1 and in order with
             // the Resolved::Lut ops — the whole threading contract.
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Lut { mix })
         }
         "dof" => {
@@ -1111,8 +1306,14 @@ fn resolve_one(
             // the LUT cube is. A `dof` effect always resolves to exactly one
             // Resolved::Dof, so the ordered enabled-builtin-`dof` list stays
             // 1:1 and in order with the Dof ops — the threading contract.
-            let focus = (e.float_at_with_context("focus", lt, expression_context.clone()).unwrap_or(0.5) as f32).clamp(0.0, 1.0);
-            let range = (e.float_at_with_context("range", lt, expression_context.clone()).unwrap_or(0.1) as f32).clamp(0.0, 1.0);
+            let focus = (e
+                .float_at_with_context("focus", lt, expression_context.clone())
+                .unwrap_or(0.5) as f32)
+                .clamp(0.0, 1.0);
+            let range = (e
+                .float_at_with_context("range", lt, expression_context.clone())
+                .unwrap_or(0.1) as f32)
+                .clamp(0.0, 1.0);
             // Aperture is the px@comp master; Near/Far are the per-side
             // radii it scales about its default 8 (unity). A pre-feature
             // project has only `aperture` and lacks Near/Far, which then
@@ -1120,9 +1321,16 @@ fn resolve_one(
             // 8·(aperture/8)·px_scale = aperture·px_scale — identical to the
             // old single-aperture behaviour. px@comp is scaled by the §2.3
             // preview factor so a Half preview blurs the same disc as Full.
-            let master = e.float_at_with_context("aperture", lt, expression_context.clone()).unwrap_or(8.0) as f32 / 8.0;
-            let near = e.float_at_with_context("near_aperture", lt, expression_context.clone()).unwrap_or(8.0) as f32;
-            let far = e.float_at_with_context("far_aperture", lt, expression_context.clone()).unwrap_or(8.0) as f32;
+            let master = e
+                .float_at_with_context("aperture", lt, expression_context.clone())
+                .unwrap_or(8.0) as f32
+                / 8.0;
+            let near = e
+                .float_at_with_context("near_aperture", lt, expression_context.clone())
+                .unwrap_or(8.0) as f32;
+            let far = e
+                .float_at_with_context("far_aperture", lt, expression_context.clone())
+                .unwrap_or(8.0) as f32;
             // Budget cap (docs/13, docs/14): the disc gather is O(coc²) taps
             // per pixel, and the Aperture master MULTIPLIES the per-side radii
             // (so Aperture 150 × Near 55 becomes a ~1000 px circle of
@@ -1142,7 +1350,11 @@ fn resolve_one(
                 Some(EffectValue::Choice(c)) => (*c).min(2),
                 _ => 0,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Dof {
                 focus,
                 range,
@@ -1156,12 +1368,27 @@ fn resolve_one(
         "glow" => {
             // Radius is px@comp (K-135), scaled by the §2.3 preview factor so
             // a Half preview blurs the same halo as Full, only softer.
-            let radius = e.float_at_with_context("radius", lt, expression_context.clone()).unwrap_or(24.0) as f32;
-            let threshold = (e.float_at_with_context("threshold", lt, expression_context.clone()).unwrap_or(0.8) as f32).max(0.0);
-            let knee = (e.float_at_with_context("knee", lt, expression_context.clone()).unwrap_or(0.5) as f32).clamp(0.0, 1.0);
-            let intensity = (e.float_at_with_context("intensity", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.0);
+            let radius = e
+                .float_at_with_context("radius", lt, expression_context.clone())
+                .unwrap_or(24.0) as f32;
+            let threshold = (e
+                .float_at_with_context("threshold", lt, expression_context.clone())
+                .unwrap_or(0.8) as f32)
+                .max(0.0);
+            let knee = (e
+                .float_at_with_context("knee", lt, expression_context.clone())
+                .unwrap_or(0.5) as f32)
+                .clamp(0.0, 1.0);
+            let intensity = (e
+                .float_at_with_context("intensity", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.0);
             let tint = e.colour_at("tint", lt).unwrap_or([1.0; 4]);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Glow {
                 radius_px: (radius * px_scale).max(0.0),
                 threshold,
@@ -1172,17 +1399,41 @@ fn resolve_one(
             })
         }
         "shake" => {
-            let amp_pct = (e.float_at_with_context("amplitude", lt, expression_context.clone()).unwrap_or(1.5) as f32).max(0.0);
-            let freq = e.float_at_with_context("frequency", lt, expression_context.clone()).unwrap_or(8.0).max(0.0);
-            let rot_amount = (e.float_at_with_context("rotation", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.0);
+            let amp_pct = (e
+                .float_at_with_context("amplitude", lt, expression_context.clone())
+                .unwrap_or(1.5) as f32)
+                .max(0.0);
+            let freq = e
+                .float_at_with_context("frequency", lt, expression_context.clone())
+                .unwrap_or(8.0)
+                .max(0.0);
+            let rot_amount = (e
+                .float_at_with_context("rotation", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.0);
             // Per-axis wobble (twirl group, K-146): amount multipliers scale
             // the master Amplitude, frequency multipliers the master rate.
             // Defaults of 1 reproduce the old uniform x/y shake exactly.
-            let x_amp = (e.float_at_with_context("x_amp", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.0);
-            let y_amp = (e.float_at_with_context("y_amp", lt, expression_context.clone()).unwrap_or(1.0) as f32).max(0.0);
-            let x_freq = e.float_at_with_context("x_freq", lt, expression_context.clone()).unwrap_or(1.0).max(0.0);
-            let y_freq = e.float_at_with_context("y_freq", lt, expression_context.clone()).unwrap_or(1.0).max(0.0);
-            let z_freq = e.float_at_with_context("z_freq", lt, expression_context.clone()).unwrap_or(1.0).max(0.0);
+            let x_amp = (e
+                .float_at_with_context("x_amp", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.0);
+            let y_amp = (e
+                .float_at_with_context("y_amp", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32)
+                .max(0.0);
+            let x_freq = e
+                .float_at_with_context("x_freq", lt, expression_context.clone())
+                .unwrap_or(1.0)
+                .max(0.0);
+            let y_freq = e
+                .float_at_with_context("y_freq", lt, expression_context.clone())
+                .unwrap_or(1.0)
+                .max(0.0);
+            let z_freq = e
+                .float_at_with_context("z_freq", lt, expression_context.clone())
+                .unwrap_or(1.0)
+                .max(0.0);
             // z (depth/scale) amount: the new id, else the old `zoom_pump`
             // (migration — a project saved before FX-11 keeps its pump), a
             // scale-pump per cent either way.
@@ -1207,7 +1458,11 @@ fn resolve_one(
                 Some(EffectValue::Seed(s)) => *s,
                 _ => 0,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             // The wobble: independent noise channels sampled at local time ×
             // frequency (per axis, §3.4) — deterministic, hop-free, identical
             // on every machine (§2.4). One sampler drives the frame-time wobble
@@ -1232,7 +1487,9 @@ fn resolve_one(
             // (the bit-exact passthrough). The centre offset is 0, so the middle
             // sample equals the frame-time wobble exactly.
             let motion_blur = e.bool_of("motion_blur").unwrap_or(false);
-            let mb_amount = e.float_at_with_context("mb_amount", lt, expression_context.clone()).unwrap_or(0.5);
+            let mb_amount = e
+                .float_at_with_context("mb_amount", lt, expression_context.clone())
+                .unwrap_or(0.5);
             let mb = (motion_blur && mb_amount > 0.0).then(|| {
                 let mut samples = [ShakeSample::IDENTITY; SHAKE_MB_SAMPLES];
                 for (s, db) in samples.iter_mut().zip(shake_mb_offsets(mb_amount)) {
@@ -1255,7 +1512,10 @@ fn resolve_one(
             })
         }
         "block_glitch" => {
-            let intensity = (e.float_at_with_context("intensity", lt, expression_context.clone()).unwrap_or(0.35) as f32).clamp(0.0, 1.0);
+            let intensity = (e
+                .float_at_with_context("intensity", lt, expression_context.clone())
+                .unwrap_or(0.35) as f32)
+                .clamp(0.0, 1.0);
             let seed = match e.param("seed") {
                 Some(EffectValue::Seed(s)) => *s,
                 _ => 0,
@@ -1263,15 +1523,32 @@ fn resolve_one(
             // Local time discretised at the fixed tick rate (§3.12
             // status note): block hashing reads this, never raw time.
             let tick = (lt * GLITCH_TICK_HZ).floor() as i32;
-            let block_size_px =
-                (e.float_at_with_context("block_size", lt, expression_context.clone()).unwrap_or(24.0) as f32 * px_scale).max(1.0);
-            let jitter_frac =
-                (e.float_at_with_context("block_jitter", lt, expression_context.clone()).unwrap_or(25.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let amount_pct = e.float_at_with_context("block_amount", lt, expression_context.clone()).unwrap_or(3.0) as f32;
-            let chan_pct = e.float_at_with_context("channel_offset", lt, expression_context.clone()).unwrap_or(1.0) as f32;
-            let slice_frac =
-                (e.float_at_with_context("slice_repeat", lt, expression_context.clone()).unwrap_or(20.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let block_size_px = (e
+                .float_at_with_context("block_size", lt, expression_context.clone())
+                .unwrap_or(24.0) as f32
+                * px_scale)
+                .max(1.0);
+            let jitter_frac = (e
+                .float_at_with_context("block_jitter", lt, expression_context.clone())
+                .unwrap_or(25.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let amount_pct = e
+                .float_at_with_context("block_amount", lt, expression_context.clone())
+                .unwrap_or(3.0) as f32;
+            let chan_pct = e
+                .float_at_with_context("channel_offset", lt, expression_context.clone())
+                .unwrap_or(1.0) as f32;
+            let slice_frac = (e
+                .float_at_with_context("slice_repeat", lt, expression_context.clone())
+                .unwrap_or(20.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::BlockGlitch {
                 intensity,
                 seed,
@@ -1290,15 +1567,26 @@ fn resolve_one(
             // param (0..100): fold it in, so the loaded look is the old
             // Intensity × Darkness product exactly. A new project has no
             // Darkness param, so the raw Intensity stands.
-            let raw = e.float_at_with_context("intensity", lt, expression_context.clone()).unwrap_or(0.35);
-            let folded = match e.float_at_with_context("scanline_darkness", lt, expression_context.clone()) {
+            let raw = e
+                .float_at_with_context("intensity", lt, expression_context.clone())
+                .unwrap_or(0.35);
+            let folded = match e.float_at_with_context(
+                "scanline_darkness",
+                lt,
+                expression_context.clone(),
+            ) {
                 Some(darkness_pct) => raw * (darkness_pct / 100.0),
                 None => raw,
             };
             let intensity = (folded as f32).clamp(0.0, 1.0);
-            let period_px =
-                (e.float_at_with_context("scanline_period", lt, expression_context.clone()).unwrap_or(3.0) as f32 * px_scale).max(1.0);
-            let roll_speed = e.float_at_with_context("scanline_roll", lt, expression_context.clone()).unwrap_or(0.0);
+            let period_px = (e
+                .float_at_with_context("scanline_period", lt, expression_context.clone())
+                .unwrap_or(3.0) as f32
+                * px_scale)
+                .max(1.0);
+            let roll_speed = e
+                .float_at_with_context("scanline_roll", lt, expression_context.clone())
+                .unwrap_or(0.0);
             // The scanline pattern's pixel offset at this frame (roll
             // speed × local time × period), so the kernel never sees
             // raw time or does its own time maths (§2.4: the CPU/GPU
@@ -1309,7 +1597,11 @@ fn resolve_one(
                 Some(EffectValue::Bool(b)) => *b,
                 _ => false,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Scanlines {
                 intensity,
                 period_px,
@@ -1323,20 +1615,31 @@ fn resolve_one(
             // > 1 extrapolates past the moshed frame. Displacement supersedes
             // the K-148 `streak_length` id (read as a fallback so an old
             // project keeps its reach); default 4 frames.
-            let intensity = (e.float_at_with_context("intensity", lt, expression_context.clone()).unwrap_or(0.5) as f32).max(0.0);
+            let intensity = (e
+                .float_at_with_context("intensity", lt, expression_context.clone())
+                .unwrap_or(0.5) as f32)
+                .max(0.0);
             let displacement = e
                 .float_at_with_context("displacement", lt, expression_context.clone())
-                .or_else(|| e.float_at_with_context("streak_length", lt, expression_context.clone()))
+                .or_else(|| {
+                    e.float_at_with_context("streak_length", lt, expression_context.clone())
+                })
                 .unwrap_or(4.0)
                 .max(1.0) as f32;
-            let bloom = (e.float_at_with_context("bloom", lt, expression_context.clone()).unwrap_or(0.6) as f32).clamp(0.0, 1.0);
+            let bloom = (e
+                .float_at_with_context("bloom", lt, expression_context.clone())
+                .unwrap_or(0.6) as f32)
+                .clamp(0.0, 1.0);
             // Periodic I-frame reset (K-164): the melt ramps from a clean frame
             // just after each reset up to full by the next. A pure function of
             // layer time `lt` (seconds), so the kernel stays time-agnostic and
             // the frame-cache key already covers it (a param+time function, the
             // K-093/K-094 reasoning). 0 = off (a constant melt); the content-
             // driven reset at stills/cuts (zero flow) fires regardless.
-            let interval = (e.float_at_with_context("reset_interval", lt, expression_context.clone()).unwrap_or(0.0)).max(0.0);
+            let interval = (e
+                .float_at_with_context("reset_interval", lt, expression_context.clone())
+                .unwrap_or(0.0))
+            .max(0.0);
             let ramp = if interval > 0.0 {
                 (lt / interval).rem_euclid(1.0) as f32
             } else {
@@ -1352,7 +1655,11 @@ fn resolve_one(
             } else {
                 (eff_displacement.round() as i32).clamp(2, 64)
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Datamosh {
                 intensity: eff_intensity,
                 displacement: eff_displacement,
@@ -1366,8 +1673,15 @@ fn resolve_one(
             // decay^k (v1 fixed one-frame spacing); the render supplies
             // the neighbour frame at each offset. weights[i] is the echo
             // at offset -(i+1). Up to 16 echoes (FX-17/K-149).
-            let count = (e.float_at_with_context("echoes", lt, expression_context.clone()).unwrap_or(4.0).round() as i32).clamp(1, 16);
-            let decay = (e.float_at_with_context("decay", lt, expression_context.clone()).unwrap_or(0.6) as f32).clamp(0.0, 1.0);
+            let count = (e
+                .float_at_with_context("echoes", lt, expression_context.clone())
+                .unwrap_or(4.0)
+                .round() as i32)
+                .clamp(1, 16);
+            let decay = (e
+                .float_at_with_context("decay", lt, expression_context.clone())
+                .unwrap_or(0.6) as f32)
+                .clamp(0.0, 1.0);
             // Combine blend mode; the default when the param is absent matches
             // the schema default (Screen, index 3). Clamped to the 0..=13 range
             // the CPU oracle and WGSL kernel branch over (T21).
@@ -1375,7 +1689,11 @@ fn resolve_one(
                 Some(EffectValue::Choice(c)) => (*c).min(13),
                 _ => 3,
             };
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             let mut weights = [0.0f32; 16];
             for (i, w) in weights.iter_mut().enumerate() {
                 if (i as i32) < count {
@@ -1389,10 +1707,21 @@ fn resolve_one(
             // (the motion itself) is threaded to the kernel separately.
             // Samples is the spec's integer carried as a Float row —
             // rounded and clamped to the same 2..64 the kernel loops.
-            let shutter_frac =
-                (e.float_at_with_context("shutter_angle", lt, expression_context.clone()).unwrap_or(180.0) as f32 / 360.0).max(0.0);
-            let samples = (e.float_at_with_context("samples", lt, expression_context.clone()).unwrap_or(16.0).round() as i32).clamp(2, 64);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let shutter_frac = (e
+                .float_at_with_context("shutter_angle", lt, expression_context.clone())
+                .unwrap_or(180.0) as f32
+                / 360.0)
+                .max(0.0);
+            let samples = (e
+                .float_at_with_context("samples", lt, expression_context.clone())
+                .unwrap_or(16.0)
+                .round() as i32)
+                .clamp(2, 64);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             // View (FX-19): a diagnostic look at the flow or confidence, else the
             // blurred picture. An older project without the row reads Rendered.
             let view = match e.param("view") {
@@ -1410,16 +1739,33 @@ fn resolve_one(
         "transform" => {
             // px@comp parameters scale by the preview factor (§2.3) so
             // Half preview frames exactly like Full, only softer.
-            let px = |id: &str| e.float_at_with_context(id, lt, expression_context.clone()).unwrap_or(0.0) as f32 * px_scale;
-            let pct = |id: &str| e.float_at_with_context(id, lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0;
-            let opacity =
-                (e.float_at_with_context("opacity", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
-            let mix = (e.float_at_with_context("mix", lt, expression_context.clone()).unwrap_or(100.0) as f32 / 100.0).clamp(0.0, 1.0);
+            let px = |id: &str| {
+                e.float_at_with_context(id, lt, expression_context.clone())
+                    .unwrap_or(0.0) as f32
+                    * px_scale
+            };
+            let pct = |id: &str| {
+                e.float_at_with_context(id, lt, expression_context.clone())
+                    .unwrap_or(100.0) as f32
+                    / 100.0
+            };
+            let opacity = (e
+                .float_at_with_context("opacity", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
+            let mix = (e
+                .float_at_with_context("mix", lt, expression_context.clone())
+                .unwrap_or(100.0) as f32
+                / 100.0)
+                .clamp(0.0, 1.0);
             Some(Resolved::Transform {
                 anchor: [px("anchor_x"), px("anchor_y")],
                 position: [px("position_x"), px("position_y")],
                 scale: [pct("scale_x"), pct("scale_y")],
-                rotation_deg: e.float_at_with_context("rotation", lt, expression_context.clone()).unwrap_or(0.0) as f32,
+                rotation_deg: e
+                    .float_at_with_context("rotation", lt, expression_context.clone())
+                    .unwrap_or(0.0) as f32,
                 opacity,
                 mix,
             })

--- a/crates/lumit-core/src/lib.rs
+++ b/crates/lumit-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! (docs/05-ARCHITECTURE.md dependency rules).
 
 pub mod anim;
+pub mod expression;
 pub mod fx;
 pub mod lut;
 pub mod markers;
@@ -15,7 +16,6 @@ pub mod retime;
 pub mod sequence;
 pub mod store;
 pub mod time;
-pub mod expression;
 
 pub use model::Document;
 pub use ops::{Op, OpError};

--- a/crates/lumit-core/src/model.rs
+++ b/crates/lumit-core/src/model.rs
@@ -591,14 +591,18 @@ impl EffectInstance {
             _ => None,
         }
     }
-    
-    pub fn float_at_with_context(&self, id: &str, lt: f64, context: Arc<ExpressionContext>) -> Option<f64> {
+
+    pub fn float_at_with_context(
+        &self,
+        id: &str,
+        lt: f64,
+        context: Arc<ExpressionContext>,
+    ) -> Option<f64> {
         match self.param(id)? {
             EffectValue::Float(p) => Some(p.value_at_with_context(lt, context)),
             _ => None,
         }
     }
-    
 
     /// A colour parameter's evaluated scene-linear RGBA at layer time `lt`
     /// (channels animate independently), or None when absent or not a
@@ -615,7 +619,12 @@ impl EffectInstance {
         }
     }
 
-    pub fn colour_at_with_context(&self, id: &str, lt: f64, context: Arc<ExpressionContext>) -> Option<[f64; 4]> {
+    pub fn colour_at_with_context(
+        &self,
+        id: &str,
+        lt: f64,
+        context: Arc<ExpressionContext>,
+    ) -> Option<[f64; 4]> {
         match self.param(id)? {
             EffectValue::Colour(ch) => Some([
                 ch[0].value_at_with_context(lt, context.clone()),
@@ -910,9 +919,7 @@ impl TextDocument {
     pub fn resolved_text(&self, context: Arc<ExpressionContext>) -> std::borrow::Cow<'_, str> {
         match &self.expression {
             None => std::borrow::Cow::Borrowed(&self.text),
-            Some(e) => {
-                std::borrow::Cow::Owned(crate::expression::evaluate_text(e, Some(context)))
-            }
+            Some(e) => std::borrow::Cow::Owned(crate::expression::evaluate_text(e, Some(context))),
         }
     }
 }

--- a/crates/lumit-eval/src/lib.rs
+++ b/crates/lumit-eval/src/lib.rs
@@ -23,7 +23,10 @@
 
 use std::sync::Arc;
 
-use lumit_core::{expression::ExpressionContext, model::{Composition, Document, LayerKind, MatteChannel}};
+use lumit_core::{
+    expression::ExpressionContext,
+    model::{Composition, Document, LayerKind, MatteChannel},
+};
 use uuid::Uuid;
 
 pub mod epoch;
@@ -77,7 +80,12 @@ pub fn comp_frame_key(
 ) -> Option<FrameKey> {
     let mut visited = Vec::new();
     let mut h = blake3::Hasher::new();
-    feed_comp(&mut h, doc, comp, t, quality, stamper, &mut visited)?;
+    // Taken once per key, not once per layer. An expression context needs an
+    // owned handle on the document, and cloning the project per layer is
+    // quadratic in layer count — 30ms a frame at two hundred layers, which is
+    // twice the whole 60fps budget spent before anything is drawn.
+    let doc = Arc::new(doc.clone());
+    feed_comp(&mut h, &doc, comp, t, quality, stamper, &mut visited)?;
     let bytes = h.finalize();
     let mut k = [0u8; 16];
     k.copy_from_slice(&bytes.as_bytes()[..16]);
@@ -86,7 +94,7 @@ pub fn comp_frame_key(
 
 fn feed_comp(
     h: &mut blake3::Hasher,
-    doc: &Document,
+    doc: &Arc<Document>,
     comp: &Composition,
     t: f64,
     quality: Quality,
@@ -174,7 +182,7 @@ fn feed_effect_stack(
     effects: &[lumit_core::model::EffectInstance],
     marker_layer: &lumit_core::model::Layer,
     comp: &Composition,
-    doc: &Document,
+    doc: &Arc<Document>,
     t: f64,
     lt: f64,
     quality: Quality,
@@ -186,7 +194,7 @@ fn feed_effect_stack(
         return Some(());
     }
     h.update(b"effects/");
-    
+
     // The §1.4 marker context, built lazily (only marker-driven effects read
     // it) by the same shared constructor resolution uses (K-031), so the key
     // hashes exactly the beat times resolution sees.
@@ -380,7 +388,7 @@ fn feed_effect_stack(
 #[allow(clippy::too_many_arguments)]
 fn feed_layer(
     h: &mut blake3::Hasher,
-    doc: &Document,
+    doc: &Arc<Document>,
     comp: &Composition,
     layer: &lumit_core::model::Layer,
     t: f64,
@@ -393,7 +401,7 @@ fn feed_layer(
     feed_source(h, doc, comp, layer, lt, t, quality, stamper, visited)?;
 
     let context = Arc::new(ExpressionContext {
-        document: Arc::new(doc.clone()),
+        document: doc.clone(),
         comp: Some(comp.id),
         layer: Some(layer.id),
         comp_time: t,
@@ -625,9 +633,10 @@ fn blend_tag(b: lumit_core::model::BlendMode) -> u8 {
 
 /// The layer's source pixels as content (docs/06 §5.2 "node type id ‖
 /// algorithm version, evaluated parameters, key(inputs)").
+#[allow(clippy::too_many_arguments)]
 fn feed_source(
     h: &mut blake3::Hasher,
-    doc: &Document,
+    doc: &Arc<Document>,
     // The comp the layer sits in — the expression context a text layer's words
     // may be resolved through, so the key hashes the line the rasteriser will
     // actually draw.
@@ -702,7 +711,7 @@ fn feed_source(
             // stored text would key them all the same and freeze the first
             // frame it rendered on screen for the rest of the comp.
             let context = ExpressionContext {
-                document: Arc::new(doc.clone()),
+                document: doc.clone(),
                 comp: Some(owner.id),
                 layer: Some(layer.id),
                 comp_time,

--- a/crates/lumit-media/Cargo.toml
+++ b/crates/lumit-media/Cargo.toml
@@ -11,7 +11,7 @@ test-fixtures = []
 [dependencies]
 bincode = "1"
 blake3 = "1"
-rsmpeg = { version = "0.18", default-features = false, features = ["ffmpeg6", "link_system_ffmpeg"] }
+rsmpeg = { version = "0.18", default-features = false, features = ["ffmpeg7_1", "link_system_ffmpeg"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 

--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -150,6 +150,13 @@ pub fn parent_world_placement(
         };
         let alt = t_comp - a.start_offset.0.to_f64();
         let tr = &a.transform;
+        // An ancestor's own expressions are about the ancestor: `layer()`,
+        // `cut_in` and `cut_out` must resolve to the layer being evaluated, not
+        // to the child that started the walk up the chain.
+        let context = Arc::new(ExpressionContext {
+            layer: Some(a.id),
+            ..(*context).clone()
+        });
         let p = lumit_gpu::place_matrix(
             (
                 tr.position_x.value_at_with_context(alt, context.clone()) as f32,
@@ -209,6 +216,14 @@ pub fn motion_blur_samples(
         .iter()
         .map(|off| {
             let lt = t_comp + off * dt - start_offset;
+            // Each shutter sample is a different moment, so an expression that
+            // reads `time` has to be evaluated at that moment. Reusing the
+            // frame's context would return the same placement for every sample
+            // and an expression-driven layer would simply not smear.
+            let context = Arc::new(ExpressionContext {
+                comp_time: t_comp + off * dt,
+                ..(*context).clone()
+            });
             lumit_gpu::MbSample {
                 position: (
                     tr.position_x.value_at_with_context(lt, context.clone()) as f32,
@@ -356,8 +371,6 @@ pub fn build_comp_draws_at(
     // planner (app_state::collect_comp_jobs) decodes layer-input references
     // exactly like matte sources, and export applies the same in-span-only
     // gate (K-031).
-
-
 
     let dof_inputs_for =
         |effects: &[lumit_core::model::EffectInstance]| -> Vec<Option<DofInputDraw>> {

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -4615,3 +4615,70 @@ this feature would otherwise ship with. So the rasteriser and the cache key ask
 the same one function for the line, and by construction cannot disagree: a
 counter keys a new frame each frame, and an expression that always says the same
 thing keys once and is reused, with nothing to configure either way.
+
+### Expressions, and why the engine is kept rather than built
+
+An expression is a line of code sitting where a number would normally sit. A
+property — position, rotation, opacity, an effect's knob — usually holds either
+a fixed value or a row of keyframes. With an expression it holds a small sum
+instead, and the answer is worked out afresh every time the property is read:
+`time * 90` spins a layer at ninety degrees a second without a single keyframe.
+
+The language is [Rhai](https://rhai.rs), a small scripting language that embeds
+into Rust. An expression can read a handful of things about where it is —
+`time`, `comp_width`, `comp_fps`, `cut_in` — and it can reach other layers:
+`layer("Sun").x` is the horizontal position of the layer called Sun, at this
+moment. That last one is what makes expressions worth having rather than a
+novelty, and it is also what makes them awkward to implement, for two reasons
+that are worth spelling out.
+
+**Expressions nest.** Asking for `layer("Sun").x` means evaluating Sun's own x
+property, and Sun's x may itself be an expression. So evaluating one expression
+can start another, part-way through, before the first has finished. In
+programming terms the evaluator is *re-entrant*: it has to cope with being
+called again while it is already running.
+
+**And they can chase their own tail.** If layer A's position reads layer B's,
+and B's reads A's, that nesting never bottoms out. Lumit counts how deep it has
+gone and gives up at a hundred, which is far more nesting than any real rig uses
+and far less than it takes to exhaust the stack and crash.
+
+Now the part that looks odd in the code. To run an expression you need an
+*engine* — the Rhai interpreter, with all of Lumit's functions (`sin`, `noise`,
+`layer`, `comp`) registered into it so expressions can call them. Building one
+is not cheap: registering those functions takes roughly 370 microseconds, which
+sounds like nothing until you notice how often expressions run.
+
+They run *constantly*. Every driven property is re-evaluated for every frame,
+and twice over: once by the renderer to draw the picture, and once by the frame
+cache to work out whether this frame is one it has already got. At sixty frames
+a second, a rig with a few dozen driven properties is tens of thousands of
+evaluations a second. At 370µs each, forty-odd of them would use up the entire
+budget for a frame before anything was drawn.
+
+The obvious fix is to build one engine and keep it. That does not quite work
+here, because the engine is where the *context* is parked — which comp, which
+layer, what time — and a nested evaluation needs a different context from the
+one that is running. One shared engine would have the inner expression trample
+the outer one's context.
+
+So Lumit keeps a small **pool**: a pile of ready-built engines. An evaluation
+takes one off the pile, uses it, and puts it back. A nested evaluation takes a
+second one, so the two never share. In practice the pile ends up as deep as the
+deepest nesting, which is nearly always one. The cost per evaluation drops from
+about 370 microseconds to about one — the engine is built once and then simply
+handed round.
+
+The same instinct applies a little further out. An expression needs to be able
+to look at the project — that is how `layer("Sun")` finds Sun — so it holds a
+reference to the document. Handing it a *copy* of the project would be tidy but
+ruinous: copying a two-hundred-layer project takes about 150µs, and doing that
+once per layer per frame is thirty milliseconds a frame, which is twice the
+whole budget, spent entirely on copying. So the project is shared rather than
+copied (an `Arc`, in Rust's terms — a single copy that many things can point at
+safely), and the sharing is set up once per frame rather than once per layer.
+
+The general lesson, which applies well beyond expressions: anything on the
+per-frame path is run tens of thousands of times a second, so the question is
+never "is this fast enough once", it is "what is this multiplied by sixty, by
+the number of layers".

--- a/flutter_ui/lib/panels/debug_panel.dart
+++ b/flutter_ui/lib/panels/debug_panel.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/panels/performance_view.dart';
 import 'package:lumit_flutter/widgets/controls.dart';

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -18,7 +18,6 @@
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:lumit_flutter/data/expressions_metadata.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -711,8 +711,19 @@ class ExpressionTextEditingController extends TextEditingController {
       {required BuildContext context,
       TextStyle? style,
       required bool withComposing}) {
+    final theme = ThemeScope.of(context).theme.mode == ThemeMode2.dark
+        ? darkTheme
+        : lightTheme;
 
-        final theme = ThemeScope.of(context).theme.mode == ThemeMode2.dark ? darkTheme! : lightTheme!;
+    // Highlighting is loaded asynchronously at startup by
+    // `initSyntaxHighlighting`, so there is a window in which it is not there
+    // yet — and a widget test never runs that startup at all. Draw the line
+    // plainly until it is ready rather than throwing, which is the same choice
+    // the completion list already makes when the engine has not answered.
+    if (theme == null) {
+      return super.buildTextSpan(
+          context: context, style: style, withComposing: withComposing);
+    }
 
     var highlighter = Highlighter(
       language: 'dart',

--- a/flutter_ui/lib/panels/graph_maths.dart
+++ b/flutter_ui/lib/panels/graph_maths.dart
@@ -157,7 +157,7 @@ double evaluateKeys(List<BridgeKeyframe> keys, double t) {
 double evaluateScalar(BridgeScalar scalar, double t) => switch (scalar) {
       BridgeScalar_Static(:final field0) => field0,
       BridgeScalar_Keyframed(:final field0) => evaluateKeys(field0, t),
-      BridgeScalar_Expression(:final field0) => () {
+      BridgeScalar_Expression() => () {
         debugPrint("TODO: implement evaluate scalar expression in flutter ui");
         return 0.0;
       }()

--- a/flutter_ui/lib/panels/performance_view.dart
+++ b/flutter_ui/lib/panels/performance_view.dart
@@ -16,7 +16,6 @@ extension FPS on Duration {
 }
 
 class _PerformanceMonitorState extends State<PerformanceMonitor> {
-  Duration? previous;
   List<Duration> timings = [];
 
   double fps = 0.0;
@@ -26,37 +25,49 @@ class _PerformanceMonitorState extends State<PerformanceMonitor> {
 
   @override
   void initState() {
-    SchedulerBinding.instance.addPostFrameCallback(update);
     super.initState();
+    SchedulerBinding.instance.addTimingsCallback(_onTimings);
   }
 
-  void update(Duration duration) {
-    if (previous != null) {
-      final frameDuration = duration - previous!;
-      timings.add(frameDuration);
+  @override
+  void dispose() {
+    SchedulerBinding.instance.removeTimingsCallback(_onTimings);
+    super.dispose();
+  }
 
-      final currentFps = frameDuration.fps;
+  /// Flutter hands over the timings of frames it has already drawn.
+  ///
+  /// This used to be a post-frame callback that re-registered itself, which
+  /// had two problems. It never stopped — nothing cancelled it, so after the
+  /// monitor closed it kept firing and calling setState on a dead State. And
+  /// asking for a callback every frame *is* asking for a frame every frame, so
+  /// the counter kept the app rendering flat out for as long as it was open
+  /// and then reported the frame rate it had itself caused. A test never
+  /// settled either, because the tree was never idle.
+  ///
+  /// `addTimingsCallback` is the measuring version of the same thing: it
+  /// reports frames that happened rather than causing them, so an idle app
+  /// reads as idle and the numbers describe the app instead of the monitor.
+  void _onTimings(List<FrameTiming> reported) {
+    if (!mounted || reported.isEmpty) return;
 
-      const maxFrames = 60;
-      if (timings.length > maxFrames) {
-        timings = timings.sublist(timings.length - maxFrames);
-      }
+    // `totalSpan` is vsync to raster finish — the whole cost of the frame.
+    timings.addAll(reported.map((t) => t.totalSpan));
 
-      final avg =
-          timings.fold(0.0, (v, t) => v + t.fps) / timings.length.toDouble();
-      final avgFrameTime =
-          timings.fold(0.0, (v, t) => v + t.ms) / timings.length.toDouble();
-      setState(() {
-        fps = currentFps;
-        frameTime = frameDuration.ms;
-        average = avg;
-        averageFrameTime = avgFrameTime;
-      });
+    const maxFrames = 60;
+    if (timings.length > maxFrames) {
+      timings = timings.sublist(timings.length - maxFrames);
     }
 
-    previous = duration;
-
-    SchedulerBinding.instance.addPostFrameCallback(update);
+    final latest = timings.last;
+    setState(() {
+      fps = latest.fps;
+      frameTime = latest.ms;
+      average =
+          timings.fold(0.0, (v, t) => v + t.fps) / timings.length.toDouble();
+      averageFrameTime =
+          timings.fold(0.0, (v, t) => v + t.ms) / timings.length.toDouble();
+    });
   }
 
   @override

--- a/flutter_ui/lib/panels/performance_view.dart
+++ b/flutter_ui/lib/panels/performance_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:lumit_flutter/panels/debug_panel.dart';
 import 'package:lumit_flutter/widgets/controls.dart';
 
 class PerformanceMonitor extends StatefulWidget {

--- a/flutter_ui/lib/panels/source_rows_frb.dart
+++ b/flutter_ui/lib/panels/source_rows_frb.dart
@@ -11,7 +11,6 @@
 // does.
 
 import 'package:flutter/widgets.dart';
-import 'package:lumit_flutter/data/expressions_metadata.dart';
 import 'package:lumit_flutter/panels/effect_param_row_frb.dart';
 import 'package:lumit_flutter/src/rust/api/assets.dart';
 import 'package:lumit_flutter/src/rust/api/effect.dart';

--- a/flutter_ui/lib/src/rust/api/effect.dart
+++ b/flutter_ui/lib/src/rust/api/effect.dart
@@ -11,7 +11,7 @@ import 'package:freezed_annotation/freezed_annotation.dart' hide protected;
 import 'package:uuid/uuid.dart';
 part 'effect.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `animation`, `param`, `presets_in`, `read_instance_info`, `read`, `read`, `read`, `read`, `write`, `write`, `write`
+// These functions are ignored because they are not marked as `pub`: `animation`, `document_for`, `param`, `presets_in`, `read_instance_info`, `read`, `read`, `read`, `read`, `write`, `write`, `write`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `get_effects`
 

--- a/flutter_ui/lib/widgets/autofill.dart
+++ b/flutter_ui/lib/widgets/autofill.dart
@@ -1,9 +1,7 @@
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:lumit_flutter/data/expressions_metadata.dart';
 import 'package:lumit_flutter/theme/theme.dart';
-import 'package:lumit_flutter/widgets/controls.dart';
 
 abstract class AutofillGenerator<T> {
   List<T> getSuggestions(String text, int cursor);

--- a/flutter_ui/lib/widgets/controls.dart
+++ b/flutter_ui/lib/widgets/controls.dart
@@ -601,6 +601,11 @@ class _HouseTextFieldState extends State<HouseTextField>
   @override
   void dispose() {
     widget.controller.removeListener(_changed);
+    // The completion list is an OverlayEntry, which lives in the Overlay rather
+    // than under this widget — so it outlives the field that opened it unless
+    // it is taken down here, and a field disposed with suggestions showing
+    // leaves them on screen over whatever comes next.
+    hideOverlay();
     _focus.dispose();
     super.dispose();
   }

--- a/flutter_ui/pubspec.lock
+++ b/flutter_ui/pubspec.lock
@@ -490,10 +490,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -719,10 +719,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Six commits on top of `expressions` (@Airyzz), meant as suggestions rather than a rewrite — the shape of the feature is yours and I have not touched the design calls. Take, drop, or argue with any commit individually; they are split so that is easy.

Everything below is measured on one machine, comparing like build profiles.

## What was broken

**The workspace did not compile.** `crates/lumit-media/Cargo.toml` had rsmpeg's feature switched from `ffmpeg7_1` to `ffmpeg6`. That picks the FFmpeg ABI the bindings generate against, and against the headers this project targets it fails outright — the avio write callback changed from `*mut u8` to `*const u8`. `cargo check --workspace` died there before reaching any Lumit code. Reverted; it reads like a local build tweak that travelled with the branch.

**A test on the branch was failing** — `expression_driven_text_keys_per_frame`, the regression test for the load-bearing part of K-210. Bisected to `82379e2d`, which moved `scope.push_constant("time", …)` inside the `if let Some(comp)` block. `time` then only existed when a comp resolved out of the document; everywhere else an expression reading it errored, resolved to nothing, and keyed every frame identically — the exact bug the text-expression work exists to prevent. That commit also deleted the whole `mod tests` for expressions rather than updating it for the new signature, so the evaluator had no tests left. Restored and extended.

**Two panics reachable from the UI.** `evaluate_range` ended in `todo!()` for an expression that does not compile — reachable by typing a half-finished expression with the graph editor open. `sample_scalar_range_with_context` ended in `todo!()` for any non-expression scalar, inside an `#[frb(sync)]` call, so it unwinds across the FFI boundary. Also `clone_cast` in the `layer`/`comp` helpers, which panics whenever the engine carries no context.

## The evaluator: ~370µs → ~1.08µs per evaluation

`make_engine` registers three modules' worth of functions and was running for **every** evaluation. The cost was flat regardless of what the expression said, which is the tell — it was all setup.

```
before   constant   : 377µs per eval   (16.6ms frame = 44 evals)
         sin/cos    : 348µs per eval   (16.6ms frame = 47 evals)
after    constant   : 1.08µs per eval  (16.6ms frame = 15,384 evals)
         sin/cos    : 2.68µs per eval  (16.6ms frame = 6,191 evals)
```

A single shared engine does not work here — the context lives on the engine via `set_default_tag`, and expressions nest, so an inner evaluation would trample the outer one's context. Hence a thread-local **pool**: take an engine, use it, put it back; a nested evaluation takes a second one. The `RefCell` borrow is held only across the pop and push, never across evaluation, so re-entry finds the cell free. The tag is cleared on return so a pooled engine cannot carry one comp's document into another's — there is a test for that, plus tests for re-entrancy and for cycles terminating.

This makes AST caching (your listed follow-up) much less urgent — parsing is now a small share of what is left.

## The per-layer project copy

`feed_layer` and `feed_source` each did `Arc::new(doc.clone())` — a deep copy of the entire project, per layer, per frame. It runs for every frame whether or not anything uses an expression, because the key is computed before anyone knows.

```
Document::clone   10 layers:   2.9µs      ×10  per frame =  29µs
                  50 layers:  37.9µs      ×50  per frame = 1.9ms
                 200 layers: 151.1µs      ×200 per frame =  30ms   <- twice the whole 60fps budget
```

The `feed_*` chain is private, so it now carries `&Arc<Document>` and the one real copy is taken once in `comp_frame_key`. 200 layers goes to 151µs a frame, and stops growing with the square of the layer count.

That last copy could go too by taking `&Arc<Document>` at the public seam (`comp_frame_key`, `cache::frame_key`, `build_comp_draws_at`) — the callers already hold one from `store.snapshot()`. That is a wider signature change through render and bridge, so I left it out rather than smuggling it in.

## Two wrong contexts in the render path

- `parent_world_placement` walked the parent chain evaluating each ancestor's transform but passed the **child's** context throughout, so an expression on a parent saw `layer()`, `cut_in` and `cut_out` belonging to its child.
- `motion_blur_samples` built one context at the frame's time and reused it for every shutter sample. Keyframes are fine there (the time argument is what is read) but `time` in an expression comes from the context — so every sample evaluated identically and an expression-driven transform got **no smear at all**.

## Smaller

`cosh` returned `sinh`. `to_f64` and `convert_result` were two copies of one conversion. `detached()` deep-copied an empty `Document` every call. The eight transform getters were the same twelve lines eight times, now one helper — which is also what makes the context fix apply once instead of eight times. `cargo fmt` had not been run (CI gates it). `expression_editor.dart` was committed empty. GUIDE.md explained the text feature but never expressions themselves, which K-007 asks for.

## Deliberately not touched — your calls, not mine

- **`-1.0` as the error value** for numeric expressions. A broken expression silently becoming a valid-looking coordinate feels wrong to me and text got it right (prints nothing), but it is a design decision and it is yours. Surfacing the error in the UI is probably the real answer, and that is a bigger conversation.
- **Rhai vs QuickJS-ng.** `docs/impl/expressions.md` is titled "Embedding QuickJS-ng deterministically" and K-063 picks it specifically for bit-identical cross-platform floats. Rhai's `sin`/`cos` go to platform libm, and determinism is a CI gate here. Needs a superseding entry with the argument written down, or a move — either way a decision, not a patch.
- **The scope creep** (fps monitor, `performance_view.dart`, the text-selection fix). All fine, all unrelated, and `performance_view.dart` is an add/add conflict with something main grew independently. Would merge on its own today.
- **The rebase.** This branch is 204 commits behind main with 14 conflicting files, four of them frb-generated — those want regenerating, not hand-resolving.
- **The Flutter side.** Untouched; I only ran the Rust suite.

## State

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets` zero warnings · `cargo test --workspace` 736 passed, 0 failed.