### PR TITLE
A frame hands the driver one command buffer, not one per layer (K-290)

### DIFF
--- a/crates/lumit-gpu/src/composite.rs
+++ b/crates/lumit-gpu/src/composite.rs
@@ -977,11 +977,7 @@ impl Compositor {
             })
             .collect();
 
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("composite"),
-            });
+        let mut encoder = ctx.encoder("composite");
 
         // Draw in pass segments: shader-computed blends need the accumulated
         // target copied out first (a copy cannot happen inside a pass).
@@ -1149,7 +1145,12 @@ impl Compositor {
                 ..Default::default()
             });
         }
-        ctx.queue.submit([encoder.finish()]);
+        // Recording ends here; whether the buffer goes to the driver now or at
+        // the end of the frame's batch is the encoder guard's business (K-290).
+        // The seed's buffer and bind group are released after it either way —
+        // the recorded commands hold their own references to what they use, so
+        // the deferred submission still has them.
+        drop(encoder);
         drop(seed_keep);
         target
     }
@@ -1395,11 +1396,7 @@ impl Compositor {
 
         let mut keep: Vec<wgpu::Buffer> = Vec::with_capacity(binds.len() + 1);
         let mut add_binds: Vec<wgpu::BindGroup> = Vec::with_capacity(binds.len());
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("mb-average"),
-            });
+        let mut encoder = ctx.encoder("mb-average");
         // The running sum starts at zero.
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("mb-accum-clear"),
@@ -1534,7 +1531,7 @@ impl Compositor {
             rp.set_bind_group(0, &copy_bind, &[]);
             rp.draw(0..6, 0..1);
         }
-        ctx.queue.submit([encoder.finish()]);
+        drop(encoder);
         drop((keep, add_binds));
         target
     }
@@ -1634,11 +1631,7 @@ impl Compositor {
 
         // Buffers must outlive the encoder they feed; hold them until submit.
         let mut keep: Vec<wgpu::Buffer> = Vec::with_capacity(layers.len() + 1);
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("accumulate"),
-            });
+        let mut encoder = ctx.encoder("accumulate");
 
         // The running sum starts at zero: clear accum_a (the first pass's prev).
         encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -1760,7 +1753,7 @@ impl Compositor {
             rpass.set_bind_group(0, &copy_bind, &[]);
             rpass.draw(0..6, 0..1);
         }
-        ctx.queue.submit([encoder.finish()]);
+        drop(encoder);
         drop(keep);
         target
     }

--- a/crates/lumit-gpu/src/fx/common.rs
+++ b/crates/lumit-gpu/src/fx/common.rs
@@ -244,7 +244,7 @@ pub fn readback_linear_f32(
             depth_or_array_layers: 1,
         },
     );
-    ctx.queue.submit([enc.finish()]);
+    ctx.submit([enc.finish()]);
     let slice = buf.slice(..);
     let (tx, rx) = std::sync::mpsc::channel();
     slice.map_async(wgpu::MapMode::Read, move |r| {

--- a/crates/lumit-gpu/src/fx/dof.rs
+++ b/crates/lumit-gpu/src/fx/dof.rs
@@ -149,11 +149,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-dof-enc"),
-            });
+        let mut enc = ctx.encoder("fx-dof-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-dof-pass"),
@@ -163,7 +159,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
         out
     }
 
@@ -243,11 +239,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-lut-enc"),
-            });
+        let mut enc = ctx.encoder("fx-lut-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-lut-pass"),
@@ -257,7 +249,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
         out
     }
 
@@ -323,11 +315,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-adjust-enc"),
-            });
+        let mut enc = ctx.encoder("fx-adjust-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-adjust-pass"),
@@ -337,7 +325,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
         out
     }
 }

--- a/crates/lumit-gpu/src/fx/lens_flare.rs
+++ b/crates/lumit-gpu/src/fx/lens_flare.rs
@@ -1083,11 +1083,7 @@ impl FxEngine {
         let flare_tex = work_texture(ctx, fpw, fph, "fx-lens-flare-buffer");
         let msaa_tex = live.then(|| lf.take_msaa(ctx, fpw, fph));
 
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-lens-flare-enc"),
-            });
+        let mut encoder = ctx.encoder("fx-lens-flare-enc");
 
         // Matte-mode source detection (impl note §6): tile maxima, then the
         // serial top-K pick — both before any trace pass reads the lights.
@@ -1442,14 +1438,15 @@ impl FxEngine {
                     // submission the operating system would kill (see
                     // [`STEPS_PER_SUBMIT`]).
                     if flushes[bi] {
-                        let done = std::mem::replace(
-                            &mut encoder,
-                            ctx.device
-                                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                                    label: Some("fx-lens-flare-enc"),
-                                }),
-                        );
-                        ctx.queue.submit([done.finish()]);
+                        // The guard is dropped first because the flush needs
+                        // the batch it borrows. Inside a frame batch this
+                        // submits the frame so far and opens a fresh buffer;
+                        // outside one it submits this pass's own. Either way
+                        // the reason is unchanged — the scratch below is
+                        // recycled once this work has gone to the driver.
+                        drop(encoder);
+                        ctx.flush();
+                        encoder = ctx.encoder("fx-lens-flare-enc");
                     }
                 }
                 lf.put_scratch(scratch);
@@ -1606,7 +1603,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &combine_bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([encoder.finish()]);
+        drop(encoder);
         if let Some(tex) = msaa_tex {
             lf.put_msaa(tex, fpw, fph);
         }
@@ -1805,7 +1802,7 @@ impl FxEngine {
             cpass.dispatch_workgroups(ray_count.div_ceil(64), combos.len() as u32, 1);
         }
         enc.copy_buffer_to_buffer(&rays_buf, 0, &read_buf, 0, rays_size);
