### PR TITLE
Hold the time readouts still, and let them be typed into (K-287)

### DIFF
--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6034,3 +6034,45 @@ machine-local" needs no narrowing for it after all. The disk cache's *Applies to
 stays in Settings → Performance: its whole purpose is choosing between the two scopes, so it is
 the one control that has to stand with a foot in each. Colour management and export defaults
 land in the new window when they are built, rather than back in Settings.
+
+**K-287 · DECIDED · The bars that carry time hold still: fixed slots, the progress bar on
+the transport, typed timecode, and a Retime that reads as a clock.** From the owner
+(2026-08-06). Five changes, all of them the same complaint — the parts of the interface
+that report *time* were moving while time passed, which is distracting exactly when the
+picture is being watched.
+
+- **The Viewer's preview progress bar moves onto the right-hand end of the transport**
+  (docs/07 §2.5), instead of floating over the bottom of the picture. Over the picture it
+  covered the composition while a frame was being waited for, which is when the
+  composition is being looked at hardest. On the bar it has a place of its own: the
+  controls take the space that is left over, so the bar arriving and leaving moves none of
+  them.
+- **Every part of the Viewer's bar whose text varies gets a fixed slot** (docs/07 §2.2),
+  sized for the longest thing it can ever say, and a part that comes and goes — the
+  degradation badge — keeps its slot while it is away.
+- **The playback-mode button says the mode and nothing else**: "Adaptive res" or "Every
+  frame". It used to carry the settled tier beside the name ("Adaptive · Half"), so it
+  re-lettered itself as the engine felt its way up and down the ladder. Which tier a frame
+  was made at is the degradation badge's job (docs/13 §4 still stands: silent degradation
+  is a bug — the badge is what says it, and it says it only while there is something to
+  say).
+- **The Timeline's timecode and frame readouts get the same fixed slots, and both become
+  click-to-type** (docs/07 §4.1). They sit left of the layer search, and a readout that
+  resized itself as it counted shoved the search field sideways through every second of
+  playback. Typing a time in either moves the playhead — the timecode in the format it
+  already shows, the frame readout as a plain number with or without its `f` — and a time
+  outside the composition is **clamped to the nearest end** rather than refused. The
+  Viewer's own clock gains the same typing, which docs/07 §2.2 item 11 had always asked
+  for.
+- **The Retime row reads as `HH:MM:SS:FF`**, not as a number of seconds, realising K-075's
+  value lens for the outline row (docs/04 §9.3). It is dragged and typed in whole source
+  frames, at the composition's rate — the read model does not carry the footage's own rate
+  yet, and every other time in the panel is counted in comp frames; when it does, this
+  readout moves to the footage's timebase as K-075 asks, with no change to what is stored.
+  Settings ▸ Interface ▸ Editing ▸ *Retime values in seconds* puts the decimal seconds
+  field back, and is the only way to state a source position between two frames.
+
+The shared widget is `TimeReadout` (`flutter_ui/lib/widgets/time_readout.dart`): a slot
+measured in characters of the face it draws in, a click that turns it into a field holding
+exactly what was shown, and an optional drag for the places that were a drag field before
+they were a clock.

--- a/docs/04-RETIMING.md
+++ b/docs/04-RETIMING.md
@@ -488,6 +488,12 @@ vertically after the edited segment.
 
 ### 9.3 Numeric entry and readouts
 
+- **The Retime row's own value reads as a timecode** (`HH:MM:SS:FF`, with a leading minus
+  for a source time before zero), not as a number of seconds — K-287, realising K-075's
+  value lens for the outline row. It is dragged and typed in whole source frames, at the
+  composition's rate until the read model carries the footage's own. Settings ▸ Interface ▸
+  Editing ▸ *Retime values in seconds* puts the decimal seconds field back, which is also
+  the only way to state a position between two frames.
 - Graph editor header: speed at the playhead (per cent, one decimal), resolved source
   timecode, and the segment's type chip (RATE / MAP) with its ease name.
 - Typing digits with a segment selected opens constant-speed entry (§9.2). Typing with a

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -299,9 +299,20 @@ A single compact bar at the bottom of the Viewer holds, left to right:
    steps. Users MUST be able to tell a degraded frame from a final one at a glance.
 10. **Background colour** swatch: per-comp background (project state), plus quick black /
     grey / custom.
-11. **Current time** readout in the comp's timecode; click to type a time.
+11. **Current time** readout in the comp's timecode; click to type a time. A time outside
+    the composition lands on the nearest end rather than being refused (K-287).
 
 The bar MUST remain one row; overflow collapses from the right into a chevron menu.
+
+**Nothing on the bar may move as the picture changes (K-287).** Every part of it whose
+text varies — the clock, the playback-mode button, the degradation badge, the preview
+progress — sits in a slot sized for the longest thing it can ever say, and a part that
+comes and goes keeps its slot while it is away. The bar is read while playback runs, and a
+control that re-letters or resizes itself sixty times a second is movement in the corner
+of the eye that means nothing. For the same reason the **playback-mode button says only
+which mode is in force** ("Adaptive res" or "Every frame") and never the tier it has
+settled on: which tier a frame was made at is item 9's badge, which appears only when
+there is something to say.
 
 ### 2.3 Layer controls: the wireframe and the transform gizmo (K-217)
 
@@ -601,11 +612,16 @@ the transport (§11) and cache system. During scrubs the Viewer shows latest-win
 results (K-017); stale frames MUST never be presented as current without the degradation
 indicator lit.
 
-**Preview progress (K-276).** A frame the user is waiting on — a scrub, a playhead move, a
-dragged value — MUST be able to say how far it has got: a slim bar across the bottom of the
-picture, filling as the engine works through the frame, labelled with the stage it is in
-(preparing, reading media, reading the composition, compositing, showing). Three rules make
-it a help rather than noise:
+**Preview progress (K-276, moved by K-287).** A frame the user is waiting on — a scrub, a
+playhead move, a dragged value — MUST be able to say how far it has got: a slim bar on the
+**right-hand end of the Viewer's transport bar**, filling as the engine works through the
+frame, labelled with the stage it is in (preparing, reading media, reading the
+composition, compositing, showing). It MUST NOT be drawn over the picture: the one thing
+the Viewer exists to show is the picture, and covering its bottom edge exactly while a
+frame is being waited for covers it when it is being looked at hardest. The bar's place on
+the transport is its own — the controls take the space that is left, so the bar arriving
+and leaving MUST NOT move any of them. Three further rules make it a help rather than
+noise:
 
 - It MUST NOT appear during playback. A frame due in sixteen milliseconds has no use for a
   progress bar, and one blinking per frame would be the busiest thing on screen.
@@ -741,7 +757,9 @@ project's: a tab dragged onto another takes its place, and the order rides along
 session. Right-clicking a tab opens **Composition settings…** for that comp, the same
 dialog the Project panel's context menu opens, reached from the comp being worked in. Below them the outline carries two header rows
 of its own: the **toolbar** (the playhead as `HH:MM:SS:FF` timecode plus a zero-based
-frame readout `f72`, the layer search, the master motion-blur button, the shy filter, the
+frame readout `f72` — both in **fixed-width slots** and both **click-to-type**, per K-287:
+a time typed into either moves the playhead, and one outside the composition lands on the
+nearest end — the layer search, the master motion-blur button, the shy filter, the
 Lane and Graph view buttons, and a ⋯ menu with the layer / razor / work-area / marker /
 beat commands) and the **column-group header** (§4.2). The lane side gives those two
 rows' height to a taller, labelled time ruler — a bigger playhead grab — with the cache

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3459,11 +3459,47 @@ behind it.
 - **The broader scope asks the narrower one first.** Flutter runs every key
   handler in registration order, so the shell's `Delete` asks the Timeline's claim
   before acting (K-234).
+- **A readout that counts must not resize as it counts** (K-287). Numbers get a
+  slot as wide as the longest thing they can ever say, and a badge that comes
+  and goes keeps its slot while it is away. See below.
 - **Tests must let real time pass.** `settleFrb` in
   `flutter_ui/test/frb/frb_test_support.dart` alternates real-time slices with
   fake-clock pumps until the expected state arrives; `await tester.pump()` alone
   advances no clock, and awaiting an engine call inside `runAsync` that was not
   started there deadlocks (K-233).
