### PR TITLE
Lens flare: matte defaults to this layer, Background becomes a Blend menu (K-288, K-289)

### DIFF
--- a/crates/lumit-bridge/src/api/effect.rs
+++ b/crates/lumit-bridge/src/api/effect.rs
@@ -317,7 +317,10 @@ pub fn list_parameters(effect: String) -> Vec<BridgeParamInfo> {
                     filter: filter.iter().map(|f| (*f).to_owned()).collect(),
                     filter_name: filter_name.to_owned(),
                 },
-                ParamKind::Layer {} => BridgeParamKind::Layer,
+                // `self_default` is an engine-side instantiation detail
+                // (K-288) — the panel draws the same picker either way, and
+                // the value it edits already carries the layer id.
+                ParamKind::Layer { .. } => BridgeParamKind::Layer,
             },
         })
         .collect()

--- a/crates/lumit-bridge/src/api/layer.rs
+++ b/crates/lumit-bridge/src/api/layer.rs
@@ -2938,12 +2938,17 @@ impl LayerReference {
     #[frb(sync)]
     pub fn add_effect(&self, name: String) -> Result<(), BridgeError> {
         let comp = self.composition()?;
-        let instance = lumit_core::fx::instantiate_for_raster(
+        let mut instance = lumit_core::fx::instantiate_for_raster(
             &name,
             f64::from(comp.width),
             f64::from(comp.height),
         )
         .ok_or(BridgeError::UnknownEffectName)?;
+        // A `self_default` layer reference starts pointed at the layer the
+        // effect is landing on (K-288, docs/impl/layer-input.md): the Lens
+        // flare's Matte source, whose natural reading is "the lights in this
+        // picture" — and on an adjustment layer, the composite below.
+        lumit_core::fx::point_self_layer_params_at(&mut instance, self.layer_id);
 
         self.with_effects(move |effects| {
             effects.push(instance);

--- a/crates/lumit-core/src/fx/builtins.rs
+++ b/crates/lumit-core/src/fx/builtins.rs
@@ -1194,8 +1194,13 @@ pub const BUILTINS: &[EffectSchema] = &[
                 label: "Depth layer",
                 // The layer whose red channel is the depth pass (0 = near,
                 // 1 = far by convention; the effect is symmetric about Focus).
-                // Unset until the owner picks one (a labelled no-op).
-                kind: ParamKind::Layer {},
+                // Unset until the owner picks one (a labelled no-op): a
+                // depth pass is never the picture itself, so no
+                // `self_default` here (K-288) — though pointing it at this
+                // layer is still allowed, and reads the effect's own input.
+                kind: ParamKind::Layer {
+                    self_default: false,
+                },
             },
             // The depth Layer input's sampling mode (K-142) is not a schema
             // parameter: the inspector renders a source combobox beside the
@@ -2596,7 +2601,7 @@ pub const BUILTINS: &[EffectSchema] = &[
         ],
         match_name: "lens_flare",
         label: "Lens flare",
-        version: 4,
+        version: 5,
         category: FxCategory::Stylise,
         traits: EffectTraits {
             cost: CostClass::Heavy,
@@ -2871,10 +2876,16 @@ pub const BUILTINS: &[EffectSchema] = &[
             ParamSchema {
                 id: "matte",
                 label: "Matte layer",
-                // The layer whose brightest sources spawn the flares
-                // (impl note §6); unset is a labelled no-flare, never a
-                // fault — the File/Layer no-op convention (§1.2).
-                kind: ParamKind::Layer {},
+                // The layer whose brightest sources spawn the flares (impl
+                // note §6); unset is a labelled no-flare, never a fault —
+                // the File/Layer no-op convention (§1.2). `self_default`
+                // (K-288): a fresh flare points at its OWN layer, because
+                // "flare the lights in this picture" is what asking for a
+                // matte source nearly always means — and on an adjustment
+                // layer that reads the composite of everything below, so
+                // the effect works there without hunting for another layer
+                // to point at.
+                kind: ParamKind::Layer { self_default: true },
             },
             ParamSchema {
                 id: "threshold",
@@ -2909,15 +2920,22 @@ pub const BUILTINS: &[EffectSchema] = &[
                 },
             },
             ParamSchema {
-                id: "background",
-                label: "Background",
-                // Transparent keeps the layer's own alpha; Black makes the
-                // output opaque — the flare-element-over-black export for
-                // Screen/Add workflows (K-258).
+                id: "blend",
+                label: "Blend",
+                // How the flare element combines with the layer under it
+                // (K-289, replacing K-258's Transparent/Black Background
+                // pair). The curated light-combine set Echo offers, for the
+                // same reason (T21): the HSL / burn / dodge modes are
+                // ill-defined on a premultiplied light overlay. Normal heads
+                // the list, then a divider, because it is the one mode that
+                // REPLACES the layer — the flare on its own opaque black,
+                // which is what Background = Black existed to export.
+                // Default Add: the behaviour every flare had before this
+                // menu, so nothing anyone had built moves.
                 kind: ParamKind::Choice {
-                    options: &["Transparent", "Black"],
-                    default: 0,
-                    dividers_after: &[],
+                    options: crate::fx::lens_flare::BLEND_OPTIONS,
+                    default: crate::fx::lens_flare::BLEND_ADD,
+                    dividers_after: &[0],
                 },
             },
             MIX_PARAM,
@@ -2992,7 +3010,7 @@ pub fn default_param_value(kind: &ParamKind) -> EffectValue {
         // effect is a labelled no-op until the owner picks a layer, the same
         // sanctioned exception the File parameter takes to the "no no-op
         // default" rule.
-        ParamKind::Layer {} => EffectValue::Layer(None),
+        ParamKind::Layer { .. } => EffectValue::Layer(None),
     }
 }
 
@@ -3010,6 +3028,7 @@ pub fn backfill_builtin_params(effects: &mut [EffectInstance]) {
         let Some(s) = schema(&e.effect.match_name) else {
             continue;
         };
+        migrate_lens_flare_background(e);
         for p in s.params {
             if !e.params.iter().any(|have| have.id == p.id) {
                 e.params.push(EffectParam {
@@ -3018,6 +3037,66 @@ pub fn backfill_builtin_params(effects: &mut [EffectInstance]) {
                     extra: serde_json::Map::new(),
                 });
             }
+        }
+    }
+}
+
+/// Carry a saved Lens flare's Background choice over to the Blend menu that
+/// replaced it (K-289, superseding K-258). The old parameter had two values:
+/// Transparent (the flare added to the layer's own alpha) and Black (the
+/// output forced opaque — the flare-element-over-black export). Transparent
+/// *is* the new Add, bit for bit, and it was the default, so almost every
+/// saved flare needs nothing beyond the ordinary backfill. Black becomes
+/// Normal: on the empty layer that option was for, "the flare on opaque
+/// black" is what both produce.
+///
+/// The legacy parameter is dropped once read — the schema no longer declares
+/// it, so leaving it would be a row `set_value` refuses and the panel cannot
+/// draw. Runs before the backfill appends `blend`, so a project saved with
+/// Black never briefly reads as Add.
+fn migrate_lens_flare_background(e: &mut EffectInstance) {
+    if e.effect.match_name != "lens_flare" {
+        return;
+    }
+    let Some(old) = e.params.iter().position(|p| p.id == "background") else {
+        return;
+    };
+    let was_black = matches!(e.params[old].value, EffectValue::Choice(1));
+    e.params.remove(old);
+    if e.params.iter().any(|p| p.id == "blend") {
+        return;
+    }
+    e.params.push(EffectParam {
+        id: "blend".to_owned(),
+        value: EffectValue::Choice(if was_black {
+            crate::fx::lens_flare::BLEND_NORMAL
+        } else {
+            crate::fx::lens_flare::BLEND_ADD
+        }),
+        extra: serde_json::Map::new(),
+    });
+}
+
+/// Point every `self_default` Layer parameter in `inst` at `layer` — the
+/// layer the effect is being added to (K-288, docs/impl/layer-input.md).
+///
+/// A schema constant cannot know which layer it will land on, so the apply
+/// site passes it, exactly as [`instantiate_for_raster`] passes the raster.
+/// Today that is the Lens flare's Matte layer: adding the effect and
+/// switching Source to Matte should flare the lights in the picture the
+/// effect is already looking at, not sit there doing nothing until a layer
+/// is picked. Presets and plain [`instantiate`] leave the reference unset,
+/// which stays the labelled no-op it always was.
+pub fn point_self_layer_params_at(inst: &mut EffectInstance, layer: uuid::Uuid) {
+    let Some(s) = schema(&inst.effect.match_name) else {
+        return;
+    };
+    for p in s.params {
+        if !matches!(p.kind, ParamKind::Layer { self_default: true }) {
+            continue;
+        }
+        if let Some(slot) = inst.params.iter_mut().find(|have| have.id == p.id) {
+            slot.value = EffectValue::Layer(Some(layer));
         }
     }
 }

--- a/crates/lumit-core/src/fx/lens_flare.rs
+++ b/crates/lumit-core/src/fx/lens_flare.rs
@@ -106,14 +106,167 @@ pub struct LensFlareParams {
     /// less) without changing wavelength count or buffer resolution.
     /// Frame-time — never rebakes.
     pub detail: f32,
-    /// 0 Transparent (the layer's own alpha carries the flare — today's
-    /// behaviour), 1 Black (the output is made opaque, the flare-element-
-    /// over-black export the Screen/Add workflow wants). Applies only while
-    /// the effect is live: the Intensity-0 / Mix-0 passthroughs stay
-    /// bit-exact whatever this holds.
-    pub background: u32,
+    /// How the flare element combines with the layer under it — an index
+    /// into [`BLEND_OPTIONS`] (K-289, replacing the old Transparent/Black
+    /// Background choice). Default [`BLEND_ADD`], the old Transparent
+    /// behaviour exactly; [`BLEND_NORMAL`] shows the flare alone on its own
+    /// opaque black background, which is what the old Black option was for.
+    /// Applies only while the effect is live: the Intensity-0 / Mix-0
+    /// passthroughs stay bit-exact whatever this holds.
+    pub blend: u32,
     /// 0..1.
     pub mix: f32,
+}
+
+/// The Blend menu's options, in code order (K-289, docs/08 §3.27). The
+/// flare is a black-backed light *element*: everything the effect renders
+/// lands on a frame that is pure black where there is no flare, and this
+/// menu says how that element combines with the layer beneath it — the same
+/// question a layer's own Mode dropdown asks, and the same curated set Echo
+/// offers for the same reason (K-149, T21: the HSL / burn / dodge modes are
+/// ill-defined on a premultiplied light overlay, so they are not listed).
+///
+/// [`BLEND_NORMAL`] heads the list because it is the odd one out: the flare
+/// element *replaces* the layer, black background and all, which is exactly
+/// the "flare over black" the old Background = Black option existed to
+/// export. Everything from Add down leaves the layer visible.
+pub const BLEND_OPTIONS: &[&str] = &[
+    "Normal",
+    "Add",
+    "Screen",
+    "Multiply",
+    "Overlay",
+    "Soft light",
+    "Hard light",
+    "Lighten",
+    "Darken",
+    "Difference",
+    "Exclusion",
+    "Subtract",
+    "Divide",
+];
+
+/// The flare element alone on its opaque black background — index 0 of
+/// [`BLEND_OPTIONS`].
+pub const BLEND_NORMAL: u32 = 0;
+/// Light addition — index 1 of [`BLEND_OPTIONS`], and the default a fresh
+/// effect carries (the behaviour every flare had before the menu existed).
+pub const BLEND_ADD: u32 = 1;
+
+/// Combine the flare element `e` with the layer under it `d` by
+/// [`BLEND_OPTIONS`] index `mode` — the CPU twin of
+/// `fx_lens_flare_combine.wgsl`'s `flare_blend`, written in the same
+/// arithmetic order so the two agree bit-for-bit (§1.6).
+///
+/// Both sides are **premultiplied linear RGBA** and every mode runs per
+/// channel on all four, exactly as Echo's combine does (K-149) and for the
+/// same reason: this is light being added to light, not a perceptual
+/// re-encode of a finished picture. `e` is the flare element — its RGB is
+/// what the trace and starburst put on the frame, its alpha the coverage
+/// that light implies — and `d` is the layer.
+///
+/// [`BLEND_NORMAL`] ignores `d` entirely and returns the element on opaque
+/// black; the alpha clamp at the end is the caller's, not this function's.
+pub fn flare_blend(mode: u32, d: [f32; 4], e: [f32; 4]) -> [f32; 4] {
+    let mut o = [0.0_f32; 4];
+    match mode {
+        // Normal: the element replaces the layer, on the opaque black it
+        // was rendered against. The old Background = Black, as a blend.
+        BLEND_NORMAL => {
+            o = [e[0], e[1], e[2], 1.0];
+        }
+        // Add (the default): light sums. Bit-identical to the pre-menu
+        // behaviour, so a project that never touched this renders the same.
+        1 => {
+            for c in 0..4 {
+                o[c] = d[c] + e[c];
+            }
+        }
+        // Screen.
+        2 => {
+            for c in 0..4 {
+                o[c] = d[c] + e[c] - d[c] * e[c];
+            }
+        }
+        // Multiply.
+        3 => {
+            for c in 0..4 {
+                o[c] = d[c] * e[c];
+            }
+        }
+        // Overlay = hard light with the LAYER as the switch.
+        4 => {
+            for c in 0..4 {
+                o[c] = if d[c] <= 0.5 {
+                    2.0 * d[c] * e[c]
+                } else {
+                    1.0 - 2.0 * (1.0 - d[c]) * (1.0 - e[c])
+                };
+            }
+        }
+        // Soft light (W3C), source = the element, backdrop = the layer.
+        5 => {
+            for c in 0..4 {
+                let dd = if d[c] <= 0.25 {
+                    ((16.0 * d[c] - 12.0) * d[c] + 4.0) * d[c]
+                } else {
+                    d[c].sqrt()
+                };
+                o[c] = if e[c] <= 0.5 {
+                    d[c] - (1.0 - 2.0 * e[c]) * d[c] * (1.0 - d[c])
+                } else {
+                    d[c] + (2.0 * e[c] - 1.0) * (dd - d[c])
+                };
+            }
+        }
+        // Hard light: the element is the switch.
+        6 => {
+            for c in 0..4 {
+                o[c] = if e[c] <= 0.5 {
+                    2.0 * d[c] * e[c]
+                } else {
+                    1.0 - 2.0 * (1.0 - d[c]) * (1.0 - e[c])
+                };
+            }
+        }
+        // Lighten (per-channel max).
+        7 => {
+            for c in 0..4 {
+                o[c] = d[c].max(e[c]);
+            }
+        }
+        // Darken (per-channel min).
+        8 => {
+            for c in 0..4 {
+                o[c] = d[c].min(e[c]);
+            }
+        }
+        // Difference.
+        9 => {
+            for c in 0..4 {
+                o[c] = (d[c] - e[c]).abs();
+            }
+        }
+        // Exclusion.
+        10 => {
+            for c in 0..4 {
+                o[c] = d[c] + e[c] - 2.0 * d[c] * e[c];
+            }
+        }
+        // Subtract.
+        11 => {
+            for c in 0..4 {
+                o[c] = (d[c] - e[c]).max(0.0);
+            }
+        }
+        // Divide, and the catch-all for an index no menu can produce.
+        _ => {
+            for c in 0..4 {
+                o[c] = (d[c] / e[c].max(1e-6)).max(0.0);
+            }
+        }
+    }
+    o
 }
 
 /// Per-quality pupil grid side, traced wavelength count, and flare-buffer
@@ -1656,7 +1809,7 @@ pub fn bake_with(p: &LensFlareParams, lens_text: Option<&str>) -> FlareBaked {
         anamorphic: 1.0,
         quality: 0,
         detail: 1.0,
-        background: 0,
+        blend: BLEND_ADD,
         mix: 1.0,
     };
     let (pw, ph) = (96u32, 54u32);
@@ -2474,23 +2627,20 @@ pub fn cpu_combine(
             let i = ((y * w + x) * 4) as usize;
             let o = [rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3]];
             let luma = 0.2126 * add[0] + 0.7152 * add[1] + 0.0722 * add[2];
-            let flared = [
-                o[0] + add[0],
-                o[1] + add[1],
-                o[2] + add[2],
-                (o[3] + luma).min(1.0),
-            ];
+            // The flare element (K-289): the light this frame drew, with the
+            // coverage that light implies as its alpha — a premultiplied
+            // black-backed overlay. Blend it with the layer, then saturate
+            // alpha at 1. Add reduces to `o + add` with alpha `min(o.a +
+            // luma, 1)`, which is exactly what the effect did before the
+            // menu existed. Only reached while live: the Intensity-0/Mix-0
+            // early return above keeps the passthroughs bit-exact.
+            let e = [add[0], add[1], add[2], luma];
+            let mut flared = flare_blend(p.blend, o, e);
+            flared[3] = flared[3].min(1.0);
             rgba[i] = o[0] * (1.0 - p.mix) + flared[0] * p.mix;
             rgba[i + 1] = o[1] * (1.0 - p.mix) + flared[1] * p.mix;
             rgba[i + 2] = o[2] * (1.0 - p.mix) + flared[2] * p.mix;
             rgba[i + 3] = o[3] * (1.0 - p.mix) + flared[3] * p.mix;
-            // Black background (K-258): the output is made opaque — laying
-            // the premultiplied result over black changes nothing but alpha.
-            // Only while live: the Intensity-0/Mix-0 early return above keeps
-            // the passthroughs bit-exact.
-            if p.background == 1 {
-                rgba[i + 3] = 1.0;
-            }
         }
     }
 }

--- a/crates/lumit-core/src/fx/resolved.rs
+++ b/crates/lumit-core/src/fx/resolved.rs
@@ -1255,9 +1255,15 @@ fn resolve_one(
                 _ => 1,
             };
             let detail = (e.float_at("detail", lt).unwrap_or(1.0) as f32).clamp(0.25, 4.0);
-            let background = match e.param("background") {
-                Some(EffectValue::Choice(c)) => (*c).min(1),
-                _ => 0,
+            // Blend menu (K-289). An index past the menu clamps to the last
+            // option rather than faulting; a project saved before the menu
+            // existed is migrated by `backfill_builtin_params`, so the
+            // fallback here is simply the default.
+            let blend = match e.param("blend") {
+                Some(EffectValue::Choice(c)) => {
+                    (*c).min(crate::fx::lens_flare::BLEND_OPTIONS.len() as u32 - 1)
+                }
+                _ => crate::fx::lens_flare::BLEND_ADD,
             };
             // Source mode (K-257): Lights resolves as Manual until light
             // layers land (the option is prepared, not wired).
@@ -1322,7 +1328,7 @@ fn resolve_one(
                     anamorphic,
                     quality,
                     detail,
-                    background,
+                    blend,
                     mix,
                 },
             ))

--- a/crates/lumit-core/src/fx/schema.rs
+++ b/crates/lumit-core/src/fx/schema.rs
@@ -100,12 +100,27 @@ pub enum ParamKind {
     },
     /// A reference to another layer in the composition (docs/impl/
     /// layer-input.md), sampled as an auxiliary picture — the depth pass a
-    /// depth-of-field effect reads. The value carries an
-    /// [`EffectValue::Layer`] (an optional layer id); the caller renders that
-    /// layer alone at comp size and threads its texture beside the resolved
-    /// op, exactly as a matte layer is rendered alone. Unset (or a dangling
-    /// reference) is a labelled no-op, never a fault.
-    Layer {},
+    /// depth-of-field effect reads, the bright-source matte a Lens flare
+    /// detects lights in. The value carries an [`EffectValue::Layer`] (an
+    /// optional layer id); the caller renders that layer alone at comp size
+    /// and threads its texture beside the resolved op, exactly as a matte
+    /// layer is rendered alone. Unset (or a dangling reference) is a
+    /// labelled no-op, never a fault.
+    ///
+    /// **This layer** (K-288): a reference to the layer the effect is *on*
+    /// is not a re-render of that layer — it is the effect's own input at
+    /// its point in the stack. On an ordinary layer that is the picture the
+    /// effect is about to process; on an **adjustment layer** it is the
+    /// composite of everything below, which is the only thing an adjustment
+    /// layer has to look at. `self_default` declares that a fresh instance
+    /// should start pointed at its own layer (the Lens flare's matte, whose
+    /// natural reading is "the lights in this picture"), rather than unset.
+    Layer {
+        /// A fresh instance added to a layer starts referencing that layer
+        /// (see the type docs). `false` leaves it unset, the historical
+        /// no-op default — a depth pass is never the picture itself.
+        self_default: bool,
+    },
 }
 
 /// How a transform- or displacement-domain effect treats the border pixels

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -5240,12 +5240,12 @@ fn lens_flare_backfill_restores_missing_params() {
     let mut inst = instantiate("lens_flare").unwrap();
     // Simulate a pre-K-257 save: strip the params that pass added.
     inst.params
-        .retain(|p| !matches!(p.id.as_str(), "source_type" | "background"));
+        .retain(|p| !matches!(p.id.as_str(), "source_type" | "blend"));
     assert!(inst.params.iter().all(|p| p.id != "source_type"));
     let mut effects = vec![inst];
     backfill_builtin_params(&mut effects);
     let inst = &effects[0];
-    for id in ["source_type", "background"] {
+    for id in ["source_type", "blend"] {
         assert!(
             inst.params.iter().any(|p| p.id == id),
             "{id} must be backfilled"
@@ -5257,13 +5257,70 @@ fn lens_flare_backfill_restores_missing_params() {
     assert_eq!(effects[0].params.len(), count);
 }
 
-// Background (K-258): Black makes the live output opaque and changes nothing
-// else; the Intensity-0 passthrough stays bit-exact whatever it holds.
+// The Background → Blend migration (K-289, superseding K-258). A project
+// saved with Transparent lands on Add — the same pixels it always rendered —
+// and one saved with Black lands on Normal, the flare on opaque black that
+// option existed to produce. The dead parameter goes, because the schema no
+// longer declares it and the panel cannot draw a row `set_value` refuses.
 #[test]
-fn lens_flare_black_background_sets_alpha_only_while_live() {
+fn lens_flare_background_migrates_to_the_blend_menu() {
+    use crate::fx::lens_flare::{BLEND_ADD, BLEND_NORMAL};
+    for (saved, want) in [(0u32, BLEND_ADD), (1, BLEND_NORMAL)] {
+        let mut inst = instantiate("lens_flare").unwrap();
+        inst.params.retain(|p| p.id != "blend");
+        inst.params.push(crate::model::EffectParam {
+            id: "background".to_owned(),
+            value: EffectValue::Choice(saved),
+            extra: serde_json::Map::new(),
+        });
+        let mut effects = vec![inst];
+        backfill_builtin_params(&mut effects);
+        assert!(
+            effects[0].params.iter().all(|p| p.id != "background"),
+            "the legacy parameter must be dropped"
+        );
+        assert!(
+            matches!(effects[0].param("blend"), Some(EffectValue::Choice(c)) if *c == want),
+            "background {saved} must migrate to blend {want}"
+        );
+        // Idempotent: loading twice cannot re-migrate or duplicate.
+        let count = effects[0].params.len();
+        backfill_builtin_params(&mut effects);
+        assert_eq!(effects[0].params.len(), count);
+        assert!(matches!(effects[0].param("blend"), Some(EffectValue::Choice(c)) if *c == want));
+    }
+}
+
+// "This layer" (K-288): a fresh Lens flare added to a layer points its Matte
+// source at that layer, so switching Source to Matte flares the lights in
+// the picture the effect is already on — and on an adjustment layer, the
+// composite below. Plain `instantiate` (presets, tests) leaves it unset, the
+// labelled no-op it always was, and no other effect's Layer parameter moves.
+#[test]
+fn lens_flare_matte_defaults_to_the_layer_it_is_added_to() {
+    let owner = uuid::Uuid::now_v7();
+
+    let bare = instantiate("lens_flare").unwrap();
+    assert_eq!(bare.layer_ref("matte"), None, "a preset stays unset");
+
+    let mut inst = instantiate("lens_flare").unwrap();
+    point_self_layer_params_at(&mut inst, owner);
+    assert_eq!(inst.layer_ref("matte"), Some(owner));
+
+    // DoF's depth pass is never the picture itself, so it is untouched.
+    let mut dof = instantiate("dof").unwrap();
+    point_self_layer_params_at(&mut dof, owner);
+    assert_eq!(dof.layer_ref("depth"), None);
+}
+
+// Blend (K-289, replacing K-258's Background pair): Normal shows the flare
+// element alone on opaque black, Add is the historical behaviour bit for
+// bit, and every mode keeps the Intensity-0 passthrough exact.
+#[test]
+fn lens_flare_blend_normal_is_the_element_on_opaque_black() {
     use crate::fx::lens_flare::*;
     let p = LensFlareParams {
-        background: 1,
+        blend: BLEND_NORMAL,
         ..default_flare_params()
     };
     let baked = bake(&p);
@@ -5274,19 +5331,28 @@ fn lens_flare_black_background_sets_alpha_only_while_live() {
     let flare = vec![0.25f32; (w * h * 3) as usize];
     let lights = manual_light(&p, w, h);
 
-    let mut black = src.clone();
-    cpu_combine(&mut black, w, h, &p, &baked, &flare, w, h, &lights);
-    let mut transparent = src.clone();
-    let pt = LensFlareParams { background: 0, ..p };
-    cpu_combine(&mut transparent, w, h, &pt, &baked, &flare, w, h, &lights);
+    let mut normal = src.clone();
+    cpu_combine(&mut normal, w, h, &p, &baked, &flare, w, h, &lights);
+    let mut add = src.clone();
+    let pa = LensFlareParams {
+        blend: BLEND_ADD,
+        ..p
+    };
+    cpu_combine(&mut add, w, h, &pa, &baked, &flare, w, h, &lights);
     for i in 0..(w * h) as usize {
-        assert_eq!(black[i * 4 + 3], 1.0, "alpha must be opaque");
+        assert_eq!(normal[i * 4 + 3], 1.0, "alpha must be opaque");
         for c in 0..3 {
-            assert_eq!(black[i * 4 + c], transparent[i * 4 + c], "rgb untouched");
+            // Add lays the same element over the layer, so Normal is Add
+            // minus the layer: the element by itself.
+            let element = add[i * 4 + c] - src[i * 4 + c];
+            assert!(
+                (normal[i * 4 + c] - element).abs() < 1e-6,
+                "Normal must show the element alone"
+            );
         }
     }
 
-    // Neutral points ignore the background: bit-exact passthrough.
+    // Neutral points ignore the blend: bit-exact passthrough.
     let mut neutral = src.clone();
     let p0 = LensFlareParams {
         intensity: 0.0,
@@ -5294,6 +5360,120 @@ fn lens_flare_black_background_sets_alpha_only_while_live() {
     };
     cpu_combine(&mut neutral, w, h, &p0, &baked, &flare, w, h, &lights);
     assert_eq!(neutral, src);
+}
+
+// The default Blend is Add, and Add is exactly what the effect did before
+// the menu existed (K-289): `out = in + flare`, alpha saturating at 1. A
+// regression here would silently move every flare anyone has already built.
+#[test]
+fn lens_flare_add_blend_is_the_historical_combine() {
+    use crate::fx::lens_flare::*;
+    let p = LensFlareParams {
+        blend: BLEND_ADD,
+        ..default_flare_params()
+    };
+    let baked = bake(&p);
+    let (w, h) = (8u32, 6u32);
+    let src: Vec<f32> = (0..(w * h * 4) as usize)
+        .map(|i| (i % 13) as f32 / 24.0)
+        .collect();
+    let flare = vec![0.25f32; (w * h * 3) as usize];
+    let lights = manual_light(&p, w, h);
+
+    let mut out = src.clone();
+    cpu_combine(&mut out, w, h, &p, &baked, &flare, w, h, &lights);
+    for i in 0..(w * h) as usize {
+        let add: Vec<f32> = (0..3).map(|c| out[i * 4 + c] - src[i * 4 + c]).collect();
+        let luma = 0.2126 * add[0] + 0.7152 * add[1] + 0.0722 * add[2];
+        assert!(
+            (out[i * 4 + 3] - (src[i * 4 + 3] + luma).min(1.0)).abs() < 1e-6,
+            "alpha must be the historical saturating sum"
+        );
+    }
+
+    // And the schema default really is Add.
+    let inst = instantiate("lens_flare").unwrap();
+    assert!(matches!(
+        inst.param("blend"),
+        Some(EffectValue::Choice(c)) if *c == BLEND_ADD
+    ));
+}
+
+// Every Blend option is reachable, and the resolve clamps an index past the
+// menu rather than faulting (K-289).
+#[test]
+fn lens_flare_blend_options_all_resolve() {
+    use crate::fx::lens_flare::*;
+    let last = BLEND_OPTIONS.len() as u32 - 1;
+    for mode in 0..=last + 3 {
+        let mut inst = instantiate("lens_flare").unwrap();
+        for p in &mut inst.params {
+            if p.id == "blend" {
+                p.value = EffectValue::Choice(mode);
+            }
+        }
+        let ops = resolve_stack(&[inst], 0.0, 2202.9, 1.0, &MarkerContext::NONE);
+        let [Resolved::LensFlare(p)] = ops.as_slice() else {
+            panic!("lens_flare must resolve to exactly one op");
+        };
+        assert_eq!(p.blend, mode.min(last));
+    }
+}
+
+// The blend table itself (K-289), against the formulas written out by hand.
+// The CPU twin is the oracle the WGSL `flare_blend` is pinned to, so it has
+// to be right on its own terms first.
+#[test]
+fn flare_blend_matches_its_formulas() {
+    use crate::fx::lens_flare::*;
+    let d = [0.30_f32, 0.60, 0.10, 0.80];
+    let e = [0.40_f32, 0.20, 0.70, 0.25];
+    let close = |got: [f32; 4], want: [f32; 4], what: &str| {
+        for c in 0..4 {
+            assert!(
+                (got[c] - want[c]).abs() < 1e-6,
+                "{what} channel {c}: {} vs {}",
+                got[c],
+                want[c]
+            );
+        }
+    };
+    close(
+        flare_blend(BLEND_NORMAL, d, e),
+        [e[0], e[1], e[2], 1.0],
+        "Normal",
+    );
+    close(
+        flare_blend(BLEND_ADD, d, e),
+        [0.70, 0.80, 0.80, 1.05],
+        "Add",
+    );
+    close(
+        flare_blend(2, d, e),
+        [
+            d[0] + e[0] - d[0] * e[0],
+            d[1] + e[1] - d[1] * e[1],
+            d[2] + e[2] - d[2] * e[2],
+            d[3] + e[3] - d[3] * e[3],
+        ],
+        "Screen",
+    );
+    close(
+        flare_blend(3, d, e),
+        [d[0] * e[0], d[1] * e[1], d[2] * e[2], d[3] * e[3]],
+        "Multiply",
+    );
+    close(flare_blend(7, d, e), [0.40, 0.60, 0.70, 0.80], "Lighten");
+    close(flare_blend(8, d, e), [0.30, 0.20, 0.10, 0.25], "Darken");
+    close(flare_blend(9, d, e), [0.10, 0.40, 0.60, 0.55], "Difference");
+    close(
+        flare_blend(11, d, e),
+        [0.0, 0.40, 0.0, 0.55],
+        "Subtract clamps at black",
+    );
+    // Divide by a zero element cannot produce a NaN or an infinity.
+    let z = flare_blend(12, d, [0.0; 4]);
+    assert!(z.iter().all(|v| v.is_finite()), "Divide must stay finite");
 }
 
 // Light tint and Use source colour (K-259): the tint multiplies every mode's
@@ -5608,7 +5788,7 @@ fn default_flare_params() -> crate::fx::lens_flare::LensFlareParams {
         anamorphic: 1.0,
         quality: 1,
         detail: 1.0,
-        background: 0,
+        blend: crate::fx::lens_flare::BLEND_ADD,
         mix: 1.0,
     }
 }

--- a/crates/lumit-eval/src/lib.rs
+++ b/crates/lumit-eval/src/lib.rs
@@ -276,6 +276,20 @@ fn feed_effect_stack(
                     // recurse; `visited` still guards any precomp cycle
                     // inside that source. An unset or dangling reference
                     // feeds a distinct 0 marker (the effect is a no-op).
+                    //
+                    // **This layer** (K-288) feeds its own marker and stops.
+                    // The reference names the effect's own input, not a
+                    // second render, and that input is already in the key:
+                    // this layer's source and the stack above this effect
+                    // are hashed by the walk we are inside, and on an
+                    // adjustment layer the composite below is hashed by the
+                    // other layers' own `feed_layer` calls (draw order is
+                    // content). Recursing here would re-hash the same
+                    // source for no gain.
+                    if *lref == Some(marker_layer.id) {
+                        h.update(&[2]);
+                        continue;
+                    }
                     match lref
                         .as_ref()
                         .and_then(|id| comp.layers.iter().find(|l| l.id == *id))

--- a/crates/lumit-gpu/src/fx/lens_flare.rs
+++ b/crates/lumit-gpu/src/fx/lens_flare.rs
@@ -82,8 +82,9 @@ pub struct LensFlareOp {
     pub light_tint: [f32; 3],
     /// Matte/Lights: whether a detected source's own colour tints its flare.
     pub use_source_colour: bool,
-    /// 1 = Black background: the output is made opaque (K-258).
-    pub background: u32,
+    /// How the flare element combines with the layer under it — an index
+    /// into `lumit_core::fx::lens_flare::BLEND_OPTIONS` (K-289).
+    pub blend: u32,
     /// 0..1.
     pub mix: f32,
     /// `lumit_core::fx::lens_flare::bake_key` of the op — the bake cache key.
@@ -273,6 +274,11 @@ impl<T: Clone> BakeCache<T> {
     }
 }
 
+/// How many blend modes the combine kernel's `flare_blend` implements — the
+/// length of `lumit_core::fx::lens_flare::BLEND_OPTIONS` (K-289), pinned by
+/// test. An index past the last option clamps rather than faulting.
+pub const BLEND_COUNT: u32 = 13;
+
 /// Most flare sources a frame renders — must equal
 /// `lumit_core::fx::lens_flare::MAX_LIGHTS` (pinned by test).
 pub const MAX_LIGHTS: u32 = 16;
@@ -382,7 +388,7 @@ struct CombineParams {
     fscale: f32,
     mix_amt: f32,
     light_count: u32,
-    background: u32,
+    blend: u32,
 }
 
 #[repr(C)]
@@ -1544,7 +1550,7 @@ impl FxEngine {
             fscale,
             mix_amt: op.mix,
             light_count,
-            background: op.background.min(1),
+            blend: op.blend.min(BLEND_COUNT - 1),
         };
         let cp_buf = ctx
             .device

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -3004,7 +3004,7 @@ fn flare_params() -> lumit_core::fx::lens_flare::LensFlareParams {
         anamorphic: 1.0,
         quality: 0,
         detail: 1.0,
-        background: 0,
+        blend: lumit_core::fx::lens_flare::BLEND_ADD,
         mix: 1.0,
     }
 }
@@ -3046,7 +3046,7 @@ fn flare_op(p: &lumit_core::fx::lens_flare::LensFlareParams, w: u32, h: u32) -> 
         threshold_softness: p.threshold_softness,
         light_tint: p.light_tint,
         use_source_colour: p.use_source_colour,
-        background: p.background,
+        blend: p.blend,
         mix: p.mix,
         bake_key: lf::bake_key(p),
     }
@@ -3905,6 +3905,13 @@ fn wgsl_lens_flare_padded_anamorphic_matches_and_fills_the_edge() {
 #[test]
 fn wgsl_lens_flare_matte_mode_matches_the_cpu_reference() {
     assert_eq!(MAX_LIGHTS as usize, lumit_core::fx::lens_flare::MAX_LIGHTS);
+    // The combine kernel's `flare_blend` implements exactly the menu
+    // lumit-core declares (K-289) — a mode added to one and not the other
+    // would silently clamp to Divide.
+    assert_eq!(
+        crate::fx::lens_flare::BLEND_COUNT as usize,
+        lumit_core::fx::lens_flare::BLEND_OPTIONS.len()
+    );
 
     let Ok(ctx) = GpuContext::headless() else {
         crate::no_adapter();

--- a/crates/lumit-gpu/src/fx_lens_flare_combine.wgsl
+++ b/crates/lumit-gpu/src/fx_lens_flare_combine.wgsl
@@ -27,9 +27,14 @@ struct CombineParams {
     fscale: f32,
     mix_amt: f32,
     light_count: u32,
-    // 1 = Black background: the output is made opaque (K-258). Only reached
-    // while live -- the neutral early-out above the flare maths returns first.
-    background: u32,
+    // How the flare element combines with the layer under it: an index into
+    // lumit_core::fx::lens_flare::BLEND_OPTIONS (K-289) -- 0 Normal,
+    // 1 Add, 2 Screen, 3 Multiply, 4 Overlay, 5 Soft light, 6 Hard light,
+    // 7 Lighten, 8 Darken, 9 Difference, 10 Exclusion, 11 Subtract,
+    // 12 Divide. Only reached while live -- the neutral early-out above the
+    // flare maths returns first, so every mode keeps the Intensity-0 /
+    // Mix-0 passthroughs bit-exact.
+    blend: u32,
 };
 
 @group(0) @binding(0) var src_tex: texture_2d<f32>;
@@ -60,6 +65,56 @@ fn tap_rgb(tex: texture_2d<f32>, fx_in: f32, fy_in: f32, dims: vec2<i32>) -> vec
     let b = textureLoad(tex, vec2<i32>(x0, y1), 0).rgb * (1.0 - tx)
         + textureLoad(tex, vec2<i32>(x1, y1), 0).rgb * tx;
     return a * (1.0 - ty) + b * ty;
+}
+
+// W3C soft-light D(d) helper (== the compositor's and Echo's).
+fn flare_soft_light_d(d: vec4<f32>) -> vec4<f32> {
+    let poly = ((16.0 * d - 12.0) * d + 4.0) * d;
+    return select(sqrt(d), poly, d <= vec4<f32>(0.25));
+}
+
+// Combine the flare element `e` with the layer under it `d`, both
+// premultiplied linear RGBA, per channel on all four -- the exact
+// arithmetic order lumit_core::fx::lens_flare::flare_blend uses, so the two
+// agree bit-for-bit (docs/08 1.6). Normal ignores `d` and returns the
+// element on its opaque black background.
+fn flare_blend(mode: u32, d: vec4<f32>, e: vec4<f32>) -> vec4<f32> {
+    let one = vec4<f32>(1.0);
+    if (mode == 0u) {
+        return vec4<f32>(e.rgb, 1.0); // Normal: the element replaces the layer
+    } else if (mode == 1u) {
+        return d + e; // Add
+    } else if (mode == 2u) {
+        return d + e - d * e; // Screen
+    } else if (mode == 3u) {
+        return d * e; // Multiply
+    } else if (mode == 4u) {
+        // Overlay = hard light with the LAYER as the switch.
+        let lo = 2.0 * d * e;
+        let hi = one - 2.0 * (one - d) * (one - e);
+        return select(hi, lo, d <= vec4<f32>(0.5));
+    } else if (mode == 5u) {
+        // Soft light (W3C), source = the element, backdrop = the layer.
+        let darkened = d - (one - 2.0 * e) * d * (one - d);
+        let lightened = d + (2.0 * e - one) * (flare_soft_light_d(d) - d);
+        return select(lightened, darkened, e <= vec4<f32>(0.5));
+    } else if (mode == 6u) {
+        // Hard light: the element is the switch.
+        let lo = 2.0 * d * e;
+        let hi = one - 2.0 * (one - d) * (one - e);
+        return select(hi, lo, e <= vec4<f32>(0.5));
+    } else if (mode == 7u) {
+        return max(d, e); // Lighten
+    } else if (mode == 8u) {
+        return min(d, e); // Darken
+    } else if (mode == 9u) {
+        return abs(d - e); // Difference
+    } else if (mode == 10u) {
+        return d + e - 2.0 * d * e; // Exclusion
+    } else if (mode == 11u) {
+        return max(d - e, vec4<f32>(0.0)); // Subtract
+    }
+    return max(d / max(e, vec4<f32>(1e-6)), vec4<f32>(0.0)); // Divide
 }
 
 @compute @workgroup_size(8, 8)
@@ -116,10 +171,12 @@ fn combine(@builtin(global_invocation_id) gid: vec3<u32>) {
     }
     let add = (f + sb) * cp.intensity;
     let luma = 0.2126 * add.r + 0.7152 * add.g + 0.0722 * add.b;
-    let flared = vec4<f32>(o.rgb + add, min(o.a + luma, 1.0));
-    var outv = o * (1.0 - cp.mix_amt) + flared * cp.mix_amt;
-    if (cp.background == 1u) {
-        outv.a = 1.0;
-    }
+    // The flare element (K-289): the light this frame drew, with the
+    // coverage that light implies as its alpha. Blend it with the layer,
+    // then saturate alpha at 1 -- Add reduces to o + add with alpha
+    // min(o.a + luma, 1), the pre-menu behaviour exactly.
+    var flared = flare_blend(cp.blend, o, vec4<f32>(add, luma));
+    flared.a = min(flared.a, 1.0);
+    let outv = o * (1.0 - cp.mix_amt) + flared * cp.mix_amt;
     textureStore(dst_tex, xy, outv);
 }

--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -20,7 +20,8 @@
 
 use crate::decode::CompLayerPixels;
 use crate::draw::{
-    AccumulationBelow, CompLayerDraw, DofInputDraw, DrawSource, MatteDraw, TemporalBelow,
+    AccumulationBelow, CompLayerDraw, DofInputDraw, DrawSource, LayerInputDraw, MatteDraw,
+    TemporalBelow,
 };
 use crate::export::mask_rgba;
 use crate::realise::Realiser;
@@ -421,7 +422,7 @@ pub fn build_comp_draws_at(
     };
 
     let dof_inputs_for =
-        |effects: &[lumit_core::model::EffectInstance]| -> Vec<Option<DofInputDraw>> {
+        |owner: uuid::Uuid, effects: &[lumit_core::model::EffectInstance]| -> Vec<LayerInputDraw> {
             use lumit_core::model::EffectNamespace;
             effects
                 .iter()
@@ -431,58 +432,67 @@ pub fn build_comp_draws_at(
                         && e.effect.match_name == "dof"
                 })
                 .map(|e| {
-                    let id = e.layer_ref("depth")?;
-                    let src = comp.layers.iter().find(|l| l.id == id)?;
-                    if !in_span(src) {
-                        return None;
+                    // "This layer" (K-288): a reference to the layer the effect
+                    // is ON is not a second render — it is the effect's own
+                    // input, which `run_ops` already holds.
+                    if e.layer_ref("depth") == Some(owner) {
+                        return LayerInputDraw::ThisLayer;
                     }
-                    // A Precomp depth renders its comp (K-266).
-                    if let Some(nested) = nested_input_for(src) {
-                        return Some(nested);
-                    }
-                    let mode = e.layer_source("depth");
-                    // Depth source (K-142). None samples the depth layer's raw
-                    // pixels — clear its masks so `pixels_for` skips them; Masks
-                    // and Effects and masks keep them.
-                    let (rgba, tex_w, tex_h, natural) = if mode.applies_masks() {
-                        pixels_for(src)?
-                    } else {
-                        let mut bare = src.clone();
-                        bare.masks.clear();
-                        pixels_for(&bare)?
+                    let slot = || -> Option<DofInputDraw> {
+                        let id = e.layer_ref("depth")?;
+                        let src = comp.layers.iter().find(|l| l.id == id)?;
+                        if !in_span(src) {
+                            return None;
+                        }
+                        // A Precomp depth renders its comp (K-266).
+                        if let Some(nested) = nested_input_for(src) {
+                            return Some(nested);
+                        }
+                        let mode = e.layer_source("depth");
+                        // Depth source (K-142). None samples the depth layer's raw
+                        // pixels — clear its masks so `pixels_for` skips them; Masks
+                        // and Effects and masks keep them.
+                        let (rgba, tex_w, tex_h, natural) = if mode.applies_masks() {
+                            pixels_for(src)?
+                        } else {
+                            let mut bare = src.clone();
+                            bare.masks.clear();
+                            pixels_for(&bare)?
+                        };
+                        // Effects and masks (K-142): resolve the depth layer's own
+                        // stack at its layer time so render_dof_inputs runs it on the
+                        // depth texture before resampling. Uses the depth layer's
+                        // decode scale (its px@comp radii stay honest), the same
+                        // resolve export uses (K-031). Empty otherwise.
+                        let (fx, lut_files) = if mode.folds_effects() && src.switches.fx {
+                            let slt = t_comp - src.start_offset.0.to_f64();
+                            let comp_diag =
+                                ((comp.width as f32).powi(2) + (comp.height as f32).powi(2)).sqrt();
+                            let scale = tex_w as f32 / natural.0.max(1.0);
+                            let markers = lumit_core::fx::MarkerContext::for_layer(comp, src);
+                            (
+                                lumit_core::fx::resolve_stack(
+                                    &src.effects,
+                                    slt,
+                                    comp_diag * scale,
+                                    scale,
+                                    &markers,
+                                ),
+                                lut_files(&src.effects, slt),
+                            )
+                        } else {
+                            (Vec::new(), Vec::new())
+                        };
+                        Some(DofInputDraw {
+                            rgba,
+                            tex_w,
+                            tex_h,
+                            fx,
+                            lut_files,
+                            nested: None,
+                        })
                     };
-                    // Effects and masks (K-142): resolve the depth layer's own
-                    // stack at its layer time so render_dof_inputs runs it on the
-                    // depth texture before resampling. Uses the depth layer's
-                    // decode scale (its px@comp radii stay honest), the same
-                    // resolve export uses (K-031). Empty otherwise.
-                    let (fx, lut_files) = if mode.folds_effects() && src.switches.fx {
-                        let slt = t_comp - src.start_offset.0.to_f64();
-                        let comp_diag =
-                            ((comp.width as f32).powi(2) + (comp.height as f32).powi(2)).sqrt();
-                        let scale = tex_w as f32 / natural.0.max(1.0);
-                        let markers = lumit_core::fx::MarkerContext::for_layer(comp, src);
-                        (
-                            lumit_core::fx::resolve_stack(
-                                &src.effects,
-                                slt,
-                                comp_diag * scale,
-                                scale,
-                                &markers,
-                            ),
-                            lut_files(&src.effects, slt),
-                        )
-                    } else {
-                        (Vec::new(), Vec::new())
-                    };
-                    Some(DofInputDraw {
-                        rgba,
-                        tex_w,
-                        tex_h,
-                        fx,
-                        lut_files,
-                        nested: None,
-                    })
+                    slot().map_or(LayerInputDraw::Absent, LayerInputDraw::Layer)
                 })
                 .collect()
         };
@@ -494,7 +504,7 @@ pub fn build_comp_draws_at(
     // own masks and effects apply per its layer_source mode (default:
     // effects and masks — a user grading their matte expects the grade).
     let flare_mattes_for =
-        |effects: &[lumit_core::model::EffectInstance]| -> Vec<Option<DofInputDraw>> {
+        |owner: uuid::Uuid, effects: &[lumit_core::model::EffectInstance]| -> Vec<LayerInputDraw> {
             use lumit_core::model::{EffectNamespace, EffectValue};
             effects
                 .iter()
@@ -505,54 +515,65 @@ pub fn build_comp_draws_at(
                 })
                 .map(|e| {
                     if !matches!(e.param("source_type"), Some(EffectValue::Choice(1))) {
-                        return None;
+                        return LayerInputDraw::Absent;
                     }
-                    let id = e.layer_ref("matte")?;
-                    let src = comp.layers.iter().find(|l| l.id == id)?;
-                    if !in_span(src) {
-                        return None;
+                    // "This layer" (K-288), the default a fresh flare carries:
+                    // detect the lights in the effect's OWN input rather than
+                    // rendering a second layer. On an adjustment layer that
+                    // input is the composite of everything below — which is
+                    // why a flare works on an adjustment layer at all now.
+                    if e.layer_ref("matte") == Some(owner) {
+                        return LayerInputDraw::ThisLayer;
                     }
-                    // A Precomp matte renders its comp (K-266) — "a white
-                    // circle in a precomp" is the natural way to author a
-                    // flare source, and it detected nothing before this.
-                    if let Some(nested) = nested_input_for(src) {
-                        return Some(nested);
-                    }
-                    let mode = e.layer_source("matte");
-                    let (rgba, tex_w, tex_h, natural) = if mode.applies_masks() {
-                        pixels_for(src)?
-                    } else {
-                        let mut bare = src.clone();
-                        bare.masks.clear();
-                        pixels_for(&bare)?
+                    let slot = || -> Option<DofInputDraw> {
+                        let id = e.layer_ref("matte")?;
+                        let src = comp.layers.iter().find(|l| l.id == id)?;
+                        if !in_span(src) {
+                            return None;
+                        }
+                        // A Precomp matte renders its comp (K-266) — "a white
+                        // circle in a precomp" is the natural way to author a
+                        // flare source, and it detected nothing before this.
+                        if let Some(nested) = nested_input_for(src) {
+                            return Some(nested);
+                        }
+                        let mode = e.layer_source("matte");
+                        let (rgba, tex_w, tex_h, natural) = if mode.applies_masks() {
+                            pixels_for(src)?
+                        } else {
+                            let mut bare = src.clone();
+                            bare.masks.clear();
+                            pixels_for(&bare)?
+                        };
+                        let (fx, lut_files) = if mode.folds_effects() && src.switches.fx {
+                            let slt = t_comp - src.start_offset.0.to_f64();
+                            let comp_diag =
+                                ((comp.width as f32).powi(2) + (comp.height as f32).powi(2)).sqrt();
+                            let scale = tex_w as f32 / natural.0.max(1.0);
+                            let markers = lumit_core::fx::MarkerContext::for_layer(comp, src);
+                            (
+                                lumit_core::fx::resolve_stack(
+                                    &src.effects,
+                                    slt,
+                                    comp_diag * scale,
+                                    scale,
+                                    &markers,
+                                ),
+                                lut_files(&src.effects, slt),
+                            )
+                        } else {
+                            (Vec::new(), Vec::new())
+                        };
+                        Some(DofInputDraw {
+                            rgba,
+                            tex_w,
+                            tex_h,
+                            fx,
+                            lut_files,
+                            nested: None,
+                        })
                     };
-                    let (fx, lut_files) = if mode.folds_effects() && src.switches.fx {
-                        let slt = t_comp - src.start_offset.0.to_f64();
-                        let comp_diag =
-                            ((comp.width as f32).powi(2) + (comp.height as f32).powi(2)).sqrt();
-                        let scale = tex_w as f32 / natural.0.max(1.0);
-                        let markers = lumit_core::fx::MarkerContext::for_layer(comp, src);
-                        (
-                            lumit_core::fx::resolve_stack(
-                                &src.effects,
-                                slt,
-                                comp_diag * scale,
-                                scale,
-                                &markers,
-                            ),
-                            lut_files(&src.effects, slt),
-                        )
-                    } else {
-                        (Vec::new(), Vec::new())
-                    };
-                    Some(DofInputDraw {
-                        rgba,
-                        tex_w,
-                        tex_h,
-                        fx,
-                        lut_files,
-                        nested: None,
-                    })
+                    slot().map_or(LayerInputDraw::Absent, LayerInputDraw::Layer)
                 })
                 .collect()
         };
@@ -789,8 +810,8 @@ pub fn build_comp_draws_at(
                     lut_files: lut_files(&layer.effects, lt),
                     // Depth inputs of the enabled built-in `dof` effects, 1:1
                     // with the stack's Resolved::Dof ops (docs/08 §3.22).
-                    dof_inputs: dof_inputs_for(&layer.effects),
-                    flare_mattes: flare_mattes_for(&layer.effects),
+                    dof_inputs: dof_inputs_for(layer.id, &layer.effects),
+                    flare_mattes: flare_mattes_for(layer.id, &layer.effects),
                     flare_lens_files: flare_lens_files(&layer.effects, lt),
                     // The adjust stack resolves at comp scale but runs on
                     // the render target (K-266) — realise rescales.
@@ -1020,8 +1041,8 @@ pub fn build_comp_draws_at(
             // Depth inputs of the enabled built-in `dof` effects, 1:1 with the
             // stack's Resolved::Dof ops (docs/08 §3.22); built the same way
             // export does, so the two blur identically (K-031).
-            dof_inputs: dof_inputs_for(&layer.effects),
-            flare_mattes: flare_mattes_for(&layer.effects),
+            dof_inputs: dof_inputs_for(layer.id, &layer.effects),
+            flare_mattes: flare_mattes_for(layer.id, &layer.effects),
             flare_lens_files: flare_lens_files(&layer.effects, lt),
             fx_ref_width,
             // Per-layer motion blur (docs/06 §4, K-120): the layer's own

--- a/crates/lumit-render/src/build/build_tests.rs
+++ b/crates/lumit-render/src/build/build_tests.rs
@@ -374,6 +374,138 @@ fn a_live_adjustment_layer_emits_a_staging_draw() {
     }
 }
 
+/// **A Lens flare on an adjustment layer flares the picture below it**
+/// (K-288). The regression: the flare's Matte source could only name
+/// *another* layer, and an adjustment layer has no picture of its own, so
+/// putting the effect on one meant hunting for some other layer to point at
+/// — and whichever you picked was the wrong picture, since an adjustment
+/// layer is supposed to act on everything beneath it.
+///
+/// The fix is a reference to the layer the effect is ON, which resolves to
+/// that effect's own input rather than a second render. This test checks the
+/// draw builder's half: the matte slot comes back as
+/// [`LayerInputDraw::ThisLayer`] (nothing to render — `run_ops` binds the
+/// texture it is already carrying), on an adjustment layer and on an
+/// ordinary one alike, and stays `Absent` while the Source type is not
+/// Matte or the reference is unset.
+#[test]
+fn a_flare_matte_pointed_at_its_own_layer_reads_this_layers_input() {
+    use crate::draw::LayerInputDraw;
+    use lumit_core::model::{EffectValue, LayerKind};
+
+    let solid_def = Uuid::now_v7();
+    let base = Layer {
+        markers: Vec::new(),
+        id: Uuid::now_v7(),
+        name: "under".into(),
+        kind: LayerKind::Solid { def: solid_def },
+        in_point: CompTime(Rational::ZERO),
+        out_point: CompTime(Rational::new(10, 1).unwrap()),
+        start_offset: CompTime(Rational::ZERO),
+        transform: TransformGroup::default(),
+        matte: None,
+        parent: None,
+        label: 0,
+        volume_db: lumit_core::anim::Property::zero(),
+        retime: None,
+        interpolation: Default::default(),
+        blend: Default::default(),
+        masks: Vec::new(),
+        paint: Vec::new(),
+        effects: Vec::new(),
+        switches: Switches::default(),
+        extra: serde_json::Map::new(),
+    };
+    let mut doc = Document::new();
+    doc.items.push(lumit_core::model::ProjectItem::Solid(
+        lumit_core::model::SolidDef {
+            id: solid_def,
+            name: "red".into(),
+            colour: LinearColour([1.0, 0.0, 0.0, 1.0]),
+            width: 64,
+            height: 64,
+            extra: serde_json::Map::new(),
+        },
+    ));
+
+    // A flare in Matte mode whose Matte layer is `owner` — exactly what
+    // `add_effect` now writes for a fresh instance.
+    let flare_on = |owner: Uuid, source_type: u32, matte: Option<Uuid>| {
+        let mut fx = lumit_core::fx::instantiate("lens_flare").unwrap();
+        let _ = owner;
+        for p in &mut fx.params {
+            match p.id.as_str() {
+                "source_type" => p.value = EffectValue::Choice(source_type),
+                "matte" => p.value = EffectValue::Layer(matte),
+                _ => {}
+            }
+        }
+        fx
+    };
+
+    let comp_of = |layers: Vec<Layer>| Composition {
+        id: Uuid::now_v7(),
+        name: "Comp".into(),
+        width: 64,
+        height: 64,
+        frame_rate: FrameRate::new(60, 1).unwrap(),
+        duration: Duration(Rational::new(10, 1).unwrap()),
+        background: LinearColour::BLACK,
+        work_area: None,
+        layers,
+        markers: Vec::new(),
+        motion_blur: Default::default(),
+        extra: serde_json::Map::new(),
+    };
+    let map: HashMap<Uuid, &CompLayerPixels> = HashMap::new();
+    let slots = |comp: &Composition| -> Vec<Vec<LayerInputDraw>> {
+        let mut visited = vec![comp.id];
+        build_comp_draws(&doc, comp, 0.0, &map, &mut visited)
+            .into_iter()
+            .map(|d| d.flare_mattes)
+            .collect()
+    };
+
+    // 1. An adjustment layer, the case that did not work at all before.
+    let mut adj = base.clone();
+    adj.id = Uuid::now_v7();
+    adj.name = "adjust".into();
+    adj.kind = LayerKind::Adjustment;
+    adj.effects.push(flare_on(adj.id, 1, Some(adj.id)));
+    let comp = comp_of(vec![adj.clone(), base.clone()]);
+    let drawn = slots(&comp);
+    // Bottom-up: the solid, then the adjustment's staging draw.
+    assert_eq!(drawn.len(), 2);
+    assert!(
+        matches!(drawn[1].as_slice(), [LayerInputDraw::ThisLayer]),
+        "an adjustment layer's flare must read the composite below it"
+    );
+
+    // 2. An ordinary layer pointed at itself reads its own input too — no
+    //    second render of the same picture.
+    let mut own = base.clone();
+    own.id = Uuid::now_v7();
+    own.effects.push(flare_on(own.id, 1, Some(own.id)));
+    let comp = comp_of(vec![own.clone()]);
+    assert!(
+        matches!(slots(&comp)[0].as_slice(), [LayerInputDraw::ThisLayer]),
+        "a layer's own flare must read its own input"
+    );
+
+    // 3. Absent while the Source type is Manual, and while the reference is
+    //    unset — both still the labelled no-flare they always were.
+    for (source_type, matte) in [(0u32, Some(own.id)), (1, None)] {
+        let mut quiet = base.clone();
+        quiet.id = Uuid::now_v7();
+        quiet.effects.push(flare_on(quiet.id, source_type, matte));
+        let comp = comp_of(vec![quiet]);
+        assert!(
+            matches!(slots(&comp)[0].as_slice(), [LayerInputDraw::Absent]),
+            "source {source_type} / matte {matte:?} must stay absent"
+        );
+    }
+}
+
 // --- K-119: Settings → Export filename template ------------------------
 
 /// A paint stroke is stamped into the layer's own pixels before its masks gate

--- a/crates/lumit-render/src/draw.rs
+++ b/crates/lumit-render/src/draw.rs
@@ -91,6 +91,26 @@ pub struct DofInputDraw {
     pub nested: Option<Box<NestedInputDraw>>,
 }
 
+/// What a layer-input parameter resolves to for one effect op (docs/impl/
+/// layer-input.md, K-288): nothing, this effect's own input, or another
+/// layer's picture. One of these per op that declares a Layer parameter,
+/// 1:1 and in order with those ops.
+pub enum LayerInputDraw {
+    /// Unset, dangling, out of its time span, or not in a mode that reads
+    /// one — the effect degrades to its labelled no-op, never a fault.
+    Absent,
+    /// The reference points at the layer the effect is **on** (K-288), so
+    /// the input is that effect's own input at its point in the stack. No
+    /// second render happens: `run_ops` binds the texture it is already
+    /// carrying. On an adjustment layer that texture is the composite of
+    /// everything below, which is the only picture an adjustment layer has —
+    /// so a Lens flare added to one finds the lights in the footage beneath
+    /// it without being pointed anywhere.
+    ThisLayer,
+    /// Another layer, rendered alone at this raster.
+    Layer(DofInputDraw),
+}
+
 /// A layer-input's nested comp render (K-266) — the [`DrawSource::Nested`]
 /// shape, boxed onto [`DofInputDraw`].
 pub struct NestedInputDraw {
@@ -211,19 +231,20 @@ pub struct CompLayerDraw {
     /// `run_ops`. No GPU work happens here; these are just the strings.
     pub lut_files: Vec<Option<String>>,
     /// The depth inputs of the layer's enabled built-in `dof` effects (docs/08
-    /// §3.22, docs/impl/layer-input.md; None = unset/dangling). Because
-    /// `resolve_stack` keeps the same filter and order and a `dof` effect
-    /// always resolves to exactly one `Resolved::Dof`, this list is 1:1 and in
-    /// order with the stack's `Dof` ops — the caller renders each one alone at
-    /// comp size and passes the parallel `layer_inputs` to `run_ops`. Each
+    /// §3.22, docs/impl/layer-input.md). Because `resolve_stack` keeps the
+    /// same filter and order and a `dof` effect always resolves to exactly one
+    /// `Resolved::Dof`, this list is 1:1 and in order with the stack's `Dof`
+    /// ops — the caller renders each one alone at comp size and passes the
+    /// parallel `layer_inputs` to `run_ops`. A [`LayerInputDraw::Layer`]
     /// carries the referenced layer's source pixels; the GPU render happens in
     /// `realise_segment`.
-    pub dof_inputs: Vec<Option<DofInputDraw>>,
+    pub dof_inputs: Vec<LayerInputDraw>,
     /// The Lens flare Matte sources (docs/08 §3.27, K-257), 1:1 with the
-    /// stack's `Resolved::LensFlare` ops: the referenced layer's pixels in
-    /// the same shape the DoF depth inputs take (None = unset/dangling/not
-    /// in Matte mode — the effect then detects nothing, never faults).
-    pub flare_mattes: Vec<Option<DofInputDraw>>,
+    /// stack's `Resolved::LensFlare` ops, in the same shape the DoF depth
+    /// inputs take. [`LayerInputDraw::Absent`] when the reference is unset,
+    /// dangling or the Source type is not Matte — the effect then detects
+    /// nothing, never faults.
+    pub flare_mattes: Vec<LayerInputDraw>,
     /// The `lens_file` paths of the layer's enabled built-in `lens_flare`
     /// effects (K-264), 1:1 with the stack's `Resolved::LensFlare` ops —
     /// None = unset. The caller reads and hashes each file and passes the

--- a/crates/lumit-render/src/fxops.rs
+++ b/crates/lumit-render/src/fxops.rs
@@ -106,6 +106,33 @@ impl LutCache {
     }
 }
 
+/// One layer-input slot as [`run_ops`] receives it — the realised twin of
+/// [`crate::draw::LayerInputDraw`] (docs/impl/layer-input.md, K-288).
+pub enum LayerInput {
+    /// Nothing to read: the effect degrades to its labelled no-op.
+    Absent,
+    /// The effect's **own input** at its point in the stack. There is no
+    /// texture to carry here because only `run_ops` knows it — it is the
+    /// picture the chain is holding when the op comes round, which on an
+    /// adjustment layer is the composite of everything below.
+    ThisLayer,
+    /// Another layer, already rendered alone at this raster.
+    Texture(Tex),
+}
+
+impl LayerInput {
+    /// The texture this slot names, given the texture the chain currently
+    /// holds. `None` for [`LayerInput::Absent`] — the passthrough.
+    #[must_use]
+    pub fn texture<'a>(&'a self, current: &'a Tex) -> Option<&'a Tex> {
+        match self {
+            LayerInput::Absent => None,
+            LayerInput::ThisLayer => Some(current),
+            LayerInput::Texture(t) => Some(t),
+        }
+    }
+}
+
 /// Render one referenced layer alone into the depth input a depth-of-field
 /// effect samples (docs/impl/layer-input.md §2). The **one** helper the preview
 /// (`GpuViewer`) and export (`Renderer`) paths both call, so the depth pass is
@@ -178,15 +205,16 @@ pub fn render_layer_input(
 /// or unreadable file) is a passthrough, exactly like a missing flow field.
 /// `layer_inputs` is the parallel depth-input list (docs/08 §3.22, docs/impl/
 /// layer-input.md): the k-th `Resolved::Dof` op binds `layer_inputs[k]` — the
-/// referenced layer rendered alone at comp size, or `None` (unset, missing or
-/// cyclic) for a passthrough, exactly like a missing LUT.
+/// referenced layer rendered alone at comp size, [`LayerInput::ThisLayer`]
+/// for the effect's own input (K-288), or [`LayerInput::Absent`] (unset,
+/// missing or cyclic) for a passthrough, exactly like a missing LUT.
 /// `flare_mattes` is the parallel Lens flare Matte-source list (docs/08
 /// §3.27, K-257), and `flare_lens` the parallel custom-prescription list
 /// (K-264, `lens_file` as content hash + text; None = use the picked
 /// library lens): the k-th `Resolved::LensFlare` op binds `flare_mattes[k]`
-/// — the referenced matte layer rendered alone at this raster, or `None`
-/// (unset, dangling, or not in Matte mode) which detects no sources, the
-/// LUT/DoF passthrough convention.
+/// — the referenced matte layer rendered alone at this raster, this effect's
+/// own input, or absent (unset, dangling, or not in Matte mode) which
+/// detects no sources, the LUT/DoF passthrough convention.
 #[allow(clippy::too_many_arguments)]
 pub fn run_ops(
     fx: &FxEngine,
@@ -198,8 +226,8 @@ pub fn run_ops(
     neighbours: &[(i32, Tex)],
     flow_field: Option<&Tex>,
     luts: &[Option<LoadedLut>],
-    layer_inputs: &[Option<Tex>],
-    flare_mattes: &[Option<Tex>],
+    layer_inputs: &[LayerInput],
+    flare_mattes: &[LayerInput],
     flare_lens: &[Option<(u64, String)>],
     mut timings: Option<&mut Vec<f32>>,
 ) -> Tex {
@@ -845,7 +873,7 @@ pub fn run_ops(
                 // (the labelled no-op rule; never a fault). The depth is a
                 // whole texture, so it travels beside the op, exactly as the
                 // LUT cube does, since it is not Copy in `Resolved`.
-                let depth = layer_inputs.get(dof_i).and_then(|o| o.as_ref());
+                let depth = layer_inputs.get(dof_i).and_then(|o| o.texture(&tex));
                 dof_i += 1;
                 if let Some(depth) = depth {
                     tex = fx.dof(
@@ -873,7 +901,7 @@ pub fn run_ops(
                 // parameter-hash cache misses. The k-th LensFlare op binds
                 // the k-th `flare_mattes` slot (its Matte source).
                 use lumit_core::fx::lens_flare as lf;
-                let matte = flare_mattes.get(flare_i).and_then(|o| o.as_ref());
+                let matte = flare_mattes.get(flare_i).and_then(|o| o.texture(&tex));
                 let custom = flare_lens.get(flare_i).and_then(|o| o.as_ref());
                 flare_i += 1;
                 let (tier_base, tier_lambda, flare_div) = lf::quality_ladder(p.quality);
@@ -913,7 +941,7 @@ pub fn run_ops(
                     threshold_softness: p.threshold_softness,
                     light_tint: p.light_tint,
                     use_source_colour: p.use_source_colour,
-                    background: p.background,
+                    blend: p.blend,
                     mix: p.mix,
                     bake_key: lf::bake_key_with(p, custom.map(|(h, _)| *h)),
                 };

--- a/crates/lumit-render/src/realise.rs
+++ b/crates/lumit-render/src/realise.rs
@@ -14,7 +14,7 @@
 //! Because every caller drives this one walk, a comp looks the same in the
 //! viewport, in Flutter, and in the exported file (K-031).
 
-use crate::draw::{AccumulationBelow, CompLayerDraw, DofInputDraw, DrawSource};
+use crate::draw::{AccumulationBelow, CompLayerDraw, DrawSource, LayerInputDraw};
 use crate::fxops::LoadedLut;
 
 /// The GPU primitives that turn a comp draw list into a linear texture,
@@ -145,23 +145,33 @@ impl Realiser<'_> {
             .collect()
     }
 
-    /// Render a layer's depth-of-field depth inputs (docs/impl/layer-input.md
-    /// §2): each `DofInputDraw` (the referenced layer's source pixels) is
-    /// uploaded, linearised and resampled into the effect's working raster
-    /// `(w, h)` through the shared [`crate::fxops::render_layer_input`], so the
-    /// parallel `layer_inputs` handed to `run_ops` is 1:1 with the stack's
-    /// `Dof` ops and aligned with the layer texture the kernel blurs. Export
-    /// renders these identically (K-031).
-    fn render_dof_inputs(
+    /// Render a layer's layer-input slots (docs/impl/layer-input.md §2) — the
+    /// depth passes of its `dof` effects, the matte sources of its Lens
+    /// flares. Each [`LayerInputDraw::Layer`] (the referenced layer's source
+    /// pixels) is uploaded, linearised and resampled into the effect's
+    /// working raster `(w, h)` through the shared
+    /// [`crate::fxops::render_layer_input`], so the parallel list handed to
+    /// `run_ops` is 1:1 with the stack's ops and aligned with the layer
+    /// texture the kernel reads. Export renders these identically (K-031).
+    ///
+    /// [`LayerInputDraw::ThisLayer`] (K-288) renders nothing here: it names
+    /// the texture `run_ops` is already carrying, which only `run_ops` can
+    /// hand over, so it passes through as [`LayerInput::ThisLayer`].
+    fn render_layer_inputs(
         &self,
-        inputs: &[Option<DofInputDraw>],
+        inputs: &[LayerInputDraw],
         w: u32,
         h: u32,
-    ) -> Vec<Option<wgpu::Texture>> {
+    ) -> Vec<crate::fxops::LayerInput> {
+        use crate::fxops::LayerInput;
         inputs
             .iter()
             .map(|slot| {
-                let d = slot.as_ref()?;
+                let d = match slot {
+                    LayerInputDraw::Absent => return LayerInput::Absent,
+                    LayerInputDraw::ThisLayer => return LayerInput::ThisLayer,
+                    LayerInputDraw::Layer(d) => d,
+                };
                 // A Precomp input realises its nested comp exactly as a
                 // Precomp layer's picture does (K-266); anything else is
                 // the uploaded source pixels.
@@ -201,7 +211,7 @@ impl Realiser<'_> {
                         None,
                     )
                 };
-                Some(crate::fxops::render_layer_input(
+                LayerInput::Texture(crate::fxops::render_layer_input(
                     self.compositor,
                     &self.ctx,
                     w,
@@ -268,8 +278,8 @@ impl Realiser<'_> {
             // identical to export (K-031). The adjustment stack runs on the
             // comp-sized composite, so its depth inputs resample to comp size.
             let luts = self.load_luts(&l.lut_files);
-            let layer_inputs = self.render_dof_inputs(&l.dof_inputs, tw, th);
-            let flare_mattes = self.render_dof_inputs(&l.flare_mattes, tw, th);
+            let layer_inputs = self.render_layer_inputs(&l.dof_inputs, tw, th);
+            let flare_mattes = self.render_layer_inputs(&l.flare_mattes, tw, th);
             let flare_lens = self.load_flare_lens(&l.flare_lens_files);
             // The stack was resolved against the comp raster; this render
             // target may be smaller (reduced-resolution preview), and every
@@ -505,8 +515,8 @@ impl Realiser<'_> {
                 // The depth-of-field depth inputs, resampled to this layer's
                 // working raster (w, h), 1:1 with the stack's Resolved::Dof ops
                 // (§3.22); the same render export runs (K-031).
-                let layer_inputs = self.render_dof_inputs(&l.dof_inputs, w, h);
-                let flare_mattes = self.render_dof_inputs(&l.flare_mattes, w, h);
+                let layer_inputs = self.render_layer_inputs(&l.dof_inputs, w, h);
+                let flare_mattes = self.render_layer_inputs(&l.flare_mattes, w, h);
                 let flare_lens = self.load_flare_lens(&l.flare_lens_files);
                 // A stack resolved against a raster wider than the one it is
                 // about to run on (a Precomp layer's, under reduced-resolution

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6076,3 +6076,67 @@ The shared widget is `TimeReadout` (`flutter_ui/lib/widgets/time_readout.dart`):
 measured in characters of the face it draws in, a click that turns it into a field holding
 exactly what was shown, and an optional drag for the places that were a drag field before
 they were a clock.
+
+**K-288 · DECIDED · A layer-input parameter may name the layer the effect is on, and
+that means "this effect's own input" — which on an adjustment layer is everything
+below.** A layer reference (K-123, K-142) used to name only *another* layer: the picker
+excluded the owner outright, on the reasonable-sounding ground that sampling yourself is
+not defined. For a depth pass that is true enough. For the Lens flare's Matte source it
+was simply wrong, in two ways at once. On an ordinary layer, "flare the lights in this
+picture" is what asking for a matte source nearly always means, and the effect made you
+go and find the layer you were already standing on. On an **adjustment layer** — which
+has no picture of its own, and whose whole job is to act on the composite beneath it —
+there was nothing correct to point at at all: whichever layer you picked, you were
+detecting lights in the wrong image, and the effect that most wants to sit on an
+adjustment layer was the one that could not.
+
+So a reference to the owning layer resolves, everywhere, to **the effect's own input at
+its point in the stack**. No second render happens — `run_ops` binds the texture it is
+already carrying — which makes it cheaper than any other answer as well as the right
+one, and makes it exactly aligned with the raster the effect writes (a separately
+rendered layer is resampled to get there). On an adjustment layer that texture is the
+composite of everything below, so the flare finds the lights in the footage beneath it
+with no setup. The K-142 source combobox (None / Masks / Effects and masks) does not
+apply to a this-layer reference: nothing is re-rendered, so there is nothing for it to
+choose between.
+
+A schema declares `ParamKind::Layer { self_default }`, and a `true` there means a fresh
+instance **added to a layer** starts pointed at that layer. The Lens flare's Matte layer
+takes it; DoF's Depth layer does not, because a depth pass is never the picture itself —
+though it may still be pointed at this layer by hand, and reads the same input if it is.
+Plain `instantiate` (presets, tests) leaves every reference unset, so the labelled no-op
+stays the value a preset carries. The frame key feeds a distinct marker and stops
+recursing: this layer's own content is already hashed by the walk the parameter is
+inside, and an adjustment layer's below-composite by the other layers' entries, since
+draw order is content.
+
+**K-289 · DECIDED · The Lens flare's Background pair becomes a Blend menu, defaulting
+to Add; Normal is the flare on black.** K-258 gave the flare a two-option Background
+choice — Transparent (the layer's own alpha carries the flare) or Black (the output
+forced opaque, so the flare could be exported as an element over black and Screened or
+Added back in a compositor). That is a blend mode question wearing a disguise: both
+options are answers to "how does this light combine with the picture", and only two of
+the answers were available.
+
+Everything the effect renders is a black-backed light **element** — a frame that is pure
+black where there is no flare — so the honest control is the same menu a layer's Mode
+dropdown offers, applied to that element over the layer beneath. It offers the curated
+light-combine set **Echo** offers (K-149, T21) and omits the same modes for the same
+reason: the HSL, burn and dodge modes are ill-defined on a premultiplied light overlay.
+In code order: Normal, a divider, then Add (the default), Screen, Multiply, Overlay,
+Soft light, Hard light, Lighten, Darken, Difference, Exclusion, Subtract, Divide. Every
+mode runs per channel on all four channels in premultiplied linear light — this is light
+being added to light, not a perceptual re-encode of a finished picture, which is also
+what keeps the CPU reference and the WGSL kernel bit-exact (§1.6) without an sRGB round
+trip.
+
+Two modes carry the old behaviour. **Add** is `out = in + flare` with alpha saturating at
+1 — bit-identical to every flare rendered before this menu existed, which is why it is
+the default and why a project that never touched Background renders the same pixels.
+**Normal** ignores the layer and returns the element on its opaque black background:
+that is precisely the flare-over-black that Background = Black existed to export, so a
+project saved with Black migrates to Normal. The migration runs in
+`backfill_builtin_params` and drops the dead `background` parameter, because the schema
+no longer declares it and the panel cannot draw a row `set_value` refuses. The neutral
+passthroughs (Intensity 0, Mix 0) return before any of this, so they stay bit-exact
+whatever the menu holds.

--- a/docs/08-EFFECTS.md
+++ b/docs/08-EFFECTS.md
@@ -52,13 +52,23 @@ effect's maths in a release invalidates stale cached frames rather than mixing g
   until a file is chosen, the one sanctioned exception to the "no no-op default" rule above,
   since a file the user must supply cannot have a tasteful default.
 - **Layer-reference** parameters (K-123, [impl/layer-input.md](impl/layer-input.md)) name
-  **another layer** in the same composition as an auxiliary picture an effect samples — a
-  depth pass for Depth of field (§3.22). The stored value is an optional layer id (the shape
+  a layer in the same composition as an auxiliary picture an effect samples — a
+  depth pass for Depth of field (§3.22), a bright-source matte for the Lens flare (§3.27).
+  The stored value is an optional layer id (the shape
   a matte reference uses, §5.1 of [03-DATA-MODEL.md](03-DATA-MODEL.md)), static in v1. The
   host renders that layer alone and threads its texture to the effect, exactly as a matte
   layer is rendered alone. An **unset** or **dangling** reference resolves to identity — the
   same sanctioned exception to the "no no-op default" rule, since a layer the user must
-  supply cannot have a tasteful default. Beside the picker sits a **source** combobox
+  supply cannot have a tasteful default.
+  **This layer** (K-288): a reference may name the layer the effect is *on*, and then it is
+  not a second render at all — it is the effect's own input at its point in the stack. On an
+  ordinary layer that is the picture the effect is about to process; on an **adjustment
+  layer** it is the composite of everything below, which is the only picture an adjustment
+  layer has, and which is what makes a matte-sourced effect usable there. A schema may
+  declare this the *default* for one of its layer references (the Lens flare's Matte layer
+  does), in which case a fresh instance added to a layer starts pointed at that layer; the
+  source combobox below does not apply to a this-layer reference, since nothing is
+  re-rendered. Beside the picker sits a **source** combobox
   (K-142, revising K-125's before/after bool) choosing *what of* the referenced layer is
   read: **None** (its raw footage/solid — no masks, no effects), **Masks** (its source plus
   its masks) or **Effects and masks** (its finished picture — a graded or blurred input).
@@ -1216,8 +1226,9 @@ The depth layer only needs to be **in-span**
 preview decode planner and export decode a hidden layer-input reference exactly as they do a
 matte source. The bokeh is a plain flat disc; shaped, bright-rimmed highlights are the
 planned "DOF PRO" second effect. The depth layer is chosen with the inspector's Layer picker
-(a dropdown of the comp's other layers), with the Depth source combobox beside it; an unset
-or dangling reference is a no-op.
+(a dropdown of the comp's layers, its own included — K-288, where it reads the effect's
+own input), with the Depth source combobox beside it; an unset or dangling reference is a
+no-op.
 
 ### 3.23 Invert
 
@@ -1463,15 +1474,35 @@ the tail:
 |---|---|
 | *Lens options* (twirl) | Focus (m) (0.5–100 slider, hard min 0.2 — the focus distance; K-260, refocusing shifts the sensor plane and visibly rearranges the whole ghost train, the "same lens, different focus" look), Anamorphic squeeze (0.5–3), Blades (int 3–16), Rotation, Coating (0 uncoated → 1 fully coated), Roundness, Softness |
 | *Flare options* (twirl) | Ghost intensity (0–4), Ghost softness (0–1 slider, % of the frame diagonal — FlareSim's Ghost Blur, K-261: a touch of out-of-focus softness on the ghost train; default 0.02 since K-264 — taste, not cover: the vertex-smoothed density and the multisampled raster leave nothing for it to hide, and **0 is a clean setting**), Max ghosts (int 0–200 — the brightest survive), **Detail** (0.25–4 slider, default 1; K-265 — multiplies the Quality tier's ray grid AND its traced wavelength count through one shared pair of helpers, so the budget is the user's dial: a lens whose rims still show structure buys more without jumping a tier, a preview buys less), Dispersion (0–2), Starburst intensity (0–4), Scale (0.05–20 — the WHOLE flare about the optical centre, ghosts and starbursts together) |
-| *Source* | Source type (Manual light / Matte / Lights); **Light tint** (a colour, with picker and eyedropper — multiplies every light in every mode); then, shown conditionally: **Use source colour** (Matte *and* Lights) and — Matte only — Matte layer (a layer reference), Threshold (linear luma, slider 0–1, open above), Threshold softness |
+| *Source* | Source type (Manual light / Matte / Lights); **Light tint** (a colour, with picker and eyedropper — multiplies every light in every mode); then, shown conditionally: **Use source colour** (Matte *and* Lights) and — Matte only — Matte layer (a layer reference, defaulting to **this layer**, K-288), Threshold (linear luma, slider 0–1, open above), Threshold softness |
 
-and **Quality** (Draft / Normal / High / Ultra), **Background** (Transparent /
-Black, K-258 — Black makes the output opaque, the flare-element-over-black
-export for Screen/Add workflows; the neutral passthroughs stay bit-exact
-regardless), **Mix**. Blades and Max
-ghosts are the first **Int-kind** parameters (§1.2): stored and animated as
-Float scalars, but declared whole-number so the row steps, displays and
-commits integers.
+and **Quality** (Draft / Normal / High / Ultra), **Blend** (K-289 — how the
+flare element combines with the layer under it; see below), **Mix**. Blades
+and Max ghosts are the first **Int-kind** parameters (§1.2): stored and
+animated as Float scalars, but declared whole-number so the row steps,
+displays and commits integers.
+
+**Blend (K-289, superseding K-258's Background pair).** Everything the effect
+renders is a black-backed light **element**: a frame that is pure black where
+there is no flare. Blend says how that element combines with the layer
+beneath it — the same question a layer's Mode dropdown asks — and offers the
+curated light-combine set Echo does (§3.13, T21), for the same reason: the
+HSL / burn / dodge modes are ill-defined on a premultiplied light overlay, so
+they are not listed. In code order: **Normal**, a divider, then **Add**
+(default), Screen, Multiply, Overlay, Soft light, Hard light, Lighten,
+Darken, Difference, Exclusion, Subtract, Divide. Every mode runs per channel
+on all four channels in premultiplied linear light, and the result's alpha
+saturates at 1.
+
+**Normal** heads the list because it is the odd one out: the element
+*replaces* the layer, black background and all, so you see the flare on
+opaque black. That is exactly what Background = Black existed to produce —
+the flare-element-over-black export for a Screen/Add workflow — and it is
+what a project saved with that option migrates to. **Add** is light
+addition, bit-identical to what the effect did before this menu existed
+(`out = in + flare`, alpha saturating), so a project saved with the old
+default renders the same pixels. The neutral passthroughs (Intensity 0, Mix
+0) stay bit-exact whatever the menu holds.
 
 **Source modes (K-257).** **Manual light** is the tracked-point workflow: one
 white source at the Light point. **Matte** detects the flare's sources in a
@@ -1481,9 +1512,14 @@ the source, gated by the soft Threshold; each anchor's brightness is the
 **summed flux of every gated detection tile nearest it** (K-267), so a
 practical spanning half the frame finally weighs as its whole lit area
 where it used to count as one pixel, while a true point source reads
-exactly as before; the matte layer renders alone
-exactly as a DoF depth pass does (its own masks and effects apply, K-142
-default) and is expected to be hidden. **Lights** is prepared for light
+exactly as before. The matte layer defaults to **this layer** — the layer
+the effect is on (K-288) — because "flare the lights in this picture" is
+what asking for a matte source nearly always means; that reads the effect's
+own input at its point in the stack rather than re-rendering anything, and
+on an **adjustment layer** it is the composite of everything below, which is
+the only picture an adjustment layer has. Point it at any *other* layer and
+that layer renders alone exactly as a DoF depth pass does (its own masks and
+effects apply, K-142 default) and is expected to be hidden. **Lights** is prepared for light
 layers: the option exists and resolves as Manual until they land, so projects
 built against it survive the wiring.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -723,6 +723,41 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   the owner's white-circle precomp flares with the strength of the whole
   circle where it used to count as a single pixel — while a true pinpoint
   light reads exactly as before.
+  A sixth pass fixed two things that had been quietly making the effect
+  harder to use than it needed to be.
+  **The matte now starts on the layer you put the effect on** (K-288).
+  Switching Source to Matte used to leave the Matte layer empty, so the
+  effect did nothing until you went and found a layer to point it at — and
+  the layer you nearly always wanted was the one you were already standing
+  on. Worse: on an **adjustment layer** there was no right answer at all.
+  An adjustment layer has no picture of its own; its job is to act on
+  everything below it. But the picker refused to offer the layer itself
+  ("you can't sample yourself"), so you had to point at some other layer and
+  detect lights in the wrong image. Now the picker does offer it, labelled
+  *(this layer)*, and it means something precise: **read whatever picture is
+  arriving at this effect**. On an ordinary layer that is the layer's own
+  image; on an adjustment layer it is the composite of everything beneath
+  it — which is exactly the picture you wanted flared. Nothing is rendered
+  twice to do it (the effect already has that picture in hand), so it is
+  cheaper as well as more useful, and it lines up pixel-for-pixel with what
+  the flare draws instead of being stretched to fit. The rule applies to any
+  effect that reads another layer, not just this one — the depth-of-field
+  depth pass can be pointed at its own layer too, though it doesn't start
+  there, because a depth map is never the picture itself.
+  **And the Background choice became a Blend menu** (K-289). The flare used
+  to offer Transparent or Black, which was really a blend-mode question in
+  disguise: everything the effect renders is a picture of light on a black
+  background, and those two options were two ways of combining that picture
+  with your layer. So it is now the same menu a layer's own Mode dropdown
+  offers — Normal, then Add, Screen, Multiply, Overlay, Soft light, Hard
+  light, Lighten, Darken, Difference, Exclusion, Subtract, Divide (the same
+  list Echo offers, and short of the layer list for the same reason: hue and
+  colour-burn style modes don't mean anything applied to a glow). **Add** is
+  the default and is exactly what the flare always did, pixel for pixel, so
+  nothing you have already built moves. **Normal** shows the flare on its
+  own black background and hides the layer, which is what "Black" was for —
+  the flare as a separate element you Screen back on in another comp — so a
+  project saved with Black opens on Normal.
 - **RGB split gains a Wavelength mode** (K-090's quality-tier pattern: where the smooth
   look is optional, it hides behind a Bool next to the fast one). Off — the default —
   the split is three tinted samples: the first colour pulled one way, the third the

--- a/docs/impl/layer-input.md
+++ b/docs/impl/layer-input.md
@@ -15,13 +15,37 @@ its texture in. A layer-input parameter is the same idea, but the referenced
 layer's texture is handed to an **effect** instead of the matte stage.
 
 ## 1. The parameter (mirror `MatteRef`)
-- `ParamKind::Layer { }` (fx.rs) — declares the effect wants a reference to
-  another layer (a depth/aux input).
+- `ParamKind::Layer { self_default }` (fx.rs) — declares the effect wants a
+  reference to a layer (a depth/aux input). `self_default: true` means a fresh
+  instance **added to a layer** starts pointed at that layer (K-288); the Lens
+  flare's Matte layer takes it, DoF's Depth layer does not.
 - `EffectValue::Layer(Option<Uuid>)` (model.rs) — the referenced layer's id, or
   None when unset. Exactly the shape of `MatteRef.layer`, minus channel/invert.
 - Inspector: a **Layer picker** arm — a dropdown of the comp's layers by name
   (plus "None"), like the Parent picker in the Effect Controls panel (K-103).
   Selecting sets the id through an undoable op.
+
+### This layer (K-288)
+
+A reference may name **the layer the effect is on**, and then nothing is
+rendered a second time: the slot resolves to that effect's own input at its
+point in the stack. The draw builder answers `LayerInputDraw::ThisLayer` for
+it, `realise` passes that through as `fxops::LayerInput::ThisLayer`, and
+`run_ops` binds the texture it is already carrying.
+
+Two consequences, both wanted. The input is already at the raster the effect
+writes, so no resample stands between them. And on an **adjustment layer** —
+which has no picture of its own — that input is the composite of everything
+below, so a matte-sourced effect (the Lens flare) works there without being
+pointed at some other, wrong layer. The picker therefore offers the owning
+layer, labelled `<name> (this layer)`, whether or not it has a picture of its
+own; every other layer still has to have one.
+
+The K-142 source combobox does not apply to a this-layer reference (nothing is
+re-rendered, so there is nothing to choose between), and the frame key feeds a
+distinct marker and stops rather than recursing: this layer's own content is
+already in the key from the walk the parameter sits inside, and an adjustment
+layer's below-composite from the other layers' own entries.
 
 ## 2. Threading the referenced layer's texture (mirror mattes + the LUT §8)
 `run_ops` takes only `&[Resolved]` (Copy scalars), so — exactly as the LUT

--- a/docs/impl/lens-flare.md
+++ b/docs/impl/lens-flare.md
@@ -362,6 +362,43 @@ the mode can land later without moving any shipped parameter. Full-image convolu
 seconds-per-frame offline technique, not an interactive effect; the top-K model is what
 fits a compositor.
 
+### 6a. Which layer the matte reads (K-288)
+
+The Matte layer parameter defaults to **this layer** — the layer the effect is on — and
+that reference does not render a second picture: it binds the effect's own input at its
+point in the stack (`fxops::LayerInput::ThisLayer`, chosen by the draw builder when the
+reference equals the owning layer's id). Two things fall out of that, and both were
+broken before it:
+
+- **Alignment is free.** The effect's input is already at the raster the flare writes,
+  so no resample stands between the picture and the detection grid. A separately
+  rendered layer has to be stretched to the working raster first.
+- **Adjustment layers work at all.** An adjustment layer has no picture of its own, so
+  the old "point at another layer" model had no correct answer there: whatever you
+  picked, you detected lights in the wrong image. Its input *is* the composite of
+  everything below it, which is exactly the picture an adjustment-layer flare is meant
+  to flare.
+
+Pointing the parameter at any other layer keeps the K-257 behaviour unchanged (rendered
+alone at this raster, its own masks and effects per the K-142 source mode). See K-288
+for the general rule, which covers every layer-input parameter, not just this one.
+
+### 6b. Blending the element in (K-289)
+
+The combine stage no longer asks Transparent-or-Black. It builds the flare **element** —
+`rgb = (ghosts + starbursts) × Intensity`, `a =` that element's Rec. 709 luma, a
+premultiplied black-backed overlay — and hands it to `flare_blend(mode, layer, element)`,
+whose thirteen modes mirror Echo's arithmetic order exactly (per channel, all four
+channels, premultiplied linear). The alpha saturates at 1 afterwards, and Mix lerps the
+whole thing against the untouched input as before.
+
+Add is `layer + element`, which reproduces the pre-menu combine bit for bit, so the
+default moves nothing. Normal returns `(element.rgb, 1)`, ignoring the layer — the flare
+on opaque black, which is what Background = Black produced on the empty layer that
+option was for. `lumit-gpu` keeps its own `BLEND_COUNT` (it does not depend on
+lumit-core) and a test pins it to `BLEND_OPTIONS.len()`, so a mode added to one and not
+the other cannot silently clamp to Divide.
+
 ## 7. Traps (learned the hard way — do not rediscover)
 
 - **Sub-pixel quads are silently dropped by every rasteriser.** The caustic flux that
@@ -465,8 +502,19 @@ fits a compositor.
    "custom file" bakes identically to picking it; the bake key separates library /
    custom / edited-custom; unparsable text degrades to the picked lens bit-for-bit
    (`lens_flare_custom_lens_file_overrides_and_degrades`).
-8. **Neutrals and background**: Black background flips alpha only while live; the
-   passthroughs ignore it.
+8. **Neutrals and blend (K-289)**: Normal shows the element alone on opaque black; Add
+   reproduces the historical `in + flare` with saturating alpha; every option resolves
+   and an index past the menu clamps; the blend table matches its formulas by hand; the
+   Intensity-0 / Mix-0 passthroughs are bit-exact whatever the menu holds. Migration:
+   a saved Transparent becomes Add, a saved Black becomes Normal, the dead parameter
+   goes, and loading twice changes nothing
+   (`lens_flare_background_migrates_to_the_blend_menu`).
+8b. **This layer (K-288)**: a fresh flare's Matte layer points at the layer it was added
+   to, a preset's stays unset, DoF's depth is untouched
+   (`lens_flare_matte_defaults_to_the_layer_it_is_added_to`); the draw builder answers
+   `ThisLayer` for a self-reference on an ordinary layer AND on an adjustment layer, and
+   `Absent` while Source is Manual or the reference is unset
+   (`a_flare_matte_pointed_at_its_own_layer_reads_this_layers_input`).
 9. **Focus**: the thin-lens shift is 0 at infinity, `f²/(1000·d − f)` near, ≤ f always.
 10. **Shader validity** (K-263, `lumit-gpu/tests/wgsl_validates.rs`): every `.wgsl` in
    the crate parses and validates through naga, with no graphics card involved — so a

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -81,7 +81,8 @@ class EffectParamRowFrb extends StatelessWidget {
   final bool twoColumn;
 
   /// The layer this effect sits on, and every layer in the comp — what a
-  /// layer-valued parameter picks from, minus the owner itself (K-194). Both
+  /// layer-valued parameter picks from (K-194). The owner is offered too
+  /// (K-288): picking it means "this layer", the effect's own input. Both
   /// ride in from the read model, so the closed picker costs nothing.
   final UuidValue ownerLayerId;
   final List<BridgeLayerEntry> ownerLayers;
@@ -635,6 +636,10 @@ class EffectParamRowFrb extends StatelessWidget {
   /// container with FFmpeg while drawing a row.
   Widget _layerPicker(BuildContext context, UuidValue id, UuidValue? current) {
     final chosen = current?.toString();
+    // The layer the effect is on says so, so "everything below" is readable
+    // on an adjustment layer rather than an unexplained self-reference.
+    String named(String name, UuidValue layerId) =>
+        layerId == ownerLayerId ? '$name (this layer)' : name;
     return SizedBox(
       width: effectCellWidth + 40,
       child: BareLazyDropdown<UuidValue?>(
@@ -645,19 +650,27 @@ class EffectParamRowFrb extends StatelessWidget {
             ? 'None'
             : (ownerLayers
                     .where((l) => l.layer.internallayerId == current)
-                    .map((l) => l.info.name)
+                    .map((l) => named(l.info.name, l.layer.internallayerId))
                     .firstOrNull ??
                 'Missing layer'),
         options: () => [
           (null, 'None'),
           for (final entry in ownerLayers)
-            // A layer-valued parameter samples another layer's *picture* — a
-            // depth map, a displacement source — so a layer with none (a
-            // camera, an audio-only clip) is not offered, and neither is the
-            // layer the effect is on: sampling itself is not defined.
-            if (entry.layer.internallayerId != ownerLayerId &&
+            // A layer-valued parameter samples a *picture*, so a layer with
+            // none (a camera, an audio-only clip) is not offered.
+            //
+            // The layer the effect is ON is always offered, picture or not
+            // (K-288): picking it does not re-render that layer, it reads
+            // the effect's own input at its point in the stack. That is the
+            // whole point on an **adjustment layer** — which has no picture
+            // of its own, and whose input is the composite of everything
+            // below it. A Lens flare added to one starts here.
+            if (entry.layer.internallayerId == ownerLayerId ||
                 entry.layer.hasPicture())
-              (entry.layer.internallayerId, entry.info.name),
+              (
+                entry.layer.internallayerId,
+                named(entry.info.name, entry.layer.internallayerId)
+              ),
         ],
         onChanged: (picked) => _set(BridgeEffectValue.layer(picked)),
       ),

--- a/flutter_ui/test/frb/effect_controls_frb_test.dart
+++ b/flutter_ui/test/frb/effect_controls_frb_test.dart
@@ -550,6 +550,13 @@ void main() {
       expect(find.text('Threshold'), findsOneWidget);
       expect(find.text('Threshold softness'), findsOneWidget);
 
+      // The Matte layer starts pointed at the layer the effect is ON
+      // (K-288), and the picker says so. Before this it defaulted to None
+      // and the effect sat there detecting nothing until you went hunting
+      // for another layer — which on an adjustment layer, whose only
+      // picture is the composite below, was always the wrong one.
+      expect(find.textContaining('(this layer)'), findsOneWidget);
+
       // Light tint is a source-mode-independent row (K-259); Use source
       // colour appears with Matte and would with Lights.
       expect(find.text('Light tint'), findsOneWidget);
@@ -566,6 +573,22 @@ void main() {
       expect(find.text('Light tint'), findsOneWidget);
       expect(find.text('Use source colour'), findsNothing);
       expect(find.text('Matte layer'), findsNothing);
+    });
+
+    // Blend (K-289): the Transparent/Black Background pair became a blend
+    // menu, defaulting to Add — the behaviour every flare already had.
+    testWidgets('the lens flare offers a blend menu, defaulting to Add',
+        (tester) async {
+      final p = withLayer();
+      p.layer.addEffect(name: 'lens_flare');
+      p.uiState.model.refresh();
+      await mount(tester, p, transform: false);
+
+      expect(find.text('Background'), findsNothing,
+          reason: 'the two-option Background choice is gone');
+      expect(find.text('Blend'), findsOneWidget);
+      expect(find.text('Add'), findsWidgets,
+          reason: 'a fresh flare adds its light, as it always did');
     });
 
     // The Lens picker (K-262, curated K-264). Twenty entries sit well


### PR DESCRIPTION
Two changes to the Lens flare, both about making the effect usable where it was quietly awkward.

Rebased onto `main` at K-287 and **renumbered K-280/K-281 → K-288/K-289** (K-280 and K-281 had been taken by the waveform and audio-reveal work; K-286 by anti-aliasing, K-287 by the time readouts).

## A layer-input reference may name the layer the effect is on (K-288)

A layer reference could only name *another* layer — the picker excluded the owner outright, on the reasonable-sounding ground that sampling yourself is not defined. For a depth pass that is true enough. For the flare's Matte source it was wrong in two ways at once:

- On an **ordinary layer**, "flare the lights in this picture" is what asking for a matte source nearly always means, and the effect made you go and find the layer you were already standing on.
- On an **adjustment layer** there was no correct answer at all. It has no picture of its own, and its whole job is to act on the composite beneath it — so whichever layer you picked, you were detecting lights in the wrong image. The effect that most wants to sit on an adjustment layer was the one that could not.

A reference to the owning layer now resolves, everywhere, to **the effect's own input at its point in the stack**. No second render happens (`run_ops` binds the texture it is already carrying), so it is cheaper than any alternative as well as more useful, and it lines up exactly with the raster the effect writes — a separately rendered layer has to be resampled to get there. On an adjustment layer that texture is the composite of everything below.

- `ParamKind::Layer` gains `self_default`. The flare's Matte layer takes it, so a fresh instance **added to a layer** starts pointed at that layer; DoF's Depth layer does not (a depth pass is never the picture itself), though it may still be pointed at this layer by hand and reads the same input if it is.
- Presets and plain `instantiate` leave every reference unset — the labelled no-op it always was.
- The picker offers the owning layer, labelled ` (this layer)`, picture or not; every other layer still needs one.
- The K-142 source combobox does not apply to a this-layer reference — nothing is re-rendered, so there is nothing to choose between.
- The frame key feeds a distinct marker and stops recursing: this layer's content is already hashed by the walk the parameter sits inside, and an adjustment layer's below-composite by the other layers' entries.

## The Background pair becomes a Blend menu (K-289)

K-258's Transparent/Black choice was a blend-mode question in disguise: everything the effect renders is a black-backed light **element**, and both options were answers to "how does this light combine with the picture" — with only two of the answers available.

It is now the same menu a layer's Mode dropdown offers, applied to that element over the layer beneath, using the curated light-combine set **Echo** offers (K-149, T21) and omitting the same modes for the same reason — the HSL, burn and dodge modes are ill-defined on a premultiplied light overlay. In code order: **Normal**, a divider, then **Add** (default), Screen, Multiply, Overlay, Soft light, Hard light, Lighten, Darken, Difference, Exclusion, Subtract, Divide. Every mode runs per channel on all four channels in premultiplied linear light, alpha saturating at 1.

Two modes carry the old behaviour:

- **Add** is `out = in + flare` with saturating alpha — bit-identical to every flare rendered before this menu existed, which is why it is the default and why nothing already built moves.
- **Normal** ignores the layer and returns the element on its opaque black background: precisely the flare-over-black that Background = Black existed to export.

Migration runs in `backfill_builtin_params` — a saved Transparent becomes Add, a saved Black becomes Normal — and drops the dead `background` parameter, since the schema no longer declares it and the panel cannot draw a row `set_value` refuses. The neutral passthroughs (Intensity 0, Mix 0) return before any of this, so they stay bit-exact whatever the menu holds.

## Tests

- The blend table against its formulas by hand; Normal is the element alone on opaque black; Add reproduces the historical combine; every option resolves and an over-range index clamps rather than faulting.
- The Background → Blend migration, both directions, idempotent, legacy parameter dropped.
- The `self_default` filler: a fresh flare points at its layer, a preset stays unset, DoF's depth is untouched.
- A draw-builder test that a flare's matte resolves to `ThisLayer` on an adjustment layer and on an ordinary one, and stays `Absent` while Source is Manual or the reference is unset.
- `lumit-gpu` pins its `BLEND_COUNT` to `BLEND_OPTIONS.len()`, so a mode added to one crate and not the other cannot silently clamp to Divide.

Re-run after the rebase: `lumit-core`, `lumit-render` and `lumit-eval` green (463 tests), `cargo check --workspace --all-targets` clean, `cargo fmt --check` clean. The GPU oracle tests and the Flutter suites remain CI-covered (no adapter and no Dart toolchain in the dev container).

## Docs

Changed in the same commit, per the repo's standing rule: `08-EFFECTS.md` §3.27 and the §1.2 layer-reference paragraph, `impl/lens-flare.md` (new §6a/§6b plus the test-plan entries), `impl/layer-input.md`, `GUIDE.md`, and K-288 / K-289 appended to `02-DECISIONS.md`.