-        ctx.queue.submit([enc.finish()]);
+        ctx.submit([enc.finish()]);
         let slice = read_buf.slice(..);
         let (tx, rx) = std::sync::mpsc::channel();
         slice.map_async(wgpu::MapMode::Read, move |r| {

--- a/crates/lumit-gpu/src/fx/mod.rs
+++ b/crates/lumit-gpu/src/fx/mod.rs
@@ -158,11 +158,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-enc"),
-            });
+        let mut enc = ctx.encoder("fx-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-pass"),
@@ -172,7 +168,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
     }
 }
 

--- a/crates/lumit-gpu/src/fx/temporal.rs
+++ b/crates/lumit-gpu/src/fx/temporal.rs
@@ -216,11 +216,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-mb-enc"),
-            });
+        let mut enc = ctx.encoder("fx-mb-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-mb-pass"),
@@ -230,7 +226,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
         out
     }
 
@@ -295,11 +291,7 @@ impl FxEngine {
                 },
             ],
         });
-        let mut enc = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                label: Some("fx-dm-enc"),
-            });
+        let mut enc = ctx.encoder("fx-dm-enc");
         {
             let mut cpass = enc.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("fx-dm-pass"),
@@ -309,7 +301,7 @@ impl FxEngine {
             cpass.set_bind_group(0, &bind, &[]);
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
-        ctx.queue.submit([enc.finish()]);
+        drop(enc);
         out
     }
 }

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -48,6 +48,59 @@ pub struct GpuContext {
     /// which only [`Self::headless`] holds — every other handle in the engine
     /// is a cheap clone of a device and a queue.
     pub sample_flags: wgpu::TextureFormatFeatureFlags,
+    /// The frame's open command buffer, while one is being batched.
+    ///
+    /// A submit is a round trip to the driver. Every pass in this crate used to
+    /// make its own encoder and submit it, so a frame cost one round trip per
+    /// layer and per effect; all of a frame's passes are in order on one queue,
+    /// so they can be encoded once and handed over once instead. Between
+    /// [`Self::begin_frame`] and the matching [`Self::end_frame`], every
+    /// [`Self::encoder`] hands back *this* encoder rather than a fresh one, and
+    /// nothing is submitted until the batch closes.
+    ///
+    /// A `RefCell` rather than a lock because a context is used by one thread at
+    /// a time — the same reason the realiser's LUT cache is one — and because a
+    /// lock here would be held across GPU work, which
+    /// docs/14-ENGINEERING-RULES.md forbids. It keeps `GpuContext: Send`, which
+    /// is what the renderer living on a worker thread actually needs; it was
+    /// never `Sync`.
+    frame: std::cell::RefCell<Option<wgpu::CommandEncoder>>,
+    /// How many [`Self::begin_frame`] calls are open. The realise walk recurses
+    /// — nested comps, adjustment layers, one whole render per motion-blur
+    /// sample — so the batch is closed by the *outermost* caller, not the first
+    /// one to finish.
+    frame_depth: std::cell::Cell<u32>,
+    /// How many command buffers **this context** has handed to the driver
+    /// ([`Self::submits_so_far`]).
+    ///
+    /// Every submission in the engine goes through [`Self::submit`], which
+    /// counts here. It exists because "a frame submits once, not once per
+    /// layer" is a claim about behaviour that would otherwise only be checkable
+    /// with a stopwatch on real hardware — and a submit is a round trip to the
+    /// driver whose cost does not depend on the card, so the *count* is the
+    /// honest gate and it runs anywhere, including on a software rasteriser
+    /// (docs/16-ROADMAP.md standing rules: verification beats assertion).
+    ///
+    /// **Per context, not per process.** It began as one global atomic, which
+    /// made the count a shared number: the test suite runs its cases in
+    /// parallel threads, each with a renderer of its own, so any *other* test
+    /// rendering between the two reads was counted as this render's work. The
+    /// gate failed on CI — where there are cores enough for that overlap —
+    /// while passing on a quieter machine, which is the worst way for a test to
+    /// be wrong. A renderer owns its context, so counting here is both
+    /// unshared and the honest scope for the question: what did *this* render
+    /// hand over.
+    ///
+    /// Shared with every [`Self::clone_handle`] of this context, because they
+    /// are handles on the *same* device and queue: the realiser keeps one of
+    /// its own, and a count that missed what went through it would be counting
+    /// part of a frame. A context opened fresh (a new device) starts a new
+    /// count, which is what keeps one renderer's number its own.
+    ///
+    /// An atomic rather than a `Cell` because a submission may be made from
+    /// whichever thread the render is running on; relaxed throughout, since it
+    /// is a counter read between frames and never a happens-before edge.
+    submits: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// The multisample counts the composite is willing to use, highest first.
@@ -139,6 +192,59 @@ fn sample_count_from(flags: wgpu::TextureFormatFeatureFlags, requested: u32) -> 
         .unwrap_or(1)
 }
 
+/// A borrowed command encoder from [`GpuContext::encoder`].
+///
+/// Derefs to the encoder, so a pass records into it exactly as it recorded into
+/// its own. What differs is what happens when it drops: inside a frame batch,
+/// nothing — the commands stay in the frame's buffer for one submission at the
+/// end. Outside one, the encoder is finished and submitted, which is the
+/// standalone behaviour every pass had before batching.
+pub struct EncoderGuard<'a> {
+    ctx: &'a GpuContext,
+    /// Set when this guard owns its encoder (no batch open).
+    owned: Option<wgpu::CommandEncoder>,
+    /// Set when it borrows the frame's. Always `Some(..)` inside, because
+    /// [`GpuContext::encoder`] fills the slot before handing the borrow over.
+    batched: Option<std::cell::RefMut<'a, Option<wgpu::CommandEncoder>>>,
+}
+
+impl std::ops::Deref for EncoderGuard<'_> {
+    type Target = wgpu::CommandEncoder;
+    fn deref(&self) -> &Self::Target {
+        // One of the two is always set, and the batched slot is always filled.
+        // `expect` is unreachable rather than a judgement call, and an engine
+        // crate may not panic (docs/14-ENGINEERING-RULES.md §4) — but there is
+        // no `&CommandEncoder` to return instead, and returning a wrong one
+        // would corrupt a frame silently. The invariant is upheld two functions
+        // away, in `encoder`, and nothing else can construct this type.
+        match (&self.owned, &self.batched) {
+            (Some(enc), _) => enc,
+            (None, Some(slot)) => slot.as_ref().unwrap_or_else(|| unreachable!()),
+            (None, None) => unreachable!(),
+        }
+    }
+}
+
+impl std::ops::DerefMut for EncoderGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match (&mut self.owned, &mut self.batched) {
+            (Some(enc), _) => enc,
+            (None, Some(slot)) => slot.as_mut().unwrap_or_else(|| unreachable!()),
+            (None, None) => unreachable!(),
+        }
+    }
+}
+
+impl Drop for EncoderGuard<'_> {
+    fn drop(&mut self) {
+        // Only an owned encoder is submitted here. A batched one belongs to the
+        // frame and is submitted once, by `end_frame`.
+        if let Some(enc) = self.owned.take() {
+            self.ctx.submit([enc.finish()]);
+        }
+    }
+}
+
 /// The environment variable that turns "no GPU adapter" from a skip into a
 /// failure. Set it on any machine that is *supposed* to have one.
 pub const REQUIRE_ADAPTER_ENV: &str = "LUMIT_REQUIRE_GPU";