+
+### The clock readouts (`widgets/time_readout.dart`)
+
+**The problem, in plain terms.** Text is drawn as wide as it needs to be. `f9`
+is narrower than `f10`, and in most typefaces the digit `1` is narrower than the
+digit `8` — so a timecode counting up is a piece of text that changes width
+several times a second. Everything laid out beside it slides to keep up. During
+playback that means the Timeline's search field twitching sixty times a second,
+in the corner of your eye, for no reason anybody can act on.
+
+**The fix.** `TimeReadout` is one small widget every clock on a bar now uses. It
+does three things:
+
+- **It reserves its width.** You tell it how many characters the longest thing it
+  could ever say is — `00:00:00:00` is eleven — and it measures that many
+  characters of its own typeface *once*, caches the answer, and draws the number
+  inside a box of exactly that size. The number changes; the box never does.
+- **It can be typed into.** Clicking it swaps the text for a field already
+  holding what was on screen, selected, so typing replaces it. `Enter` or
+  clicking away takes what you typed; `Escape` throws it away. The widget knows
+  nothing about timecode: whoever uses it hands over a *format* function (a frame
+  number → the text) and a *parse* function (text → a frame number, or nothing if
+  it does not read as a time). That is why the same widget serves the Viewer's
+  clock, the Timeline's clock, the Timeline's `f72` frame count and the Retime
+  row's source position.
+- **It clamps rather than refuses.** A time past either end of the composition
+  lands on that end. Asking for frame 100000 in a 300-frame comp obviously means
+  "the end", and an error message would be a worse answer than the obvious one.
+
+The same "reserve the space" rule applies to things that are not text: the
+Viewer's degradation badge (the "Half" chip that appears when playback has had to
+soften the picture) keeps its empty slot when it is not showing, so it does not
+shove the bar sideways as it comes and goes.
 
 ## 10. The app icon and the brand files
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -77,8 +77,6 @@ These are v1-scope surfaces it does not yet match.
 **Viewer bar ([07-UI-SPEC.md](07-UI-SPEC.md) §2.2):**
 - The wireframe/overlay *menu*; guides menu; region-of-interest;
     colour-management indicator; background-colour swatch.
-- Click-to-edit timecode (read-only today) - decide whether it moves to the
-    Timeline's clock rather than being built twice.
 
 **Toolbar tools ([07-UI-SPEC.md](07-UI-SPEC.md) §1.7):** what is armed is a
 *tool*; what each tool then does is the backlog.

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -44,6 +44,7 @@ import '../state/tools.dart';
 import '../theme/theme.dart';
 import '../widgets/controls.dart';
 import '../widgets/marquee.dart';
+import '../widgets/time_readout.dart';
 // The ruler helpers moved with the ruler (shared with the graph editor); the
 // re-export keeps their long-standing import path alive for their tests.
 export 'timeline_extras_frb.dart' show rulerLabelStepSeconds, rulerLabelOf;
