### PR TITLE
web: a blank 0.1.0 note to write the first release notes in

### DIFF
--- a/web/src/content/releases/0.1.0.md
+++ b/web/src/content/releases/0.1.0.md
@@ -1,0 +1,9 @@
+---
+title: Lumit 0.1.0
+description: ""
+versionNumber: 0.1.0
+date: 2026-08-02
+---
+
+<!-- The notes go here, in plain Markdown. _template.md beside this file shows
+     what the styling does with headings, lists, links, code and images. -->


### PR DESCRIPTION
The `/releases` page itself is already on `main` — it went in as `3d50bf4` when you asked for it to be pushed straight there rather than opened as a pull request. So there is no page left to add, and this pull request is the other half of the ask: the empty file to write the first notes in.

## What is here

One file, `web/src/content/releases/0.1.0.md`:

- **Frontmatter only.** `title`, an empty `description`, `versionNumber: 0.1.0`, and `date: 2026-08-02` — the day v0.1.0 was published, taken from the release itself rather than guessed.
- **An empty body**, apart from a comment pointing at `_template.md` beside it, which shows what the styling does with headings, lists, links, code and images. Nothing about the wording is mine to write.

## Before merging

Merging it as it stands publishes an **empty entry** — `/releases` grows a `v0.1.0` pill with nothing beside it, and `/releases/0.1.0` becomes a page with a heading and no notes. The site builds fine either way; it just says nothing. So this wants the notes written into it first.

Once they are written, `docs/TODO.md` has a Website line under *Later* that asks to be deleted at that point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8jNrs1BtEsWvb6HTmrrnA)_