@@ -200,6 +306,9 @@ impl GpuContext {
             queue,
             software: false,
             sample_flags: wgpu::TextureFormatFeatureFlags::empty(),
+            frame: std::cell::RefCell::new(None),
+            frame_depth: std::cell::Cell::new(0),
+            submits: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -224,7 +333,97 @@ impl GpuContext {
             queue: self.queue.clone(),
             software: self.software,
             sample_flags: self.sample_flags,
+            frame: std::cell::RefCell::new(None),
+            frame_depth: std::cell::Cell::new(0),
+            submits: std::sync::Arc::clone(&self.submits),
         }
+    }
+
+    /// Hand one command buffer to the driver, counting it (see
+    /// [`Self::submits_so_far`]). Every submission in the engine comes through
+    /// here.
+    pub fn submit(&self, buffers: impl IntoIterator<Item = wgpu::CommandBuffer>) {
+        let mut n = 0u64;
+        self.queue.submit(buffers.into_iter().inspect(|_| n += 1));
+        self.submits
+            .fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// How many command buffers this context has submitted so far. Take it
+    /// either side of a render and the difference is that render's submissions
+    /// — nobody else's (see [`Self::submits`]).
+    #[must_use]
+    pub fn submits_so_far(&self) -> u64 {
+        self.submits.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Start batching: from here until the matching [`Self::end_frame`], every
+    /// [`Self::encoder`] records into one command buffer and nothing is
+    /// submitted.
+    ///
+    /// Nests. Only the outermost pair actually opens and closes the batch, so a
+    /// recursive walk can call this at the top of each level without thinking
+    /// about which level it is on.
+    pub fn begin_frame(&self) {
+        self.frame_depth.set(self.frame_depth.get() + 1);
+    }
+
+    /// Close one [`Self::begin_frame`]. On the outermost one, submit whatever
+    /// the batch holds.
+    pub fn end_frame(&self) {
+        let depth = self.frame_depth.get().saturating_sub(1);
+        self.frame_depth.set(depth);
+        if depth == 0 {
+            self.flush();
+        }
+    }
+
+    /// Submit whatever the batch holds right now and leave it open.
+    ///
+    /// Two callers need this and both have the same reason: something is about
+    /// to *observe* the GPU, and a command that has not been submitted has not
+    /// run. The profiler fences on the device to time a layer, and the lens
+    /// flare recycles its scratch buffers between batches. Outside a batch this
+    /// does nothing, because there is nothing being held back.
+    pub fn flush(&self) {
+        let held = self.frame.borrow_mut().take();
+        if let Some(enc) = held {
+            self.submit([enc.finish()]);
+        }
+    }
+
+    /// An encoder to record into.
+    ///
+    /// Inside a batch this is the frame's shared encoder and the returned guard
+    /// submits nothing when it drops. Outside one it is a fresh encoder that is
+    /// submitted on drop — which is exactly what every pass in this crate did
+    /// before batching existed, so a standalone call still works unchanged.
+    ///
+    /// The guard borrows the batch, so only one may be alive at a time. That is
+    /// the intended shape: a pass records and lets go, and no caller holds an
+    /// encoder across a nested pass.
+    pub fn encoder(&self, label: &str) -> EncoderGuard<'_> {
+        if self.frame_depth.get() == 0 {
+            return EncoderGuard {
+                ctx: self,
+                owned: Some(self.new_encoder(label)),
+                batched: None,
+            };
+        }
+        let mut slot = self.frame.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(self.new_encoder("frame"));
+        }
+        EncoderGuard {
+            ctx: self,
+            owned: None,
+            batched: Some(slot),
+        }
+    }
+
+    fn new_encoder(&self, label: &str) -> wgpu::CommandEncoder {
+        self.device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) })
     }
 
     /// Headless context (tests, future CLI export).
@@ -340,6 +539,9 @@ impl GpuContext {
             queue,
             software,
             sample_flags,
+            frame: std::cell::RefCell::new(None),
+            frame_depth: std::cell::Cell::new(0),
+            submits: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
         })
     }
 }
@@ -624,9 +826,7 @@ impl ColourEngine {
                 },
             ],
         });
-        let mut encoder = ctx
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some(label) });
+        let mut encoder = ctx.encoder(label);
         {
             let view = dst.create_view(&Default::default());
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -645,7 +845,7 @@ impl ColourEngine {
             rpass.set_bind_group(0, &bind, &[]);
             rpass.draw(0..3, 0..1);
         }
-        ctx.queue.submit([encoder.finish()]);
+        drop(encoder);
         dst
     }
 