@@ -1870,6 +1871,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb> {
                                               comp: comp,
                                               model: ui.model,
                                               playhead: ui.playheadFrame,
+                                              onSeek: ui.scrubTo,
                                               graph: _graph,
                                               onToggleGraph: () => setState(
                                                   () => _graph = !_graph),
@@ -3475,8 +3477,12 @@ class _RetimeRowState extends State<_RetimeRow> {
     final t = ThemeScope.of(context).theme;
     final scalar = widget.scalar;
     final animated = scalar is BridgeScalar_Keyframed;
-    final playhead =
-        Provider.of<LumitUiState>(context, listen: false).playheadFrame;
+    final ui = Provider.of<LumitUiState>(context, listen: false);
+    final playhead = ui.playheadFrame;
+    // Which face the row wears (K-287): the clock by default, seconds for
+    // anyone who asked for them in Settings ▸ Interface ▸ Editing.
+    final seconds = ui.workspace.interface.retimeInSeconds;
+    final (fpsNum, fpsDen) = ui.model.fpsExact;
 
     return ValueListenableBuilder<int>(
       valueListenable: playhead,
@@ -3510,33 +3516,56 @@ class _RetimeRowState extends State<_RetimeRow> {
             ),
             SizedBox(
               width: widget.valueColumn.width,
-              child: animated
-                  ? KeyedValueField(
-                      fieldKey: const ValueKey('tl-retime-seconds'),
-                      value: value,
-                      // The same open range a transform axis gets: a source
-                      // time before zero or past the end simply holds the end
-                      // frame (docs/04 §7), so clamping the field would only
-                      // fight the drag.
-                      min: -100000,
-                      max: 100000,
-                      decimals: 3,
-                      suffix: ' s',
-                      speed: 0.02,
-                      onCommit: (v) => _commitAt(scalar, v, frame),
-                    )
-                  : DragValueField(
+              child: seconds
+                  ? (animated
+                      ? KeyedValueField(
+                          fieldKey: const ValueKey('tl-retime-seconds'),
+                          value: value,
+                          // The same open range a transform axis gets: a
+                          // source time before zero or past the end simply
+                          // holds the end frame (docs/04 §7), so clamping the
+                          // field would only fight the drag.
+                          min: -100000,
+                          max: 100000,
+                          decimals: 3,
+                          suffix: ' s',
+                          speed: 0.02,
+                          onCommit: (v) => _commitAt(scalar, v, frame),
+                        )
+                      : DragValueField(
+                          key: const ValueKey('tl-retime-seconds'),
+                          value: value,
+                          min: -100000,
+                          max: 100000,
+                          decimals: 3,
+                          suffix: ' s',
+                          speed: 0.02,
+                          onChanged: (v) => _commitAt(scalar, v, frame),
+                          onChangeLive: (v) =>
+                              setState(() => _staged = v.toDouble()),
+                          onChangeEnd: (v) => _commitAt(scalar, v, frame),
+                          onDragCancel: () => setState(() => _staged = null),
+                        ))
+                  // The clock face (K-287, realising K-075): which moment of
+                  // the source is showing, written the way every other time in
+                  // the editor is written. Dragged and typed in whole source
+                  // frames — a timecode cannot say "between two frames", which
+                  // is what the seconds setting is for.
+                  : TimeReadout(
                       key: const ValueKey('tl-retime-seconds'),
-                      value: value,
-                      min: -100000,
-                      max: 100000,
-                      decimals: 3,
-                      suffix: ' s',
-                      speed: 0.02,
-                      onChanged: (v) => _commitAt(scalar, v, frame),
-                      onChangeLive: (v) =>
-                          setState(() => _staged = v.toDouble()),
-                      onChangeEnd: (v) => _commitAt(scalar, v, frame),
+                      frame: _frameOfSeconds(value, fpsNum, fpsDen),
+                      format: (f) => timecodeOfRateSigned(f, fpsNum, fpsDen),
+                      parse: (text) =>
+                          framesOfTimecodeSigned(text, fpsNum, fpsDen),
+                      widthChars: timecodeChars(fpsNum, fpsDen) + 1,
+                      style: t.mono,
+                      minFrame: -100000,
+                      maxFrame: 100000,
+                      draggable: true,
+                      onDragLive: (f) => setState(
+                          () => _staged = _secondsOfFrame(f, fpsNum, fpsDen)),
+                      onCommit: (f) => _commitAt(
+                          scalar, _secondsOfFrame(f, fpsNum, fpsDen), frame),
                       onDragCancel: () => setState(() => _staged = null),
                     ),
             ),
@@ -3546,6 +3575,18 @@ class _RetimeRowState extends State<_RetimeRow> {
       },
     );
   }
+
+  /// A source time in seconds as a whole source frame, and back.
+  ///
+  /// At the composition's rate: the read model does not carry the footage's own
+  /// rate yet, and every other time in the panel is counted in comp frames.
+  static int _frameOfSeconds(double seconds, int fpsNum, int fpsDen) {
+    if (fpsDen <= 0 || fpsNum <= 0) return 0;
+    return (seconds * fpsNum / fpsDen).round();
+  }
+
+  static double _secondsOfFrame(int frame, int fpsNum, int fpsDen) =>
+      fpsNum <= 0 ? 0 : frame * (fpsDen <= 0 ? 1 : fpsDen) / fpsNum;
 
   void _commitAt(BridgeScalar scalar, num value, int frame) {
     widget.layer.setRetimeProperty(
@@ -3747,6 +3788,11 @@ class _Toolbar extends StatelessWidget {
 
   /// Listened to, not read: only the two readouts redraw as it moves.
   final ValueListenable<int> playhead;
+
+  /// Where a typed time goes — the same take-hold-of-the-playhead move a drag
+  /// on the ruler makes, so typing a time also stops the transport.
+  final ValueChanged<int> onSeek;
+
   final bool graph;
   final VoidCallback onToggleGraph;
   final bool razor;
@@ -3760,6 +3806,7 @@ class _Toolbar extends StatelessWidget {
     required this.comp,
     required this.model,
     required this.playhead,
+    required this.onSeek,
     required this.graph,
     required this.onToggleGraph,
     required this.razor,
@@ -3775,6 +3822,7 @@ class _Toolbar extends StatelessWidget {
     final t = ThemeScope.of(context).theme;
     final (fpsNum, fpsDen) = model.fpsExact;
     final mbOn = model.motionBlurEnabled;
+    final lastFrame = model.durationFrames - 1;
     return Container(
       height: _toolbarHeight,
       color: t.surface1,
@@ -3783,20 +3831,44 @@ class _Toolbar extends StatelessWidget {
         children: [
           // The clock face and the frame count, both zero-based: frame 0 is
           // 00:00:00:00, so three seconds into a 24 fps comp reads f72.
+          //
+          // Both sit in slots wide enough for the longest thing they can say
+          // and both can be typed into (K-287): a readout that resized itself
+          // as it counted shoved the search field sideways through every
+          // second of playback, and a time you can read is a time you should
+          // be able to state. Anything outside the composition lands on its
+          // nearest end.
           ValueListenableBuilder<int>(
             valueListenable: playhead,
             builder: (context, frame, _) => Row(
               children: [
-                Text(
-                  timecodeOfRate(frame, fpsNum, fpsDen),
+                TimeReadout(
                   key: const ValueKey('tl-timecode'),
+                  frame: frame,
+                  format: (f) => timecodeOfRate(f, fpsNum, fpsDen),
+                  widthChars: timecodeChars(fpsNum, fpsDen),
                   style: t.mono,
+                  parse: (text) => framesOfTimecode(text, fpsNum, fpsDen),
+                  onCommit: onSeek,
+                  minFrame: 0,
+                  maxFrame: lastFrame,
+                  tooltip: 'The frame the playhead is on. '
+                      'Click to type a time.',
                 ),
-                const SizedBox(width: 6),
-                Text(
-                  'f$frame',
+                TimeReadout(
                   key: const ValueKey('tl-frame'),
+                  frame: frame,
+                  format: (f) => 'f$f',
+                  // The `f`, the digits of the last frame, and one spare so a
+                  // comp that grows past a power of ten does not start to
+                  // twitch before the next rebuild.
+                  widthChars: 2 + '${lastFrame < 0 ? 0 : lastFrame}'.length,
                   style: t.mono.copyWith(color: t.textMuted),
+                  parse: _frameOfTyped,
+                  onCommit: onSeek,
+                  minFrame: 0,
+                  maxFrame: lastFrame,
+                  tooltip: 'The frame number. Click to type one.',
                 ),
               ],
             ),
@@ -3857,6 +3929,14 @@ class _Toolbar extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  /// A typed frame number, with or without the `f` the readout wears. Null for
+  /// anything that is not a number at all, which leaves the readout alone.
+  static int? _frameOfTyped(String text) {
+    var trimmed = text.trim().toLowerCase();
+    if (trimmed.startsWith('f')) trimmed = trimmed.substring(1);
+    return int.tryParse(trimmed.trim());
   }
 
   Widget _iconButton(

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -55,6 +55,7 @@ import '../state/timecode.dart';
 import '../theme/theme.dart';
 import '../widgets/controls.dart';
 import '../widgets/dropper_overlay.dart';
+import '../widgets/time_readout.dart';
 import 'placeholder.dart';
 import 'viewer_anchor.dart';
 import 'viewer_gizmo.dart';
@@ -315,15 +316,11 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
       ),
     );
 
-    // The picture, with the preview progress bar over the bottom of it
-    // (docs/07 §2.5). An overlay rather than a row of its own: a bar that only
-    // sometimes exists must not change where the picture sits, or every slow
-    // frame would nudge the composition up and down.
+    // The picture. The preview progress bar used to float over the bottom of
+    // it; it now rides on the right of the transport instead (K-287), where it
+    // covers nothing and has a place of its own that is always the same size.
     final stage = Expanded(
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          LayoutBuilder(
+      child: LayoutBuilder(
         builder: (context, constraints) {
           final size = facts.size;
           final fitted = _fittedRect(constraints, size);
@@ -409,14 +406,6 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
             ),
           );
         },
-          ),
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: ViewerProgressBar(tracker: ui.previewProgress),
-          ),
-        ],
       ),
     );
 
@@ -1466,140 +1455,188 @@ class _Toolbar extends StatelessWidget {
         boxShadow: floating ? t.tokens.cardShadow : null,
       ),
       padding: const EdgeInsets.symmetric(horizontal: 6),
-      // Scrolls rather than overflowing: a Viewer docked narrow has less width
-      // than this bar wants, and an overflow stripe is not a design.
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            SizedBox(
-              width: 76,
-              child: BareDropdown<int>(
-                key: const ValueKey('viewer-zoom'),
-                // -1: a wheel zoom between the listed steps; the button shows
-                // the true percentage and the menu still offers the steps.
-                value: _zoomSteps.indexOf(zoom),
-                options: [for (var i = 0; i < _zoomSteps.length; i++) i],
-                label: (i) => i == -1
-                    ? '${((zoom ?? 1) * 100).round()}%'
-                    : _zoomSteps[i] == null
-                        ? 'Fit'
-                        : '${(_zoomSteps[i]! * 100).round()}%',
-                onChanged: (i) => onZoom(_zoomSteps[i]),
-              ),
+      child: Row(
+        children: [
+          // The controls, and the preview progress on the right of the same bar
+          // (K-287). The controls take the space that is left over, so the
+          // progress appearing and going never moves any of them.
+          Expanded(child: _controls(context, t)),
+          ViewerProgressBar(
+            tracker:
+                Provider.of<LumitUiState>(context, listen: false)
+                    .previewProgress,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Everything on the left of the bar: magnification, channel, the overlays,
+  /// the playback mode, the transport and the clock.
+  Widget _controls(BuildContext context, LumitTheme t) {
+    // Scrolls rather than overflowing: a Viewer docked narrow has less width
+    // than this bar wants, and an overflow stripe is not a design.
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          SizedBox(
+            width: 76,
+            child: BareDropdown<int>(
+              key: const ValueKey('viewer-zoom'),
+              // -1: a wheel zoom between the listed steps; the button shows
+              // the true percentage and the menu still offers the steps.
+              value: _zoomSteps.indexOf(zoom),
+              options: [for (var i = 0; i < _zoomSteps.length; i++) i],
+              label: (i) => i == -1
+                  ? '${((zoom ?? 1) * 100).round()}%'
+                  : _zoomSteps[i] == null
+                      ? 'Fit'
+                      : '${(_zoomSteps[i]! * 100).round()}%',
+              onChanged: (i) => onZoom(_zoomSteps[i]),
             ),
-            const SizedBox(width: 6),
-            SizedBox(
-              width: 76,
-              child: BareDropdown<ViewerChannel>(
-                key: const ValueKey('viewer-channel'),
-                value: channel,
-                options: ViewerChannel.values,
-                label: _channelLabel,
-                onChanged: onChannel,
-              ),
+          ),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: 76,
+            child: BareDropdown<ViewerChannel>(
+              key: const ValueKey('viewer-channel'),
+              value: channel,
+              options: ViewerChannel.values,
+              label: _channelLabel,
+              onChanged: onChannel,
             ),
-            const SizedBox(width: 6),
-            LumitTooltip(
-              message: 'Show the transparency grid behind the picture',
-              child: HouseButton(
-                key: const ValueKey('viewer-grid'),
-                small: true,
-                frameless: true,
-                onPressed: onGrid,
-                child: Text('Grid',
-                    style: t.small.copyWith(color: grid ? t.accent : null)),
-              ),
-            ),
-            const SizedBox(width: 6),
-            // The layer controls switch (K-217): the boxes, handles and hover
-            // highlight over the picture. An icon rather than a word, because
-            // what it governs is a *mark* — and the mark is what it draws.
-            LumitTooltip(
-              message: wireframes
-                  ? 'Hide the layer controls over the picture'
-                  : 'Show the layer controls over the picture',
-              child: HouseButton(
-                key: const ValueKey('viewer-wireframes'),
-                small: true,
-                frameless: true,
-                onPressed: onWireframes,
-                child: lumitIcon(
-                  LumitIcon.wireframe,
-                  size: iconSize,
-                  color: wireframes ? t.accent : t.textSecondary,
-                ),
-              ),
-            ),
-            const SizedBox(width: 6),
-            _PlaybackModeButton(comp: comp, tier: tier),
-            // A fixed gap, not a Spacer: the bar scrolls when the panel is
-            // narrow, and a flex child cannot live inside a scroll view.
-            const SizedBox(width: 24),
-            HouseButton(
-              key: const ValueKey('viewer-home'),
+          ),
+          const SizedBox(width: 6),
+          LumitTooltip(
+            message: 'Show the transparency grid behind the picture',
+            child: HouseButton(
+              key: const ValueKey('viewer-grid'),
               small: true,
               frameless: true,
-              onPressed: () => onSeek(0),
-              child: Text('|◀', style: t.small),
+              onPressed: onGrid,
+              child: Text('Grid',
+                  style: t.small.copyWith(color: grid ? t.accent : null)),
             ),
-            HouseButton(
-              key: const ValueKey('viewer-step-back'),
+          ),
+          const SizedBox(width: 6),
+          // The layer controls switch (K-217): the boxes, handles and hover
+          // highlight over the picture. An icon rather than a word, because
+          // what it governs is a *mark* — and the mark is what it draws.
+          LumitTooltip(
+            message: wireframes
+                ? 'Hide the layer controls over the picture'
+                : 'Show the layer controls over the picture',
+            child: HouseButton(
+              key: const ValueKey('viewer-wireframes'),
               small: true,
               frameless: true,
-              onPressed: () => onSeek(frame - 1),
-              child: Text('◀', style: t.small),
-            ),
-            HouseButton(
-              key: const ValueKey('viewer-play'),
-              small: true,
-              onPressed: onPlayPause,
-              // The transport is the one place the spec asks for 20 (§5): it
-              // is the control the eye goes to without looking for it.
-              child: lumitIcon(playing ? LumitIcon.pause : LumitIcon.play,
-                  size: iconSizeTransport, color: t.textPrimary),
-            ),
-            HouseButton(
-              key: const ValueKey('viewer-step-forward'),
-              small: true,
-              frameless: true,
-              onPressed: () => onSeek(frame + 1),
-              child: Text('▶', style: t.small),
-            ),
-            HouseButton(
-              key: const ValueKey('viewer-end'),
-              small: true,
-              frameless: true,
-              onPressed: () => onSeek(comp.durationFrames() - 1),
-              child: Text('▶|', style: t.small),
-            ),
-            const SizedBox(width: 8),
-            Text(
-              timecodeOf(frame, settings),
-              key: const ValueKey('viewer-timecode'),
-              style: t.mono,
-            ),
-            // The degradation badge (docs/13 §B5, docs/07 §2.2): when adaptive
-            // playback has dropped below Full, say so on the bar — a softer
-            // picture must never be a mystery. The tier rides in on the frame,
-            // so the bar draws it without asking anything.
-            if (playing && tier > 1) ...[
-              const SizedBox(width: 8),
-              Container(
-                key: const ValueKey('viewer-tier-badge'),
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
-                decoration: BoxDecoration(
-                  color: t.surface2,
-                  borderRadius: BorderRadius.circular(t.tokens.controlRadius),
-                ),
-                child: Text(
-                  _PlaybackModeButton._tierNames[tier.clamp(0, 4)],
-                  style: t.small.copyWith(color: t.warning),
-                ),
+              onPressed: onWireframes,
+              child: lumitIcon(
+                LumitIcon.wireframe,
+                size: iconSize,
+                color: wireframes ? t.accent : t.textSecondary,
               ),
-            ],
-          ],
-        ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          // A slot rather than a button sized to its own label: the two modes
+          // are two different words, and letting them size themselves moved
+          // the whole transport across whenever the mode changed.
+          const SizedBox(
+            width: _playbackModeWidth,
+            child: _PlaybackModeButton(),
+          ),
+          // A fixed gap, not a Spacer: the bar scrolls when the panel is
+          // narrow, and a flex child cannot live inside a scroll view.
+          const SizedBox(width: 24),
+          HouseButton(
+            key: const ValueKey('viewer-home'),
+            small: true,
+            frameless: true,
+            onPressed: () => onSeek(0),
+            child: Text('|◀', style: t.small),
+          ),
+          HouseButton(
+            key: const ValueKey('viewer-step-back'),
+            small: true,
+            frameless: true,
+            onPressed: () => onSeek(frame - 1),
+            child: Text('◀', style: t.small),
+          ),
+          HouseButton(
+            key: const ValueKey('viewer-play'),
+            small: true,
+            onPressed: onPlayPause,
+            // The transport is the one place the spec asks for 20 (§5): it
+            // is the control the eye goes to without looking for it.
+            child: lumitIcon(playing ? LumitIcon.pause : LumitIcon.play,
+                size: iconSizeTransport, color: t.textPrimary),
+          ),
+          HouseButton(
+            key: const ValueKey('viewer-step-forward'),
+            small: true,
+            frameless: true,
+            onPressed: () => onSeek(frame + 1),
+            child: Text('▶', style: t.small),
+          ),
+          HouseButton(
+            key: const ValueKey('viewer-end'),
+            small: true,
+            frameless: true,
+            onPressed: () => onSeek(comp.durationFrames() - 1),
+            child: Text('▶|', style: t.small),
+          ),
+          const SizedBox(width: 8),
+          // The clock, in a slot wide enough for the longest time this comp
+          // can show and clickable to type one (docs/07 §2.2 item 11). A
+          // time past either end of the composition lands on that end: the
+          // playhead cannot leave the comp, so asking for somewhere outside
+          // it means the nearest place inside.
+          TimeReadout(
+            key: const ValueKey('viewer-timecode'),
+            frame: frame,
+            format: (f) => timecodeOf(f, settings),
+            widthChars: timecodeChars(settings.fpsNum, settings.fpsDen),
+            style: t.mono,
+            parse: (text) =>
+                framesOfTimecode(text, settings.fpsNum, settings.fpsDen),
+            onCommit: onSeek,
+            minFrame: 0,
+            maxFrame: _lastFrameOf(settings),
+            tooltip: 'The frame on screen. Click to type a time.',
+          ),
+          // The degradation badge (docs/13 §B5, docs/07 §2.2): when adaptive
+          // playback has dropped below Full, say so on the bar — a softer
+          // picture must never be a mystery. The tier rides in on the frame,
+          // so the bar draws it without asking anything.
+          //
+          // Its slot is there whether or not the badge is: a box that comes
+          // and goes mid-playback would drag the bar about at the very
+          // moment the picture is being watched.
+          const SizedBox(width: 8),
+          SizedBox(
+            width: _tierBadgeWidth,
+            child: playing && tier > 1
+                ? Center(
+                    child: Container(
+                      key: const ValueKey('viewer-tier-badge'),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 1),
+                      decoration: BoxDecoration(
+                        color: t.surface2,
+                        borderRadius:
+                            BorderRadius.circular(t.tokens.controlRadius),
+                      ),
+                      child: Text(
+                        _PlaybackModeButton._tierNames[tier.clamp(0, 4)],
+                        style: t.small.copyWith(color: t.warning),
+                      ),
+                    ),
+                  )
+                : null,
+          ),
+        ],
       ),
     );
   }
@@ -1617,6 +1654,27 @@ class _Toolbar extends StatelessWidget {
 /// state/timecode.dart, bound to this comp's settings.
 String timecodeOf(int frame, BridgeCompSettings settings) =>
     timecodeOfRate(frame, settings.fpsNum, settings.fpsDen);
+
+/// The last frame of a comp, from its settings alone.
+///
+/// Worked out here rather than asked of the engine: this is read while the bar
+/// is being built, and the bar is built for every frame of playback (K-184).
+/// Whole-integer arithmetic, so a long comp at 29.97 cannot drift the way a
+/// double would.
+int _lastFrameOf(BridgeCompSettings settings) {
+  final den = settings.duration.den.toInt() * settings.fpsDen;
+  if (den <= 0) return 0;
+  final frames = settings.duration.num.toInt() * settings.fpsNum ~/ den;
+  return frames > 0 ? frames - 1 : 0;
+}
+
+/// The slot the playback-mode button sits in — wide enough for either of the
+/// two labels, so changing mode does not shuffle the transport sideways.
+const double _playbackModeWidth = 92;
+
+/// The slot the degradation badge sits in, kept whether or not the badge is
+/// showing.
+const double _tierBadgeWidth = 52;
 
 /// Which playback behaviour is in force, and a click to change it.
 ///
@@ -1639,14 +1697,16 @@ final String _transportName = switch (viewerTransport()) {
   BridgeViewerTransport.readBack => 'read-back (pixels copied)',
 };
 
-/// In adaptive mode the tier it has settled on is shown beside the name, so
-/// "why is it soft?" is answered on screen: Full, Half, Third or Quarter.
+/// Which of the two playback behaviours is in force — the name of the mode and
+/// nothing else (K-287).
+///
+/// It used to carry the settled tier beside the name ("Adaptive · Half"), which
+/// meant the button re-lettered itself as the engine felt its way up and down
+/// the ladder — a word changing under the pointer, in the corner of the eye,
+/// through every second of playback. Which tier a frame was made at is the
+/// degradation badge's job, and the badge already says it while it matters.
 class _PlaybackModeButton extends StatelessWidget {
-  final CompositionReference comp;
-
-  /// The tier off the last frame, given by the bar above (see [_Toolbar.tier]).
-  final int tier;
-  const _PlaybackModeButton({required this.comp, required this.tier});
+  const _PlaybackModeButton();
 
   static const _tierNames = ['Full', 'Full', 'Half', 'Third', 'Quarter'];
 
@@ -1655,9 +1715,7 @@ class _PlaybackModeButton extends StatelessWidget {
     final t = ThemeScope.of(context).theme;
     final ui = Provider.of<LumitUiState>(context);
     final adaptive = ui.workspace.performance.playback == PlaybackMode.adaptive;
-    final label = adaptive
-        ? 'Adaptive · ${_tierNames[tier.clamp(0, _tierNames.length - 1)]}'
-        : 'Every frame';
+    final label = adaptive ? 'Adaptive res' : 'Every frame';
 
     // Which route frames take to get here. A build without a zero-copy path
     // copies every pixel down, serialises it a byte at a time and uploads it

--- a/flutter_ui/lib/panels/viewer_progress_bar.dart
+++ b/flutter_ui/lib/panels/viewer_progress_bar.dart
@@ -1,9 +1,16 @@
-// The Viewer's preview progress bar (docs/07 §2.5).
+// The Viewer's preview progress bar (docs/07 §2.5, K-287).
 //
 // **In plain terms.** When a frame takes long enough to notice, this says so: a
-// slim bar across the bottom of the picture that fills as the engine works
-// through the frame, with a word for what it is doing. When the frame arrives
-// the bar goes.
+// slim bar on the right-hand end of the Viewer's transport that fills as the
+// engine works through the frame, with a word for what it is doing. When the
+// frame arrives the bar goes.
+//
+// **Where it lives.** On the transport, at the far right, not floating over the
+// picture. Over the picture it covered the bottom of the composition — the one
+// thing the Viewer exists to show — and it did so exactly while a frame was
+// being waited on, which is when people are looking hardest. On the bar it has
+// a place of its own: the controls take the space that is left, so the bar
+// arriving and leaving moves none of them.
 //
 // **What it is not.** It is not a playback indicator — nothing appears while
 // the transport is running (the engine sends no reports then), because a bar
@@ -24,6 +31,7 @@ import 'package:flutter/widgets.dart';
 import '../state/preview_progress.dart';
 import '../theme/theme.dart';
 import '../widgets/controls.dart';
+import '../widgets/time_readout.dart';
 
 /// How tall the bar's own track is.
 const double _trackHeight = 3;
@@ -34,9 +42,14 @@ const Duration _fillDuration = Duration(milliseconds: 180);
 /// One sweep of the sheen along the fill.
 const Duration _sheenPeriod = Duration(milliseconds: 1400);
 
-/// The transport's own height (`_Toolbar`), which the bar clears in round mode
-/// where the transport floats over the picture rather than sitting below it.
-const double _transportHeight = 26;
+/// How wide the track is on the transport. Fixed, so the percentage beside it
+/// never moves as the fill grows.
+const double _trackWidth = 64;
+
+/// How much room the stage name gets. The longest of them ("Reading the
+/// composition") is longer than this and is shortened with an ellipsis rather
+/// than being allowed to push the bar about.
+const double _labelWidth = 110;
 
 class ViewerProgressBar extends StatefulWidget {
   final PreviewProgressTracker tracker;
@@ -103,37 +116,28 @@ class _ViewerProgressBarState extends State<ViewerProgressBar>
     if (!tracker.visible) return const SizedBox.shrink();
     final still = scope.animationLevel == AnimationLevel.none;
 
-    // In round mode the transport floats over the bottom of the picture (its
-    // 26 px plus the window inset), so the bar steps up over it rather than
-    // hiding underneath; in sharp mode the transport is a strip below the
-    // picture and there is nothing to clear.
-    final floatingTransport = t.tokens.windowInset > 0;
     return IgnorePointer(
       child: Padding(
-        padding: EdgeInsets.fromLTRB(
-          t.tokens.windowInset + 8,
-          6,
-          t.tokens.windowInset + 8,
-          floatingTransport ? t.tokens.windowInset * 2 + _transportHeight : 6,
-        ),
-        child: Column(
+        padding: const EdgeInsets.only(left: 12),
+        child: Row(
           mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Row(
-              children: [
-                Text(tracker.label, style: t.small),
-                const Spacer(),
-                Text(
-                  '${(tracker.fraction * 100).round()}%',
-                  style: t.small,
-                ),
-              ],
+            SizedBox(
+              width: _labelWidth,
+              child: Text(
+                tracker.label,
+                style: t.small,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                softWrap: false,
+                textAlign: TextAlign.right,
+              ),
             ),
-            const SizedBox(height: 4),
+            const SizedBox(width: 6),
             ClipRRect(
               borderRadius: BorderRadius.circular(t.tokens.controlRadius),
               child: SizedBox(
+                width: _trackWidth,
                 height: _trackHeight,
                 child: Stack(
                   children: [
@@ -148,6 +152,19 @@ class _ViewerProgressBarState extends State<ViewerProgressBar>
                     ),
                   ],
                 ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            // A fixed slot for the percentage: it counts up while the frame is
+            // being waited for, and a number that resized itself as it counted
+            // would jog the whole bar (the same rule the clock readouts keep).
+            SizedBox(
+              width: monoSlotWidth(t.small, 4),
+              child: Text(
+                '${(tracker.fraction * 100).round()}%',
+                style: t.small,
+                maxLines: 1,
+                textAlign: TextAlign.right,
               ),
             ),
           ],

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -426,6 +426,22 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         ),
         settingsRow(
           t,
+          'Retime values in seconds',
+          'The Retime row shows which moment of the source is playing as a '
+              'number of seconds, instead of as a timecode in the same '
+              'HH:MM:SS:FF form as every other time in the editor. Seconds '
+              'can say a position between two frames; a timecode cannot.',
+          HouseCheckbox(
+            key: const ValueKey('settings-retime-in-seconds'),
+            value: settings.retimeInSeconds,
+            onChanged: (on) => setState(() {
+              settings.retimeInSeconds = on;
+              ui.workspace.settingsChanged();
+            }),
+          ),
+        ),
+        settingsRow(
+          t,
           'Video arrives as a Sequence layer',
           'Video and image sequences added to a composition become a Sequence '
               'layer, which can be cut into clips on its own row. Still '

--- a/flutter_ui/lib/state/settings.dart
+++ b/flutter_ui/lib/state/settings.dart
@@ -134,6 +134,17 @@ class InterfaceSettings {
   /// unaffected either way; this is a Retime-only preference.
   bool retimeOpensToSpeed;
 
+  /// Whether the Retime row shows its source position in **seconds** rather
+  /// than as a timecode (K-287).
+  ///
+  /// Off by default: a Retime says which moment of the source is showing, and
+  /// every other time in the editor says that as `HH:MM:SS:FF` — a lone
+  /// decimal number of seconds meant doing arithmetic to line a retime up with
+  /// anything else (K-075 asked for the timecode). On is for the people who
+  /// think in seconds, and for the sub-frame precision a whole-frame clock
+  /// face cannot show.
+  bool retimeInSeconds;
+
   /// Whether video footage and image sequences added to a comp arrive as a
   /// one-clip Sequence layer rather than a Footage layer (K-246).
   ///
@@ -186,6 +197,7 @@ class InterfaceSettings {
     this.showTooltips = true,
     this.transformInEffectControls = false,
     this.retimeOpensToSpeed = false,
+    this.retimeInSeconds = false,
     this.videoAsSequenceLayer = false,
     this.playheadStaysOnStop = false,
     this.pasteLayersAtOriginalTime = false,
@@ -198,6 +210,7 @@ class InterfaceSettings {
         'show_tooltips': showTooltips,
         'transform_in_effect_controls': transformInEffectControls,
         'retime_opens_to_speed': retimeOpensToSpeed,
+        'retime_in_seconds': retimeInSeconds,
         'video_as_sequence_layer': videoAsSequenceLayer,
         'playhead_stays_on_stop': playheadStaysOnStop,
         'paste_layers_at_original_time': pasteLayersAtOriginalTime,
@@ -214,6 +227,9 @@ class InterfaceSettings {
         // before these existed — a settings file written by an older build
         // must not silently change how the editor works.
         retimeOpensToSpeed: j['retime_opens_to_speed'] as bool? ?? false,
+        // Absent means off: the timecode readout is the new default, so a
+        // settings file written before this field existed adopts it.
+        retimeInSeconds: j['retime_in_seconds'] as bool? ?? false,
         videoAsSequenceLayer: j['video_as_sequence_layer'] as bool? ?? false,
         // Absent means off here too, but for the opposite reason: the returning
         // playhead is the *new* default (K-254), so a settings file written

--- a/flutter_ui/lib/state/timecode.dart
+++ b/flutter_ui/lib/state/timecode.dart
@@ -26,6 +26,38 @@ String timecodeOfRate(int frame, int fpsNum, int fpsDen) {
       '${frames.toString().padLeft(frameDigits, '0')}';
 }
 
+/// How many digits the frames field of a clock face has at this rate — two up
+/// to 99 fps, three to 999, four beyond. The readouts size their slots from
+/// this, so a number never moves what is beside it as it counts.
+int timecodeFrameDigits(int fpsNum, int fpsDen) {
+  final den = fpsDen == 0 ? 1 : fpsDen;
+  final perSecond = (fpsNum / den).ceil().clamp(1, 1000);
+  return (perSecond - 1).toString().length.clamp(2, 4);
+}
+
+/// How many characters a clock face takes at this rate: `HH:MM:SS:` and its
+/// frames field.
+int timecodeChars(int fpsNum, int fpsDen) =>
+    9 + timecodeFrameDigits(fpsNum, fpsDen);
+
+/// `HH:MM:SS:FF` for a frame that may be **before zero**, written with a minus
+/// sign — the clock face a Retime needs, where a source time earlier than the
+/// start of the media is an ordinary thing to ask for (docs/04 §7).
+String timecodeOfRateSigned(int frame, int fpsNum, int fpsDen) =>
+    frame < 0
+        ? '-${timecodeOfRate(-frame, fpsNum, fpsDen)}'
+        : timecodeOfRate(frame, fpsNum, fpsDen);
+
+/// [framesOfTimecode], accepting a leading minus for a time before zero.
+int? framesOfTimecodeSigned(String text, int fpsNum, int fpsDen) {
+  final trimmed = text.trim();
+  final negative = trimmed.startsWith('-');
+  final frames = framesOfTimecode(
+      negative ? trimmed.substring(1) : trimmed, fpsNum, fpsDen);
+  if (frames == null) return null;
+  return negative ? -frames : frames;
+}
+
 /// `HH:MM:SS:mmm` for a length in seconds — the audio-only clock face, where
 /// frames mean nothing: the last field is milliseconds.
 String timecodeOfSecondsMs(double seconds) {

--- a/flutter_ui/lib/widgets/time_readout.dart
+++ b/flutter_ui/lib/widgets/time_readout.dart
@@ -1,0 +1,275 @@
+// The clock readouts that do not move, and can be typed into.
+//
+// **In plain terms.** A timecode or a frame number drawn as ordinary text
+// changes width as it counts — `f9` is half the width of `f10`, and
+// `00:00:09:00` narrower than `00:00:10:00` in a font whose digits are not all
+// the same width. During playback that happens sixty times a second, and
+// everything to the right of the number shuffles with it: the Timeline's
+// search field used to twitch through every second of playback. So each
+// readout gets a **fixed slot**, wide enough for the longest thing it can ever
+// say, and the number sits in it without pushing anything.
+//
+// The same widget is also how a time is *typed*: clicking a readout turns it
+// into a field holding exactly what was shown, in the same format, and what is
+// typed is read back through the caller's own parser. A time outside the
+// composition is clamped to the nearest end rather than refused — asking for
+// frame 100000 in a 300-frame comp means "the end", and there is nothing
+// useful about an error where a clamp will do (docs/07 §2.2, §4.1).
+//
+// A readout may also be **dragged** left and right, the way every number field
+// in Lumit drags, for the places that were a drag field before they were a
+// clock (the Retime row).
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'controls.dart';
+
+/// The width of [characters] characters of [style], measured once per style
+/// and length.
+///
+/// Measured from the digit `0`: the readouts are drawn in the monospaced face
+/// where every glyph is that wide, and where a build falls back to a
+/// proportional font the digit is the widest thing a clock face carries, so
+/// the slot comes out generous rather than short. Cached because it is asked
+/// for on every rebuild of a bar that rebuilds per frame, and the answer
+/// depends only on the face, the size and the count.
+double monoSlotWidth(TextStyle style, int characters) {
+  final key = (style.fontFamily, style.fontSize ?? 12.0, characters);
+  final hit = _slotWidths[key];
+  if (hit != null) return hit;
+  final painter = TextPainter(
+    text: TextSpan(text: '0' * characters, style: style),
+    textDirection: TextDirection.ltr,
+    maxLines: 1,
+  )..layout();
+  final width = painter.width;
+  painter.dispose();
+  _slotWidths[key] = width;
+  return width;
+}
+
+final Map<(String?, double, int), double> _slotWidths = {};
+
+/// The padding inside a readout's slot, so the numbers on a bar sit apart from
+/// each other and from whatever is beside them.
+const EdgeInsets readoutPadding = EdgeInsets.symmetric(horizontal: 6);
+
+/// How many pixels of drag move a draggable readout by one frame.
+const double _pixelsPerFrame = 4;
+
+/// A clock readout in a fixed slot: click it to type a new time.
+///
+/// [format] writes the frame the way this readout says times; [parse] reads
+/// what was typed back into a frame, or returns null when it is not a time at
+/// all — in which case the edit is dropped and the readout goes back to
+/// showing where things really are. A parsed frame is clamped into
+/// `[minFrame, maxFrame]` before it is handed to [onCommit].
+class TimeReadout extends StatefulWidget {
+  /// What the readout is showing.
+  final int frame;
+
+  /// The frame as this readout writes it.
+  final String Function(int frame) format;
+
+  /// Typed text back to a frame, or null when it cannot be read.
+  final int? Function(String text) parse;
+
+  /// How wide the slot is, in characters — the longest thing this readout can
+  /// ever say, so nothing moves as it counts.
+  final int widthChars;
+
+  final TextStyle style;
+
+  /// Where a typed or dragged frame goes, already clamped.
+  final ValueChanged<int> onCommit;
+
+  final int minFrame;
+  final int maxFrame;
+
+  /// Whether the readout can be dragged left and right to change it.
+  final bool draggable;
+
+  /// The live frame during a drag, for a caller that shows the value it is
+  /// dragging before the drag ends. [onCommit] still fires on release.
+  final ValueChanged<int>? onDragLive;
+
+  /// A drag that ended without ever moving a whole frame, or was cancelled —
+  /// what a caller staging a live value uses to put its staging back.
+  final VoidCallback? onDragCancel;
+
+  /// What hovering says. Null for no tooltip.
+  final String? tooltip;
+
+  const TimeReadout({
+    super.key,
+    required this.frame,
+    required this.format,
+    required this.parse,
+    required this.widthChars,
+    required this.style,
+    required this.onCommit,
+    required this.minFrame,
+    required this.maxFrame,
+    this.draggable = false,
+    this.onDragLive,
+    this.onDragCancel,
+    this.tooltip,
+  });
+
+  @override
+  State<TimeReadout> createState() => _TimeReadoutState();
+}
+
+class _TimeReadoutState extends State<TimeReadout> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focus = FocusNode();
+  bool _editing = false;
+  bool _hovered = false;
+
+  /// Pixels dragged since the last whole frame was ticked.
+  double _dragAccum = 0;
+
+  /// The last frame ticked this drag, or null when nothing has ticked yet.
+  int? _dragged;
+
+  int get _low => widget.minFrame;
+  int get _high => widget.maxFrame < _low ? _low : widget.maxFrame;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  void _beginEdit() {
+    final text = widget.format(widget.frame);
+    setState(() {
+      _editing = true;
+      _controller.text = text;
+      // Selected, not merely placed: a readout is retyped far more often than
+      // it is amended, and a caret at the end would make every edit start with
+      // a select-all of its own.
+      _controller.selection =
+          TextSelection(baseOffset: 0, extentOffset: text.length);
+    });
+  }
+
+  /// Take what was typed, or leave the readout as it was when what is there
+  /// does not read as a time.
+  void _commitTyped() {
+    if (!_editing) return;
+    final parsed = widget.parse(_controller.text);
+    setState(() => _editing = false);
+    if (parsed == null) return;
+    widget.onCommit(parsed.clamp(_low, _high));
+  }
+
+  void _cancel() => setState(() => _editing = false);
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    final width =
+        monoSlotWidth(widget.style, widget.widthChars) + readoutPadding.horizontal;
+
+    final Widget inner = _editing
+        ? Focus(
+            onKeyEvent: (node, event) {
+              if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.escape) {
+                _cancel();
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: EditableText(
+              controller: _controller,
+              focusNode: _focus,
+              autofocus: true,
+              style: widget.style.copyWith(color: t.textPrimary),
+              cursorColor: t.accent,
+              backgroundCursorColor: t.surface2,
+              selectionColor: t.accent.withValues(alpha: 0.5),
+              onSubmitted: (_) => _commitTyped(),
+              // Clicking away finishes the edit rather than throwing it away:
+              // people leave a field by looking at the next thing (K-243).
+              onTapOutside: (_) => _commitTyped(),
+            ),
+          )
+        : Text(
+            widget.format(widget.frame),
+            style: widget.style,
+            maxLines: 1,
+            overflow: TextOverflow.clip,
+            softWrap: false,
+          );
+
+    final Widget slot = MouseRegion(
+      cursor: widget.draggable
+          ? SystemMouseCursors.resizeLeftRight
+          : SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _editing ? null : _beginEdit,
+        onHorizontalDragStart: widget.draggable
+            ? (_) {
+                _dragAccum = 0;
+                _dragged = null;
+              }
+            : null,
+        onHorizontalDragUpdate: widget.draggable
+            ? (d) {
+                _dragAccum += d.delta.dx;
+                final steps = (_dragAccum / _pixelsPerFrame).truncate();
+                if (steps == 0) return;
+                _dragAccum -= steps * _pixelsPerFrame;
+                final next =
+                    ((_dragged ?? widget.frame) + steps).clamp(_low, _high);
+                _dragged = next;
+                (widget.onDragLive ?? widget.onCommit)(next);
+              }
+            : null,
+        onHorizontalDragEnd: widget.draggable
+            ? (_) {
+                final last = _dragged;
+                _dragged = null;
+                if (last != null) {
+                  widget.onCommit(last);
+                } else {
+                  // Never crossed a whole frame: nothing was ticked, so a
+                  // release here changes nothing.
+                  widget.onDragCancel?.call();
+                }
+              }
+            : null,
+        onHorizontalDragCancel: widget.draggable
+            ? () {
+                _dragged = null;
+                widget.onDragCancel?.call();
+              }
+            : null,
+        child: Container(
+          width: width,
+          padding: readoutPadding,
+          alignment: Alignment.centerLeft,
+          decoration: BoxDecoration(
+            color: _editing
+                ? t.surface0
+                : _hovered
+                    ? t.surface2
+                    : null,
+            borderRadius: BorderRadius.circular(t.tokens.controlRadius),
+          ),
+          child: inner,
+        ),
+      ),
+    );
+
+    final tip = widget.tooltip;
+    return tip == null ? slot : LumitTooltip(message: tip, child: slot);
+  }
+}

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -157,6 +157,72 @@ void main() {
       expect(p.comp.getLayers().length, 1);
     });
 
+    /// The field a readout turns into when it is clicked.
+    Finder fieldIn(String key) => find.descendant(
+          of: find.byKey(ValueKey<String>(key)),
+          matching: find.byType(EditableText),
+        );
+
+    /// The toolbar's two readouts are typed into, not merely read (K-287),
+    /// and neither can send the playhead out of the composition.
+    testWidgets('typing a timecode moves the playhead, clamped to the comp',
+        (tester) async {
+      final p = withComp();
+      p.uiState.playheadFrame.value = 0;
+      p.uiState.model.refresh();
+      await mount(tester, p);
+      final last = p.comp.durationFrames() - 1;
+      final (fpsNum, fpsDen) = p.uiState.model.fpsExact;
+
+      await tester.tap(find.byKey(const ValueKey('tl-timecode')));
+      await tester.pump();
+      await tester.enterText(fieldIn('tl-timecode'), '00:00:01:00');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(p.uiState.playheadFrame.value, (fpsNum / fpsDen).ceil(),
+          reason: 'a second in, counted at this comp\'s rate');
+
+      await tester.tap(find.byKey(const ValueKey('tl-timecode')));
+      await tester.pump();
+      await tester.enterText(fieldIn('tl-timecode'), '99:00:00:00');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(p.uiState.playheadFrame.value, last,
+          reason: 'past the end of the comp is the end of the comp');
+    });
+
+    testWidgets('typing a frame number moves the playhead, clamped',
+        (tester) async {
+      final p = withComp();
+      p.uiState.playheadFrame.value = 0;
+      p.uiState.model.refresh();
+      await mount(tester, p);
+      final last = p.comp.durationFrames() - 1;
+
+      await tester.tap(find.byKey(const ValueKey('tl-frame')));
+      await tester.pump();
+      await tester.enterText(fieldIn('tl-frame'), 'f42');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(p.uiState.playheadFrame.value, 42,
+          reason: 'the f the readout wears is optional on the way back in');
+
+      await tester.tap(find.byKey(const ValueKey('tl-frame')));
+      await tester.pump();
+      await tester.enterText(fieldIn('tl-frame'), '-8');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(p.uiState.playheadFrame.value, 0,
+          reason: 'before the start is the start');
+
+      await tester.tap(find.byKey(const ValueKey('tl-frame')));
+      await tester.pump();
+      await tester.enterText(fieldIn('tl-frame'), '999999');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+      expect(p.uiState.playheadFrame.value, last);
+    });
+
     testWidgets('the razor is the toolbar tool, and undoes as one step',
         (tester) async {
       final p = withComp();
@@ -1000,6 +1066,39 @@ void main() {
       expect(keys(), hasLength(2), reason: 'no key was added or lost');
       expect(keys().first.value, greaterThan(0),
           reason: 'the edit landed in the key under the playhead');
+    });
+
+    /// The Retime row reads as a clock, not as a decimal number of seconds
+    /// (K-287, realising K-075) — and the Settings switch puts the seconds
+    /// field back for anyone who wants sub-frame precision.
+    testWidgets('Retime reads as a timecode, or as seconds when asked',
+        (tester) async {
+      final p = withComp();
+      final layer = p.comp.addSolidLayer();
+      layer.toggleRetimeProperty();
+      p.uiState.playheadFrame.value = 0;
+      p.uiState.model.refresh();
+      await mount(tester, p);
+      await tester.tap(
+          find.byKey(ValueKey<String>('tl-twirl-${layer.internallayerId}')));
+      await tester.pump();
+
+      // Frame zero of the source at frame zero of the comp: an identity map
+      // starts where the media does.
+      Finder inRetimeRow(Finder matching) => find.descendant(
+            of: find.byKey(const ValueKey('tl-retime-seconds')),
+            matching: matching,
+          );
+      expect(inRetimeRow(find.text('00:00:00:00')), findsOneWidget,
+          reason: 'the source position is a clock face');
+      expect(inRetimeRow(find.textContaining(' s')), findsNothing,
+          reason: 'and not a number of seconds');
+
+      p.uiState.workspace.interface.retimeInSeconds = true;
+      p.uiState.model.refresh();
+      await tester.pump();
+      expect(inRetimeRow(find.text('0.000 s')), findsOneWidget,
+          reason: 'the setting puts the seconds field back');
     });
 
     /// An animated value stays editable in the outline (docs/07 §4.3): on a

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -2127,9 +2127,13 @@ void main() {
 
       final button = find.byKey(const ValueKey('viewer-playback-mode'));
       expect(button, findsOneWidget, reason: 'the mode is visible, not buried');
-      expect(find.textContaining('Adaptive'), findsOneWidget,
+      expect(find.text('Adaptive res'), findsOneWidget,
           reason:
               'adaptive is the mode that always plays, so it is the default');
+      // The mode, and only the mode (K-287): the tier it settled on used to
+      // ride in the label, which re-lettered the button through playback.
+      expect(find.textContaining('·'), findsNothing,
+          reason: 'no tier beside the mode name');
 
       await tester.tap(button);
       await tester.pump();

--- a/flutter_ui/test/settings_test.dart
+++ b/flutter_ui/test/settings_test.dart
@@ -30,6 +30,9 @@ void main() {
     // somebody who has not asked for it.
     expect(i.retimeOpensToSpeed, isFalse);
     expect(i.videoAsSequenceLayer, isFalse);
+    // The Retime row reads as a clock by default (K-287); seconds are the
+    // deviation, not the shipped state.
+    expect(i.retimeInSeconds, isFalse);
   });
 
   test('a settings file written before the Vegas pair loads as After Effects',
@@ -37,6 +40,12 @@ void main() {
     final i = InterfaceSettings.fromJson(const {'ui_scale': 1.25});
     expect(i.retimeOpensToSpeed, isFalse);
     expect(i.videoAsSequenceLayer, isFalse);
+    expect(i.retimeInSeconds, isFalse);
+  });
+
+  test('the Retime seconds preference round-trips', () {
+    final i = InterfaceSettings(retimeInSeconds: true);
+    expect(InterfaceSettings.fromJson(i.toJson()).retimeInSeconds, isTrue);
   });
 
   /// The returning playhead is the *new* default (K-254), so unlike the Vegas

--- a/flutter_ui/test/time_readout_test.dart
+++ b/flutter_ui/test/time_readout_test.dart
@@ -1,0 +1,156 @@
+// The clock readouts (K-287): a fixed slot, a click that types, a clamp at
+// both ends of the composition, and a drag for the rows that had one.
+//
+// The width test is the point of the widget: a readout whose box changes size
+// as it counts is what moved the Timeline's search field through every second
+// of playback.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/state/timecode.dart';
+import 'package:lumit_flutter/theme/theme.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
+import 'package:lumit_flutter/widgets/time_readout.dart';
+
+void main() {
+  Widget host(Widget child) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThemeScope(
+          theme: LumitTheme.dark(),
+          animationLevel: AnimationLevel.none,
+          showTooltips: false,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: Row(mainAxisSize: MainAxisSize.min, children: [child]),
+          ),
+        ),
+      );
+
+  Widget clock(
+    int frame, {
+    required ValueChanged<int> onCommit,
+    int maxFrame = 300,
+    int minFrame = 0,
+    bool draggable = false,
+    ValueChanged<int>? onDragLive,
+  }) =>
+      TimeReadout(
+        key: const ValueKey('clock'),
+        frame: frame,
+        format: (f) => timecodeOfRate(f, 24, 1),
+        parse: (text) => framesOfTimecode(text, 24, 1),
+        widthChars: timecodeChars(24, 1),
+        style: LumitTheme.dark().mono,
+        onCommit: onCommit,
+        minFrame: minFrame,
+        maxFrame: maxFrame,
+        draggable: draggable,
+        onDragLive: onDragLive,
+      );
+
+  testWidgets('the slot is the same width whatever the time says',
+      (tester) async {
+    await tester.pumpWidget(host(clock(0, onCommit: (_) {})));
+    final atZero = tester.getSize(find.byKey(const ValueKey('clock')));
+
+    // The widest digits, a two-digit frames field and a minutes field: every
+    // shape the readout can take, in one number.
+    await tester.pumpWidget(host(clock(288, onCommit: (_) {})));
+    expect(tester.getSize(find.byKey(const ValueKey('clock'))), atZero,
+        reason: 'the box does not resize as the number counts');
+  });
+
+  testWidgets('clicking types a time, in the format it was showing',
+      (tester) async {
+    int? committed;
+    await tester.pumpWidget(host(clock(0, onCommit: (f) => committed = f)));
+
+    await tester.tap(find.byKey(const ValueKey('clock')));
+    await tester.pump();
+    expect(find.byType(EditableText), findsOneWidget,
+        reason: 'the readout became a field');
+
+    await tester.enterText(find.byType(EditableText), '00:00:02:00');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    expect(committed, 48, reason: 'two seconds at 24 fps');
+  });
+
+  testWidgets('a time outside the composition lands on the nearest end',
+      (tester) async {
+    final asked = <int>[];
+    await tester
+        .pumpWidget(host(clock(0, onCommit: asked.add, maxFrame: 120)));
+
+    await tester.tap(find.byKey(const ValueKey('clock')));
+    await tester.pump();
+    await tester.enterText(find.byType(EditableText), '01:00:00:00');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    expect(asked, [120], reason: 'past the end is the end, not an error');
+  });
+
+  testWidgets('a time before the start lands on the start', (tester) async {
+    final asked = <int>[];
+    // A readout whose floor is not zero — a Retime row's, say — so a time
+    // below it has somewhere to be clamped to.
+    await tester.pumpWidget(
+        host(clock(60, onCommit: asked.add, minFrame: 48, maxFrame: 300)));
+
+    await tester.tap(find.byKey(const ValueKey('clock')));
+    await tester.pump();
+    await tester.enterText(find.byType(EditableText), '00:00:00:00');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+    expect(asked, [48]);
+  });
+
+  testWidgets('text that is not a time changes nothing', (tester) async {
+    var commits = 0;
+    await tester.pumpWidget(host(clock(12, onCommit: (_) => commits++)));
+
+    await tester.tap(find.byKey(const ValueKey('clock')));
+    await tester.pump();
+    await tester.enterText(find.byType(EditableText), 'soon');
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    expect(commits, 0);
+    expect(find.text('00:00:00:12'), findsOneWidget,
+        reason: 'the readout went back to showing where things really are');
+  });
+
+  testWidgets('escape leaves the time alone', (tester) async {
+    var commits = 0;
+    await tester.pumpWidget(host(clock(12, onCommit: (_) => commits++)));
+
+    await tester.tap(find.byKey(const ValueKey('clock')));
+    await tester.pump();
+    await tester.enterText(find.byType(EditableText), '00:00:05:00');
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(commits, 0);
+    expect(find.text('00:00:00:12'), findsOneWidget);
+  });
+
+  testWidgets('a draggable readout ticks whole frames and commits once',
+      (tester) async {
+    final live = <int>[];
+    final committed = <int>[];
+    await tester.pumpWidget(host(clock(
+      10,
+      onCommit: committed.add,
+      draggable: true,
+      onDragLive: live.add,
+    )));
+
+    await tester.drag(find.byKey(const ValueKey('clock')), const Offset(40, 0));
+    await tester.pump();
+
+    expect(live, isNotEmpty, reason: 'the drag moved the value as it went');
+    expect(committed, hasLength(1), reason: 'and committed once, on release');
+    expect(committed.single, greaterThan(10));
+  });
+}

--- a/flutter_ui/test/timecode_test.dart
+++ b/flutter_ui/test/timecode_test.dart
@@ -1,0 +1,44 @@
+// The shared clock face, and the two things K-287 added to it: how wide a
+// timecode is at a given rate, and a timecode that can be negative (a Retime
+// asking for a moment before the start of its media).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/state/timecode.dart';
+
+void main() {
+  test('the frames field widens with the rate, and the slot with it', () {
+    expect(timecodeFrameDigits(24, 1), 2);
+    expect(timecodeFrameDigits(60, 1), 2);
+    expect(timecodeFrameDigits(120, 1), 3);
+    expect(timecodeFrameDigits(600, 1), 3);
+    // `HH:MM:SS:` is nine characters, then the frames field.
+    expect(timecodeChars(24, 1), 11);
+    expect(timecodeChars(600, 1), 12);
+  });
+
+  test('a rate of nothing still gives a slot to draw in', () {
+    expect(timecodeChars(0, 0), 11);
+  });
+
+  test('a source time before zero reads with a minus sign', () {
+    expect(timecodeOfRateSigned(0, 24, 1), '00:00:00:00');
+    expect(timecodeOfRateSigned(25, 24, 1), '00:00:01:01');
+    expect(timecodeOfRateSigned(-25, 24, 1), '-00:00:01:01');
+  });
+
+  test('and reads back, sign and all', () {
+    expect(framesOfTimecodeSigned('00:00:01:01', 24, 1), 25);
+    expect(framesOfTimecodeSigned('-00:00:01:01', 24, 1), -25);
+    expect(framesOfTimecodeSigned(' -00:00:01:01 ', 24, 1), -25);
+    expect(framesOfTimecodeSigned('later', 24, 1), isNull);
+    expect(framesOfTimecodeSigned('-', 24, 1), isNull);
+  });
+
+  test('a signed timecode round-trips at an inexact rate', () {
+    for (final frame in [0, 1, 29, 30, 899, -1, -30, -1801]) {
+      final shown = timecodeOfRateSigned(frame, 30000, 1001);
+      expect(framesOfTimecodeSigned(shown, 30000, 1001), frame,
+          reason: 'frame $frame reads back from $shown');
+    }
+  });
+}

--- a/flutter_ui/test/viewer_progress_bar_test.dart
+++ b/flutter_ui/test/viewer_progress_bar_test.dart
@@ -29,11 +29,12 @@ void main() {
           theme: LumitTheme.dark(),
           animationLevel: animation,
           showTooltips: false,
-          child: Center(
-            child: SizedBox(
-              width: 400,
-              child: ViewerProgressBar(tracker: tracker),
-            ),
+          // Sized by what it draws, not by the box it is in: the bar sits on
+          // the right of the transport now (K-287), taking only the room it
+          // needs, and its width is part of what is being tested.
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: ViewerProgressBar(tracker: tracker),
           ),
         ),
       );
@@ -82,5 +83,25 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.binding.transientCallbackCount, 0,
         reason: 'and nothing is moving once it has arrived');
+  });
+
+  /// The bar rides on the transport now (K-287), where a percentage that
+  /// resized itself as it counted would jog every control beside it.
+  testWidgets('the bar is the same width at 9% as at 100%', (tester) async {
+    final tracker = PreviewProgressTracker();
+    addTearDown(tracker.dispose);
+    await tester.pumpWidget(host(tracker));
+
+    tracker.report(_report(7, fraction: 0.09, stage: 3));
+    await tester.pump(PreviewProgressTracker.appearsAfter);
+    await tester.pump();
+    final narrow = tester.getSize(find.byType(ViewerProgressBar));
+
+    tracker.report(_report(7, fraction: 1.0, stage: 3));
+    await tester.pump();
+    expect(tester.getSize(find.byType(ViewerProgressBar)), narrow);
+
+    tracker.report(_report(7, done: true));
+    await tester.pumpAndSettle();
   });
 }


### PR DESCRIPTION
The parts of the interface that report *time* were moving while time passed. Five changes, all the same complaint.

Rebased onto `main` after the anti-aliasing merge (#63, K-286) and **renumbered K-280 → K-287**.

## Viewer bar

- **The preview progress bar moves onto the right-hand end of the transport** instead of floating over the bottom of the picture, where it covered the composition exactly while a frame was being waited for — which is when it is being looked at hardest. The controls sit in an `Expanded` scroll view and the bar takes what is left, so it arriving and leaving moves none of them.
- **Fixed slots for everything whose text varies**: the playback-mode button, the clock, and the degradation badge — whose slot is now reserved even while the badge is not showing, so it no longer shoves the bar sideways as it comes and goes.
- **The playback-mode button says only the mode**: "Adaptive res" or "Every frame". It used to append the settled tier ("Adaptive · Half"), so it re-lettered itself as the engine walked the ladder. The tier still appears in the degradation badge during playback — docs/13 §4 requires that ("silent degradation is a bug"), so it moved to the one place that already says it, and only while there is something to say.

## Clocks, everywhere

New `flutter_ui/lib/widgets/time_readout.dart`: a slot measured in characters of its own face (cached `TextPainter` measurement), a click that turns it into a field holding exactly what was shown, `Enter` or click-away to commit, `Escape` to cancel, a clamp to the nearest end instead of an error, and an optional drag for the rows that had one.

- The Timeline's timecode and `f72` frame count use it — fixed width, so the layer search no longer twitches through every second of playback, and both typeable. A frame is accepted as `42` or `f42`.
- The Viewer's clock is typeable too, which docs/07 §2.2 item 11 had always asked for.
- A time outside the composition lands on the nearest end rather than being refused.

## Retime

The row reads `HH:MM:SS:FF` (signed, for a source time before zero) rather than decimal seconds, realising K-075's value lens for the outline row — the seconds field had been contradicting it. Dragged and typed in whole source frames. Settings ▸ Interface ▸ Editing ▸ *Retime values in seconds* puts the old field back, and is the only way to state a sub-frame position.

Clocked at the **composition's** rate, not the footage's own: the read model does not carry a source rate yet. Noted in K-287 and docs/04 §9.3 as the remaining step, with no change to what is stored when it lands.

## Docs

Same commit, per the docs-first rule: 07 §2.2 / §2.5 / §4.1, 04 §9.3, **K-287** appended to 02-DECISIONS, a plain-English section in GUIDE, and the now-landed click-to-edit item struck from TODO.

## Tests

- `test/time_readout_test.dart` — the slot is the same width at `00:00:00:00` and `00:00:12:00`, typing commits in the shown format, both clamps, `Escape` changes nothing, a drag ticks whole frames and commits once.
- `test/timecode_test.dart` — slot widths per rate, and the signed timecode round-tripping at 29.97.
- Timeline frb — typing a timecode and a frame number moves the playhead and clamps; the Retime row shows a clock, and seconds when the setting asks.
- Progress bar — the same width at 9 % as at 100 %.
- Settings — the new preference defaults off and round-trips.

**Not verified locally:** the container has no Flutter/Dart toolchain, so `flutter analyze` and the suite have not been run here. CI is the first real check on them.

> Note for whoever merges next: PR #64 also claims **K-287**. Whichever of the two lands second needs renumbering.