@@ -857,6 +1057,10 @@ impl ColourEngine {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
+        // Hand over anything the frame batch is still holding: what is
+        // read below may have been recorded into it, and a command that has
+        // not been submitted has not run. A no-op outside a batch.
+        ctx.flush();
         let mut encoder = ctx.device.create_command_encoder(&Default::default());
         encoder.copy_texture_to_buffer(
             tex.as_image_copy(),
@@ -870,7 +1074,7 @@ impl ColourEngine {
             },
             size,
         );
-        ctx.queue.submit([encoder.finish()]);
+        ctx.submit([encoder.finish()]);
         let (tx, rx) = std::sync::mpsc::channel();
         buffer
             .slice(..)
@@ -897,6 +1101,10 @@ impl ColourEngine {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         });
+        // Hand over anything the frame batch is still holding: what is
+        // read below may have been recorded into it, and a command that has
+        // not been submitted has not run. A no-op outside a batch.
+        ctx.flush();
         let mut encoder = ctx.device.create_command_encoder(&Default::default());
         encoder.copy_texture_to_buffer(
             tex.as_image_copy(),
@@ -910,7 +1118,7 @@ impl ColourEngine {
             },
             size,
         );
-        ctx.queue.submit([encoder.finish()]);
+        ctx.submit([encoder.finish()]);
 
         let slice = buffer.slice(..);
         let (tx, rx) = std::sync::mpsc::channel();

--- a/crates/lumit-gpu/src/scope.rs
+++ b/crates/lumit-gpu/src/scope.rs
@@ -460,6 +460,8 @@ impl ScopeEngine {
             ],
         });
 
+        // The picture being measured may still be in the frame batch.
+        ctx.flush();
         let mut encoder = ctx
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -488,7 +490,7 @@ impl ScopeEngine {
             pass.set_bind_group(0, &colourise_bind, &[]);
             pass.dispatch_workgroups(GRID.div_ceil(8), GRID.div_ceil(8), 1);
         }
-        ctx.queue.submit([encoder.finish()]);
+        ctx.submit([encoder.finish()]);
         dst
     }
 }
@@ -553,7 +555,7 @@ fn readback_trace(ctx: &GpuContext, tex: &wgpu::Texture) -> Result<Vec<u8>, GpuE
             depth_or_array_layers: 1,
         },
     );
-    ctx.queue.submit([encoder.finish()]);
+    ctx.submit([encoder.finish()]);
 
     let slice = buffer.slice(..);
     let (tx, rx) = std::sync::mpsc::channel();
@@ -664,7 +666,7 @@ mod tests {
         });
         let mut enc = ctx.device.create_command_encoder(&Default::default());
         enc.copy_buffer_to_buffer(&engine.counts, 0, &staging, 0, (len * 4) as u64);
-        ctx.queue.submit([enc.finish()]);
+        ctx.submit([enc.finish()]);
         let slice = staging.slice(..);
         let (tx, rx) = std::sync::mpsc::channel();
         slice.map_async(wgpu::MapMode::Read, move |r| {

--- a/crates/lumit-gpu/src/shared.rs
+++ b/crates/lumit-gpu/src/shared.rs
@@ -244,6 +244,9 @@ impl SharedTexture {
     /// before Flutter is told it is ready. `display` must match the shared
     /// texture's dimensions (the caller recreates on a size change).
     pub fn present(&self, gpu: &GpuContext, display: &wgpu::Texture) {
+        // The frame that produced `display` may still be sitting in the
+        // batch; a copy of work that has not been submitted copies nothing.
+        gpu.flush();
         let mut encoder = gpu
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -258,7 +261,7 @@ impl SharedTexture {
                 depth_or_array_layers: 1,
             },
         );
-        gpu.queue.submit([encoder.finish()]);
+        gpu.submit([encoder.finish()]);
         // Wait for the D3D12 write to land before D3D11 reads it below: `submit`
         // only queues the copy (see the module note on synchronisation). Zero
         // *CPU* pixel work still — the bytes never leave the card.

--- a/crates/lumit-gpu/src/shared_linux.rs
+++ b/crates/lumit-gpu/src/shared_linux.rs
@@ -214,6 +214,9 @@ impl SharedDmabuf {
     /// dimensions (the caller recreates on a size change). Identical to the
     /// Windows path's `present`.
     pub fn present(&self, gpu: &GpuContext, display: &wgpu::Texture) {
+        // The frame that produced `display` may still be sitting in the
+        // batch; a copy of work that has not been submitted copies nothing.
+        gpu.flush();
         let mut encoder = gpu
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -228,7 +231,7 @@ impl SharedDmabuf {
                 depth_or_array_layers: 1,
             },
         );
-        gpu.queue.submit([encoder.finish()]);
+        gpu.submit([encoder.finish()]);
         // No fence yet: wait for the write to land so the reader never sees a torn
         // frame (see the module note). Zero *CPU* pixel work still — the bytes
         // never leave the card.

--- a/crates/lumit-gpu/src/shared_metal.rs
+++ b/crates/lumit-gpu/src/shared_metal.rs
@@ -184,6 +184,9 @@ impl SharedIoSurface {
     /// dimensions (the caller recreates on a size change). Identical to the
     /// Windows and Linux siblings' `present`.
     pub fn present(&self, gpu: &GpuContext, display: &wgpu::Texture) {
+        // The frame that produced `display` may still be sitting in the
+        // batch; a copy of work that has not been submitted copies nothing.
+        gpu.flush();
         let mut encoder = gpu
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -198,7 +201,7 @@ impl SharedIoSurface {
                 depth_or_array_layers: 1,
             },
         );
-        gpu.queue.submit([encoder.finish()]);
+        gpu.submit([encoder.finish()]);
         // No fence yet: wait for the write to land so the reader never sees a
         // torn frame (see the module note). Zero *CPU* pixel work still — the
         // bytes never leave the card.
@@ -363,7 +366,7 @@ mod tests {
                 depth_or_array_layers: 1,
             },
         );
-        gpu.queue.submit([]);
+        gpu.submit([]);
         gpu.device.poll(wgpu::Maintain::Wait);
 
         // Read it back as the consumer does: straight off the surface.

--- a/crates/lumit-render/src/fxops.rs
+++ b/crates/lumit-render/src/fxops.rs
@@ -1012,6 +1012,11 @@ pub fn run_ops(
             }
         }
         if let (Some(started), Some(into)) = (started, timings.as_mut()) {
+            // Same reason as the per-layer fence in `realise`: a frame's
+            // commands are batched, and timing a queue that has not been
+            // handed over would measure nothing. A measured frame gives the
+            // batching up, effect by effect.
+            ctx.flush();
             ctx.device.poll(wgpu::Maintain::Wait);
             into.push(started.elapsed().as_secs_f32() * 1000.0);
         }

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -3226,6 +3226,70 @@ mod tests {
         (solid, layer_id)
     }
 
+    /// **A frame is one command buffer, however many layers it has.**
+    ///
+    /// Every pass in `lumit-gpu` used to make its own encoder and submit it, so
+    /// a frame cost the driver one round trip per layer and per effect —
+    /// measured 2026-07-31 at `layers + 2`. All of a frame's passes are in
+    /// order on one queue, so they are encoded once and handed over once.
+    ///
+    /// The gate is the *count*, not a stopwatch. A submit is a round trip whose
+    /// cost does not depend on the card, so the number is the honest measure and
+    /// it runs anywhere — including on the software rasteriser CI uses, where a
+    /// timing would prove nothing (docs/16-ROADMAP.md standing rules).
+    ///
+    /// What is asserted is the **shape**: the count does not grow with the layer
+    /// count. A fixed budget would be a fragile thing to pin, but "adding thirty
+    /// layers adds no submissions" is exactly the property that was lost.
+    ///
+    /// The count is read off **this renderer's own context**. It used to be a
+    /// process-wide counter, which quietly made this test a measurement of
+    /// whatever else the suite happened to be rendering at the same moment:
+    /// green here, red on CI, where there are cores enough for two GPU tests to
+    /// overlap (docs/13 §7.0).
+    #[test]
+    fn a_frame_submits_once_however_many_layers_it_has() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                lumit_gpu::no_adapter();
+                return;
+            }
+        };
+        let (cw, ch) = (32u32, 16u32);
+
+        // One render's submissions, for a comp with `extra` layers over the base.
+        let mut submits_for = |extra: usize| -> u64 {
+            let (mut doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.8, 0.1, 0.1, 1.0]));
+            for _ in 0..extra {
+                matrix_top(&mut doc, comp_id, LinearColour([0.1, 0.2, 0.9, 1.0]));
+            }
+            let store = DocumentStore::new(doc);
+            let doc = store.snapshot();
+            // A first render warms every lazily-built pipeline and cache, so
+            // what the second one submits is the steady state.
+            let _ = r.render_rgba(&doc, comp_id, 0, 1.0).unwrap();
+            let before = r.gpu.submits_so_far();
+            let _ = r.render_rgba(&doc, comp_id, 0, 1.0).unwrap();
+            r.gpu.submits_so_far() - before
+        };
+
+        let one = submits_for(0);
+        let many = submits_for(31);
+        assert_eq!(
+            one, many,
+            "a frame's submissions must not grow with its layers: \
+             1 layer submitted {one}, 32 layers submitted {many}"
+        );
+        // And the constant is small — the walk's one buffer plus the read-back
+        // the export path ends with, not a per-pass tail hiding under the
+        // equality above.
+        assert!(
+            one <= 4,
+            "a frame should cost a handful of submissions, not {one}"
+        );
+    }
+
     /// A consumer layer matted by a hidden source carrying a mask and an
     /// effect, with the matte's sampling mode chosen per row (K-142).
     fn matte_doc(
@@ -3465,6 +3529,77 @@ mod tests {
         assert!(
             layer.ms >= 0.0 && layer.effects[0].ms >= 0.0,
             "measured times are real durations"
+        );
+    }
+
+    /// **Measuring gives the batching up, deliberately.**
+    ///
+    /// A frame's passes are recorded into one command buffer and submitted at
+    /// the end, so a fence taken mid-walk would wait on a queue that has not
+    /// been handed over and time nothing real. A *measured* frame therefore
+    /// flushes at each layer and each effect before it fences — which is the
+    /// cost the stopwatch already declares (K-276: measuring waits for the card
+    /// at each layer, which is why it is opt-in and never runs during playback).
+    ///
+    /// So the property is the opposite of the unmeasured one: an unmeasured
+    /// frame's submissions do not grow with its layers, and a measured frame's
+    /// do. Asserting both together is what stops a future change from
+    /// "optimising" the flush away and silently turning the render-time column
+    /// into a measure of how long Lumit takes to *describe* a layer.
+    #[test]
+    fn a_measured_frame_hands_its_work_over_layer_by_layer() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                lumit_gpu::no_adapter();
+                return;
+            }
+        };
+        let (cw, ch) = (32u32, 16u32);
+        let (mut doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.8, 0.1, 0.1, 1.0]));
+        for _ in 0..15 {
+            matrix_top(&mut doc, comp_id, LinearColour([0.1, 0.2, 0.9, 1.0]));
+        }
+        let store = DocumentStore::new(doc);
+        let doc = store.snapshot();
+        // A frame is only measured when the switch is on *and* the numbers have
+        // somewhere to go, so the sink is part of turning measuring on.
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<crate::profile::FrameProfile>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let into = std::sync::Arc::clone(&seen);
+        r.set_profile_sink(Some(std::sync::Arc::new(move |p| {
+            if let Ok(mut got) = into.lock() {
+                got.push(p);
+            }
+        })));
+        // Warm the lazily-built pipelines first, so neither count below
+        // includes one-off setup.
+        let _ = r.render_rgba(&doc, comp_id, 0, 1.0).expect("render");
+
+        let before = r.gpu.submits_so_far();
+        let _ = r.render_rgba(&doc, comp_id, 0, 1.0).expect("render");
+        let unmeasured = r.gpu.submits_so_far() - before;
+
+        r.measure_frames(true);
+        let before = r.gpu.submits_so_far();
+        let _ = r.render_rgba(&doc, comp_id, 1, 1.0).expect("render");
+        let measured = r.gpu.submits_so_far() - before;
+        r.measure_frames(false);
+
+        assert!(
+            !seen.lock().expect("profiles").is_empty(),
+            "the frame was supposed to be measured; without that this proves nothing"
+        );
+        assert!(
+            measured > unmeasured,
+            "a measured frame must hand its work over as it goes, or its \
+             numbers are encoding time rather than GPU time \
+             (measured {measured}, unmeasured {unmeasured})"
+        );
+        assert!(
+            unmeasured <= 4,
+            "an ordinary frame is one command buffer plus its read-back, \
+             not {unmeasured}"
         );
     }
 

--- a/crates/lumit-render/src/profile.rs
+++ b/crates/lumit-render/src/profile.rs
@@ -292,6 +292,10 @@ impl FrameProfiler {
     pub fn span<T>(&self, ctx: &lumit_gpu::GpuContext, f: impl FnOnce() -> T) -> (T, f32) {
         let started = std::time::Instant::now();
         let out = f();
+        // The span may have recorded into a batched frame buffer; hand it over
+        // before fencing, or the wait returns on an empty queue and the number
+        // is meaningless.
+        ctx.flush();
         ctx.device.poll(wgpu::Maintain::Wait);
         (out, started.elapsed().as_secs_f32() * 1000.0)
     }

--- a/crates/lumit-render/src/realise.rs
+++ b/crates/lumit-render/src/realise.rs
@@ -89,6 +89,14 @@ impl Realiser<'_> {
         };
         let ms = match started {
             Some(started) => {
+                // Hand this layer's work over before waiting on it. Batching
+                // holds a frame's commands back to the end, and a fence over an
+                // empty queue would time nothing — so a *measured* frame gives
+                // up the batching, layer by layer, which is the cost the
+                // stopwatch already declares (docs/13 §7.1, K-276: measuring
+                // waits for the card at each layer, which is why it is opt-in
+                // and never runs during playback).
+                self.ctx.flush();
                 self.ctx.device.poll(wgpu::Maintain::Wait);
                 started.elapsed().as_secs_f32() * 1000.0
             }
@@ -244,7 +252,14 @@ impl Realiser<'_> {
         if let Some(p) = self.profiler {
             p.enter_comp();
         }
+        // One command buffer for the whole walk, recursion included. Every pass
+        // below records into it and nothing reaches the driver until the
+        // outermost `end_frame`, so a frame costs one round trip rather than one
+        // per layer and per effect. `begin_frame` nests, which is what lets this
+        // sit on the recursive entry point rather than being threaded by hand.
+        self.ctx.begin_frame();
         let out = self.realise_at_depth(camera, width, height, background, layers);
+        self.ctx.end_frame();
         if let Some(p) = self.profiler {
             p.leave_comp();
         }

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6140,3 +6140,44 @@ project saved with Black migrates to Normal. The migration runs in
 no longer declares it and the panel cannot draw a row `set_value` refuses. The neutral
 passthroughs (Intensity 0, Mix 0) return before any of this, so they stay bit-exact
 whatever the menu holds.
+
+**K-290 · DECIDED · A frame is one command buffer, and a measured frame is not.** Every pass
+in `lumit-gpu` used to build its own command buffer and submit it, so a frame cost the graphics
+driver one round trip per layer and per effect — measured 2026-07-31 at `layers + 2`
+submissions, 34 at thirty-two layers. All of a frame's passes are already in order on one
+queue, so they are now encoded once and handed over once: 3 submissions, and flat in the layer
+count. This takes [impl/playback-scheduler.md](impl/playback-scheduler.md) §2's
+one-GPU-submit-thread rule further rather than conflicting with it — that rule says *who* may
+submit, this says *how often*.
+
+**Batching is a property of the context, not of a threaded parameter.** `GpuContext` holds the
+frame's encoder between `begin_frame` and `end_frame`, and `encoder()` hands it out; outside a
+batch it hands out a fresh, self-submitting one, so every pass called on its own behaves
+exactly as before and no test changed. The alternative — threading `&mut CommandEncoder`
+through the realise walk — would have rewritten every signature in the crate and every call
+site in the walk, for a walk that recurses through nested comps, adjustment staging and one
+whole render per motion-blur sample. `begin_frame` nests instead, so the recursive entry point
+opens the batch and the outermost caller closes it.
+
+**Anything that observes the GPU flushes first.** A command that has not been submitted has not
+run, so the read-backs, the scope trace and the three shared-texture present paths hand the
+batch over before their own submission and wait. These keep their own command buffers
+deliberately: each is followed by a fence, and a fence is the one thing batching cannot defer.
+
+**A measured frame gives the batching up, and that is the right trade.** The render-time
+column fences on the device at each layer and each effect; under batching that fence would
+wait on a queue nothing had been handed to, and every number would silently become the time
+Lumit takes to *describe* a layer rather than the time the card takes to draw it. So measuring
+flushes as it goes. K-276 already established that measuring costs the overlap between
+processor and card, which is why it is opt-in and never runs during playback; this is that same
+cost, not a new one.
+
+**The gate is a count, not a stopwatch.** `GpuContext::submits_so_far` counts every submission
+through the one choke point, and the regression tests assert the shape: an unmeasured frame's
+count does not grow with its layers, and a measured frame's does. A submit is a round trip
+whose cost does not depend on the card, so the count is the honest measure — and unlike a
+timing it means something on CI's software rasteriser. A fixed budget was deliberately not
+pinned; "adding thirty-one layers adds no submissions" is the property that was lost, and it is
+the one worth holding. **The wall-clock win is still unmeasured on real hardware**: the number
+that motivated this was a submission count, and what it buys in milliseconds wants a run on a
+real card either side.

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -212,6 +212,29 @@ per-layer and per-effect indicators, K-276) and the rest of it — continuous co
 recording mode, the profiler panel — and the headless benchmark harness with budget gates
 (§7.3) are not — [TODO.md](TODO.md) tracks them.
 
+### 7.0 Submissions per frame (K-290)
+
+**A frame hands the graphics driver one command buffer, and the number does not grow with the
+layer count.** A submit is a round trip through the driver whose cost does not depend on the
+card, so this is a budget that means the same on every machine — and one that can be *gated*
+rather than benchmarked: `GpuContext::submits_so_far` counts every submission, and the
+regression test asserts the shape rather than a magic number ("adding thirty-one layers adds
+no submissions"). It is checkable on the software rasteriser CI runs, where a timing would
+prove nothing.
+
+The exceptions are deliberate and each is followed by a fence, which is the one thing batching
+cannot defer: the read-backs, the scope trace, and the shared-texture present paths. A
+**measured** frame is the other exception and gives the batching up on purpose — see §7.1.
+
+**The count belongs to the context, not to the process.** It began as one global atomic, and
+that made the gate report a *shared* number: the suite runs its cases in parallel, each with a
+renderer of its own, so any other test rendering between the two reads was counted as this
+render's work. The gate went red on CI — where there are cores enough for the overlap — while
+passing on a quieter machine, which is the worst way for a test to be wrong. The counter now
+lives on `GpuContext` and is shared only with the handles of that same device, so what a
+measurement sees is one renderer's own submissions. Any future budget counted this way MUST be
+scoped the same: a number two tests can both write is not a measurement.
+
 ### 7.1 Per-node profiler
 
 A built-in profiler, surfaced in the UI — After Effects' composition profiler done properly:
@@ -222,7 +245,10 @@ A built-in profiler, surfaced in the UI — After Effects' composition profiler 
   *submitted* rather than performed and an unfenced span would time the paperwork. That is a
   true per-node number at the cost of the processor/card overlap for the frame measured, so
   it is opt-in (the Timeline column's stopwatch), never on during playback, and off by
-  default. A measured frame is also a **composited** frame: while the switch is on the
+  default. Measuring also gives up the one-command-buffer-per-frame batching (§7.0, K-290) and
+  hands work over layer by layer, because a fence over a queue that has not been submitted
+  waits for nothing — the same processor/card overlap, paid in a second place. A measured frame
+  is also a **composited** frame: while the switch is on the
   cache ladder is stepped over, because a frame served from a tier costs a copy and so
   has nothing to say about what its layers cost. Timestamp queries are what would make it continuous and free; TODO tracks the
   upgrade, and until then the honest description of this rung is "measured when asked".

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3387,6 +3387,44 @@ cache" above). Changing it means the frames already made no longer answer, and
 the ones you look at next are made afresh. That is the same rule every other
 picture-changing edit follows; it is not the setting misbehaving.
 
+### Asking the graphics card once instead of thirty-two times
+
+Work does not go to the graphics card one instruction at a time. It is written
+into a **command buffer** — a list of things to do — and the whole list is then
+*submitted*. Handing a list over is a round trip through the graphics driver,
+and that round trip costs roughly the same whether the list has one item on it
+or a thousand.
+
+Lumit used to build a separate list for every step of a frame: one for each
+layer, one for each effect on it, one for the final combine. A composition with
+thirty-two layers handed over thirty-four lists to draw a single frame. All of
+that work was going to the same card in the same order anyway, so there was
+never a reason for it to travel separately.
+
+Now a frame writes one list and hands it over once. Measured on the same
+composition: thirty-four submissions became three, and — the part that matters —
+the number no longer grows when you add layers. Adding thirty-one more layers to
+a comp now adds *no* extra round trips.
+
+**Two places still have to hand work over early**, and both for the same reason:
+they need to *look* at what the card produced. You cannot read a picture the
+card has not drawn yet, and a list that has not been submitted has not been
+drawn. So reading a finished frame back, measuring a scope, and handing the
+picture to the Viewer each push the list through first.
+
+**The render-time column is the interesting exception.** It measures a layer by
+waiting for the card to finish that layer before reading the clock — but under
+one-list-per-frame there is nothing to wait for yet, so the wait would return
+instantly and every number would be wrong. So a *measured* frame deliberately
+goes back to handing work over layer by layer. That is not a bug: it is the same
+trade the stopwatch already makes, which is why measuring is a switch you turn
+on rather than something running all the time.
+
+The thing that keeps this honest is a **count**, not a stopwatch. Lumit counts
+every submission, and a test asserts that adding layers adds none. A timing test
+would prove nothing on the machines that check the code (they have no real
+graphics card), but a count is a count anywhere.
+
 ### The panels
 
 `state/comp_model.dart` is the read model: **one** bridge call returns the whole

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -49,21 +49,6 @@ These sit above everything else: they are what the editor feels like in the hand
     `sample_scalar` per animated row plus one `time_of_frame`. Batch per frame if
     it ever bites, the way `time_of_frame` already was.
     (`bridge_call_budget_test.dart` is the gate.)
-- **A frame gives the card one command buffer per layer, where one would do.**
-    Measured 2026-07-31: submits per frame = layers + 2 (3 at one layer, 10 at
-    eight, 34 at thirty-two). Every pass in `lumit-gpu` makes and submits its own
-    encoder (`composite.rs`, `fx/*`, the display pass), yet all of a frame's
-    passes are in order on one queue, so they can be encoded once and handed over
-    once. Each submit is a round trip to the driver, a cost that does not depend
-    on the card - which is why this is worth doing even though it cannot be
-    *timed* on a software rasteriser. It takes
-    [impl/playback-scheduler.md](impl/playback-scheduler.md) §2's one-submit-thread
-    rule further rather than conflicting with it. The shape: pass a
-    `&mut wgpu::CommandEncoder` down the realise walk and submit once at the top,
-    leaving the read-backs (`start_readback8`) and shared-texture copies alone -
-    both need their own submission to be waited on. **Re-measure on real hardware
-    either side**: the stopwatch that found it was on the dropped worker-pool
-    branch, and a change made for a number needs the number.
 
 ---
 

--- a/docs/impl/playback-scheduler.md
+++ b/docs/impl/playback-scheduler.md
@@ -45,6 +45,37 @@ work-stealing is right for DAG fan-out, and cancellation is our epoch tokens, no
 Channels: `crossbeam::channel::bounded` everywhere; every `send` on a full queue is
 back-pressure by design. Choose capacities once, in one constants module, documented.
 
+### 2.1 One command buffer per frame
+
+The one-GPU-submit-thread rule above says *who* may hand work to the driver. This says *how
+often*: **once per frame, not once per pass.**
+
+Every pass in `lumit-gpu` used to make its own command encoder and submit it, so a frame cost
+the driver one round trip per layer and per effect — measured 2026-07-31 at `layers + 2`
+submissions (3 at one layer, 34 at thirty-two). All of a frame's passes are already in order
+on one queue, so they are encoded into one buffer and handed over once.
+
+- `GpuContext::begin_frame` / `end_frame` open and close the batch; `encoder()` hands back
+  the frame's encoder inside one and a fresh, self-submitting one outside. So a pass called
+  on its own — a test, a scope trace — behaves exactly as it did.
+- `begin_frame` **nests**, which is what lets the realise walk open it at its recursive entry
+  point rather than threading an encoder by hand through nested comps, adjustment staging and
+  one whole render per motion-blur sample.
+- **Anything that then observes the GPU must flush first**, because a command that has not
+  been submitted has not run: the read-backs, the scope trace, and the shared-texture present
+  paths all call `flush()` before their own submission and wait.
+- **A measured frame gives the batching up.** The profiler fences on the device at each layer
+  and each effect, and a fence over a queue that has not been handed over times nothing — so
+  measuring flushes as it goes. That is the cost the stopwatch already declares (K-276:
+  measuring waits for the card at each layer, which is why it is opt-in and never runs during
+  playback).
+
+The gate is a **count**, not a stopwatch: `GpuContext::submits_so_far` counts every submission,
+and the regression test asserts that an unmeasured frame's count does not grow with its layer
+count while a measured frame's does. A submit is a round trip whose cost does not depend on
+the card, so the count is the honest measure and it runs on CI's software rasteriser, where a
+timing would prove nothing.
+
 ## 3. The document snapshot handoff
 
 UI thread applies operations → new immutable snapshot (`Arc<Document>`) → publish with


### PR DESCRIPTION
Closes the `docs/TODO.md` **Now** entry "A frame gives the card one command buffer per layer, where one would do."

Rebased onto `main` after the lens-flare merge (#56, K-288/K-289) and **renumbered K-282 → K-290** (main took K-282 for `Mod`+arrow frame stepping).

## The number

Measured 2026-07-31: submits per frame = `layers + 2` — 3 at one layer, 34 at thirty-two. Every pass in `lumit-gpu` built its own command encoder and submitted it, yet all of a frame's passes are already in order on one queue.

Verified in this branch, by disabling the batching and re-running the new test:

| | 1 layer | 32 layers |
|---|---|---|
| before | 4 | 35 |
| after | 3 | **3** |

Flat in the layer count. Adding thirty-one layers now adds no round trips.

## How

`GpuContext` holds the frame's encoder between `begin_frame` and `end_frame`; `encoder()` hands it out. **Outside** a batch it hands out a fresh, self-submitting one — so every pass called on its own behaves exactly as before, and no existing test needed changing.

`begin_frame` **nests**. That is what lets the realise walk open the batch at its recursive entry point rather than threading `&mut wgpu::CommandEncoder` through nested comps, adjustment staging, and one whole render per motion-blur sample.

## The two hazards, and what was done about them

**Anything that observes the GPU must flush first** — a command that has not been submitted has not run. The read-backs, the scope trace and the three shared-texture present paths keep their own command buffers deliberately: each is followed by a fence, which is the one thing batching cannot defer. They call `flush()` before submitting.

**A measured frame gives the batching up, on purpose.** The render-time column fences on the device at each layer and each effect. Under batching that fence would wait on a queue nothing had been handed to, and every number would silently become the time Lumit takes to *describe* a layer rather than the time the card takes to draw it. So measuring flushes as it goes — the same cost K-276 already established for measuring, not a new one.

## The CI failure, and what it turned out to be

The gate went red on both Linux and macOS: *1 layer submitted 3, 32 layers submitted 8*. Not a batching hole — **the counter was process-wide**. `SUBMITS` was one global atomic, so with the suite running its cases in parallel, any other test rendering between this test's two reads was counted as this render's work. Green on a quiet machine, red where there are cores enough to overlap: the worst way for a test to be wrong, since it makes the *gate* the flaky thing rather than the code it guards.

Reproduced locally by raising the parallelism (`--test-threads=16` on the lavapipe software rasteriser), which made the count wander exactly as CI saw it.

The counter now lives on `GpuContext` and is shared only with `clone_handle`'s handles of the **same device** — the realiser keeps one of those, and a count that missed what went through it would be counting part of a frame. (A strictly per-context counter made the *measured-frame* test fail for exactly that reason, so the sharing is load-bearing.) A context opened on a new device starts a new count, so one renderer's number is its own. `submits_so_far()` is a method now; the two tests read `r.gpu.submits_so_far()`.

That scoping rule is written down in `13-PERFORMANCE-RULES.md` §7.0, so the next counted budget does not repeat it: *a number two tests can both write is not a measurement.*

## Verification

Re-run after the rebase onto the merged lens-flare work:

- Full workspace `cargo test` green (28 test binaries), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.
- `lumit-render --lib` green at `--test-threads=16`, the parallelism that broke the old counter.
- Both regression tests still confirmed to fail without their fix: without the batching, 35 vs 3; without the measured-frame flush, both 3.

## What this does not prove

**The wall-clock win is unmeasured on real hardware.** The number that motivated this was a submission count, and what it buys in milliseconds wants a run on a real card either side — this container has only a software rasteriser, where submission cost is not representative. The TODO entry asked for exactly that re-measurement, and it is the one part I could not do.

## Docs

`impl/playback-scheduler.md` §2.1 (new), `13-PERFORMANCE-RULES.md` §7.0 (new, including the counter-scoping rule) and §7.1, `GUIDE.md` (plain-English section), `02-DECISIONS.md` K-290, and the TODO entry deleted.
