### PR TITLE
The lock actually locks: enforced in the engine, and the rows stop offering edits (K-291)

### DIFF
--- a/crates/lumit-core/src/ops.rs
+++ b/crates/lumit-core/src/ops.rs
@@ -24,6 +24,8 @@ pub enum OpError {
     InvalidSpan,
     #[error("invalid parent: would form a cycle, self-parent, or unknown layer")]
     InvalidParent,
+    #[error("the layer is locked")]
+    LayerLocked,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -346,7 +348,86 @@ pub enum AutoFolderKind {
 }
 
 /// Apply `op` to `doc`, returning the exact inverse operation.
+/// The `(comp, layer)` a lock would protect this op from, or `None` when the
+/// lock has nothing to say about it.
+///
+/// **Lock protects the work, not the housekeeping.** A locked layer refuses
+/// every edit to what it *is* — its transform, effects, masks, paint, art,
+/// text, clips, markers, blend, matte, parent, retime, volume, switches, its
+/// span, its place in the stack and its existence. It still accepts the three
+/// that are about the Timeline's own bookkeeping rather than the composition:
+/// the lock itself (or it could never be undone), **shy** (a filter on the
+/// list, which changes no pixel and no timing) and the **label** colour.
+///
+/// Ops that name no layer — a comp setting, a project item, a folder — are not
+/// the lock's business and answer `None`.
+#[must_use]
+fn lock_guards(op: &Op) -> Option<(Uuid, Uuid)> {
+    match op {
+        // The three a locked layer still accepts.
+        Op::SetLayerLocked { .. } | Op::SetLayerShy { .. } | Op::SetLayerLabel { .. } => None,
+
+        Op::RemoveLayer { comp, layer }
+        | Op::ReorderLayer { comp, layer, .. }
+        | Op::SetLayerSpan { comp, layer, .. }
+        | Op::RenameLayer { comp, layer, .. }
+        | Op::SetLayerMasks { comp, layer, .. }
+        | Op::SetLayerPaint { comp, layer, .. }
+        | Op::SetShapeContents { comp, layer, .. }
+        | Op::SetLayerEffects { comp, layer, .. }
+        | Op::SetLayerFx { comp, layer, .. }
+        | Op::SetLayerThreeD { comp, layer, .. }
+        | Op::SetSequenceClips { comp, layer, .. }
+        | Op::SetLayerAudible { comp, layer, .. }
+        | Op::SetLayerVisible { comp, layer, .. }
+        | Op::SetLayerSolo { comp, layer, .. }
+        | Op::SetLayerMotionBlur { comp, layer, .. }
+        | Op::SetLayerCollapse { comp, layer, .. }
+        | Op::SetTextDocument { comp, layer, .. }
+        | Op::SetLayerMarkers { comp, layer, .. }
+        | Op::SetLayerBlend { comp, layer, .. }
+        | Op::SetLayerMatte { comp, layer, .. }
+        | Op::SetLayerParent { comp, layer, .. }
+        | Op::SetTransformProperty { comp, layer, .. }
+        | Op::SetCameraZoom { comp, layer, .. }
+        | Op::SetLayerVolume { comp, layer, .. }
+        | Op::SetRetimeProperty { comp, layer, .. }
+        | Op::SetLayerInterpolation { comp, layer, .. } => Some((*comp, *layer)),
+
+        // Everything else names no layer to lock: comp settings, project items,
+        // folders, and `Batch`, whose members are each guarded on their own way
+        // through `apply`.
+        _ => None,
+    }
+}
+
+/// Whether `layer` in `comp` is locked. An unknown comp or layer is not locked:
+/// the op's own arm reports what is actually missing, which is a better error
+/// than "locked".
+#[must_use]
+fn is_locked(doc: &Document, comp: Uuid, layer: Uuid) -> bool {
+    doc.comp(comp)
+        .and_then(|c| c.layers.iter().find(|l| l.id == layer))
+        .is_some_and(|l| l.switches.locked)
+}
+
 pub fn apply(doc: &mut Document, op: &Op) -> Result<Op, OpError> {
+    // **The lock is enforced here, not in the interface** (K-291). The Timeline
+    // already refused the *gestures* — the bar, the razor, rename, reorder,
+    // delete — but a locked layer's transform, effect and volume rows went on
+    // editing it, so the switch did not mean what it says. One guard covers
+    // every op, every caller and every op yet to be written; a guard per row
+    // would have to be remembered each time a row is added, and forgetting one
+    // is exactly how this hole opened.
+    //
+    // A `Batch` is guarded by its members: each goes through here on its way
+    // in, and a refusal rolls the whole batch back, so a batch is still all or
+    // nothing.
+    if let Some((comp, layer)) = lock_guards(op) {
+        if is_locked(doc, comp, layer) {
+            return Err(OpError::LayerLocked);
+        }
+    }
     match op {
         Op::AddItem { index, item } => {
             if *index > doc.items.len() {

--- a/crates/lumit-core/src/store.rs
+++ b/crates/lumit-core/src/store.rs
@@ -1550,4 +1550,209 @@ mod tests {
         assert!(store.commit(Op::RemoveItem { id: Uuid::now_v7() }).is_err());
         assert_eq!(store.revision(), r3, "a refused op moves nothing");
     }
+
+    /// A comp holding one layer, and its ids — the setting every lock test
+    /// needs before it can lock anything.
+    fn doc_with_layer() -> (DocumentStore, Uuid, Uuid) {
+        let comp = test_comp();
+        let comp_id = comp.id;
+        let layer = test_layer(Uuid::now_v7());
+        let layer_id = layer.id;
+        let store = DocumentStore::new(Document::new());
+        store
+            .commit(Op::AddItem {
+                index: 0,
+                item: Box::new(ProjectItem::Composition(comp)),
+            })
+            .expect("the comp goes in");
+        store
+            .commit(Op::AddLayer {
+                comp: comp_id,
+                index: 0,
+                layer: Box::new(layer),
+            })
+            .expect("the layer goes in");
+        (store, comp_id, layer_id)
+    }
+
+    fn lock(store: &DocumentStore, comp: Uuid, layer: Uuid, locked: bool) {
+        store
+            .commit(Op::SetLayerLocked {
+                comp,
+                layer,
+                locked,
+            })
+            .expect("the lock switch is never itself refused");
+    }
+
+    /// **A locked layer refuses the edits the interface used to let through**
+    /// (K-291). The Timeline guarded the *gestures* — the bar, the razor,
+    /// rename, reorder, delete — while the fold-out's transform, effect and
+    /// volume rows went on editing the layer, so the switch did not mean what
+    /// it says. The guard is in the op applier, so it covers every caller.
+    #[test]
+    fn a_locked_layer_refuses_an_edit_to_what_it_is() {
+        let (store, comp, layer) = doc_with_layer();
+        // Unlocked, the edit lands.
+        store
+            .commit(Op::RenameLayer {
+                comp,
+                layer,
+                name: "Before".into(),
+            })
+            .expect("an unlocked layer renames");
+
+        lock(&store, comp, layer, true);
+        let revision = store.revision();
+
+        let refused = store.commit(Op::RenameLayer {
+            comp,
+            layer,
+            name: "After".into(),
+        });
+        assert_eq!(refused, Err(OpError::LayerLocked));
+        assert_eq!(
+            store.revision(),
+            revision,
+            "a refused op moves nothing, so nothing to undo is left behind"
+        );
+        let doc = store.snapshot();
+        let l = &doc.comp(comp).expect("comp").layers[0];
+        assert_eq!(l.name, "Before", "the layer kept what it had");
+    }
+
+    /// The row families the backlog named — transform, effect and volume — plus
+    /// the structural edits, all refused through the one guard.
+    #[test]
+    fn a_locked_layer_refuses_every_family_of_edit() {
+        let (store, comp, layer) = doc_with_layer();
+        lock(&store, comp, layer, true);
+
+        let refused: Vec<Op> = vec![
+            Op::SetLayerVolume {
+                comp,
+                layer,
+                animation: crate::anim::Animation::Static(0.0),
+            },
+            Op::SetLayerEffects {
+                comp,
+                layer,
+                effects: Vec::new(),
+            },
+            Op::SetLayerVisible {
+                comp,
+                layer,
+                visible: false,
+            },
+            Op::SetLayerBlend {
+                comp,
+                layer,
+                blend: BlendMode::Multiply,
+            },
+            Op::SetLayerMasks {
+                comp,
+                layer,
+                masks: Vec::new(),
+            },
+            Op::RemoveLayer { comp, layer },
+            Op::ReorderLayer {
+                comp,
+                layer,
+                new_index: 0,
+            },
+        ];
+        for op in refused {
+            assert_eq!(
+                store.commit(op.clone()),
+                Err(OpError::LayerLocked),
+                "{op:?} must be refused while the layer is locked"
+            );
+        }
+    }
+
+    /// **Lock protects the work, not the housekeeping.** The lock itself has to
+    /// be accepted or it could never be undone; shy is a filter on the
+    /// Timeline's list and the label is a colour, and neither changes a pixel
+    /// or a frame.
+    #[test]
+    fn a_locked_layer_still_takes_the_lock_the_shy_flag_and_its_label() {
+        let (store, comp, layer) = doc_with_layer();
+        lock(&store, comp, layer, true);
+
+        store
+            .commit(Op::SetLayerShy {
+                comp,
+                layer,
+                shy: true,
+            })
+            .expect("shy is a view filter, not an edit to the work");
+        store
+            .commit(Op::SetLayerLabel {
+                comp,
+                layer,
+                label: 3,
+            })
+            .expect("a label colour is housekeeping");
+        // And the way back out.
+        lock(&store, comp, layer, false);
+        store
+            .commit(Op::RenameLayer {
+                comp,
+                layer,
+                name: "Unlocked".into(),
+            })
+            .expect("an unlocked layer edits again");
+    }
+
+    /// A batch is one undo step, so it is all or nothing: a member that names a
+    /// locked layer refuses the whole batch and leaves the document as it was.
+    #[test]
+    fn a_batch_touching_a_locked_layer_is_refused_whole() {
+        let (store, comp, layer) = doc_with_layer();
+        lock(&store, comp, layer, true);
+        let revision = store.revision();
+
+        let refused = store.commit(Op::Batch {
+            ops: vec![
+                Op::SetWorkArea {
+                    comp,
+                    work_area: None,
+                },
+                Op::RenameLayer {
+                    comp,
+                    layer,
+                    name: "Sneaked in".into(),
+                },
+            ],
+        });
+        assert_eq!(refused, Err(OpError::LayerLocked));
+        assert_eq!(store.revision(), revision, "the batch left nothing behind");
+    }
+
+    /// **Undo still works across a lock**, which is the property that makes the
+    /// guard safe to put in the applier at all: an edit can only have been made
+    /// while the layer was unlocked, so walking backwards always meets the
+    /// unlock before it meets the edit.
+    #[test]
+    fn undo_walks_back_past_a_lock_to_the_edit_beneath_it() {
+        let (store, comp, layer) = doc_with_layer();
+        store
+            .commit(Op::RenameLayer {
+                comp,
+                layer,
+                name: "Edited".into(),
+            })
+            .expect("edit while unlocked");
+        lock(&store, comp, layer, true);
+
+        // Back past the lock…
+        store.undo().expect("undo the lock");
+        // …and then past the edit, which is only reachable because the layer is
+        // unlocked again by the time the inverse is applied.
+        store.undo().expect("undo the edit under it");
+        let doc = store.snapshot();
+        let l = &doc.comp(comp).expect("comp").layers[0];
+        assert!(!l.switches.locked, "the lock came off first");
+        assert_ne!(l.name, "Edited", "and the edit under it came back out");
+    }
 }

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6181,3 +6181,37 @@ pinned; "adding thirty-one layers adds no submissions" is the property that was 
 the one worth holding. **The wall-clock win is still unmeasured on real hardware**: the number
 that motivated this was a submission count, and what it buys in milliseconds wants a run on a
 real card either side.
+
+**K-291 · DECIDED · The lock is enforced in the engine, and it protects the work rather than
+the housekeeping.** The Timeline guarded the *gestures* a locked layer offers — its bar, the
+razor, rename, reorder, delete — while the fold-out's transform, effect and volume rows went on
+editing it. So the switch did not mean what its own tooltip says ("Locked — no edits until
+unlocked"), and the backlog carried the open question: guard the rows, or enforce in the engine?
+
+**Enforce in the engine.** One guard at the top of `apply` covers every op, every caller, and
+every op yet to be written. A guard per row has to be remembered each time a row is added, and
+forgetting one is precisely how this hole opened — the rows that leaked are the three *newest*
+families of row. The refusal is `OpError::LayerLocked`, which crosses the bridge as an ordinary
+op error.
+
+**And guard the rows anyway, for the interface's sake.** A locked layer's property rows are now
+shown but not touchable: the numbers are still the document's and the curves still draw, but
+nothing on the row takes a pointer. That is not belt-and-braces for its own sake — without it
+the interface would go on offering a gesture the engine would only refuse, which is a worse
+answer than not offering it. *Group* rows stay live: twirling one open is navigation, not
+editing, and a locked layer you could not look inside would be worse than one you can.
+
+**Lock protects the work, not the housekeeping.** A locked layer refuses every edit to what it
+*is* — transform, effects, masks, paint, art, text, clips, markers, blend, matte, parent,
+retime, volume, its switches, its span, its place in the stack, its existence. It still accepts
+three: the **lock itself** (or it could never be undone), **shy** (a filter on the Timeline's
+list, changing no pixel and no timing) and the **label** colour. That line is drawn where it is
+because "locked means the composition does not change" is a sentence a user can hold, and
+neither of the other two changes the composition. If it turns out to be the wrong line, it is
+the reversible half of this decision — the guard's shape does not depend on it.
+
+**Undo still crosses a lock, which is what makes the guard safe to put in the applier.** An
+edit can only have been made while the layer was unlocked, so the journal always holds the
+unlock *after* the edit, and walking backwards meets the unlock first. A `Batch` is guarded by
+its members — each passes through `apply` on its way in, and a refusal rolls the whole batch
+back, so a batch stays all or nothing. Both are pinned by tests.

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -1069,6 +1069,16 @@ stays on screen. Still to build: `=`/`-`/`\`, and edge-follow during playback.
   **Shipped (K-193):** dragging a layer's **bar** moves it in time, and dragging a layer's
   **name** in the outline moves it up or down the stack — drop it on a row and it takes
   that row's place, as one undo step. A locked layer neither drags nor accepts a drop.
+
+  **What the lock means (K-291).** A locked layer refuses every edit to what it *is* — its
+  transform, effects, masks, paint, art, text, clips, markers, blend, matte, parent, retime,
+  volume, its switches, its span, its place in the stack and its existence. The refusal is in
+  the **engine**, so it holds for every caller, not only the gestures the Timeline happens to
+  guard; the property rows are also shown read-only, so the interface never offers a gesture
+  that would only be refused. A *group* heading in the fold-out stays live: twirling one open
+  is navigation, not editing. Three things a locked layer still accepts, because they are the
+  Timeline's own bookkeeping rather than the composition: the **lock** itself (or it could
+  never be undone), **shy**, and the **label** colour.
   Footage or a comp dragged in from the Project panel lands **where it was dropped** —
   the slot the pointer let go over, by the same midpoint rule — rather than always at the
   top of the stack; a drop past the last layer lands at the bottom.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3487,6 +3487,34 @@ bridge (K-222, K-237), paint strokes stored as the *drag* rather than the pixels
 and re-stamped at render resolution (K-227), the razor (K-221), pan behind
 (K-220), the type tool (K-225) and camera tools (K-229).
 
+### What the lock switch actually does
+
+Locking a layer used to stop you dragging its bar, cutting it, renaming it,
+reordering it or deleting it — but you could still open its twirl-down and
+change its position, its effects or its volume. The switch said "no edits until
+unlocked" and meant something narrower.
+
+Now the refusal lives in the **engine**, in the one place every edit passes
+through on its way into the document. That matters more than it sounds: there
+are twenty-nine different kinds of edit a layer can receive, and guarding them
+one interface control at a time means remembering to do it again every time a
+new control is added — which is exactly how the hole opened, since the three
+kinds of row that leaked are the three newest.
+
+The rows are also shown greyed and untouchable, so you are not offered a gesture
+that would only be refused. Headings still open and close: looking inside a
+locked layer is not editing it.
+
+Three things a locked layer still accepts, because none of them changes the
+composition: **unlocking it** (or you could never get back), the **shy** flag
+(which only hides the row from the Timeline's list) and its **label colour**.
+Everything else waits until you unlock it.
+
+Undo still works across a lock, and the reason is worth knowing because it is
+what makes the whole approach safe: an edit can only have been made while the
+layer was *unlocked*, so walking backwards through your history always reaches
+the unlock before it reaches the edit underneath.
+
 ### What is remembered, and where
 
 - **The workspace** — panel arrangement, colour scheme, interface scale, tooltips,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -245,9 +245,6 @@ colour individually; only the two Timeline tokens default from the mode.
     in [04-RETIMING.md](04-RETIMING.md).
 - **The Flow column is reserved, not wired** - per-layer optical flow has no
     engine backing. Build the engine model first, then the fold-out's Flow group.
-- **Lock guards the gestures, not the property rows** - a locked layer's bar,
-    razor, rename, reorder and delete refuse; its transform/effect/volume rows are
-    still editable. Guard the rows or enforce in the engine ops; decide which.
 - **The Timeline's two halves are built twice and kept in step by hand.**
     `_Outline` and `_LayerArea` are separate widget trees walking the same layer
     list, aligned only because both read the same numbers, with vertical scroll

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -2486,6 +2486,11 @@ class _FoldRow extends StatelessWidget {
   final ValueChanged<String> onToggle;
   final VoidCallback onChanged;
 
+  /// Whether the layer this row belongs to is locked (K-291). A locked layer's
+  /// rows are still *read* — the numbers are what the document holds and the
+  /// curves still draw — but nothing on them can be touched.
+  final bool locked;
+
   const _FoldRow({
     required this.comp,
     required this.layer,
@@ -2502,6 +2507,7 @@ class _FoldRow extends StatelessWidget {
     required this.onSeek,
     required this.onToggle,
     required this.onChanged,
+    required this.locked,
   });
 
   @override
@@ -2532,7 +2538,19 @@ class _FoldRow extends StatelessWidget {
                 : null,
       ),
       padding: EdgeInsets.only(left: indent, right: 4),
-      child: _control(context),
+      // A locked layer's rows are read-only, not hidden (K-291): the numbers
+      // are still the document's and the curves still draw, but nothing on the
+      // row can be touched. The engine refuses the edit anyway — this is what
+      // stops the interface offering a gesture that would only be refused.
+      //
+      // A *group* row is exempt: twirling one open is navigation, not editing,
+      // and a locked layer that could not be looked inside would be worse than
+      // one that can.
+      child: locked && row is! FoldGroupRow && row is! FoldWaveformRow
+          ? AbsorbPointer(
+              child: Opacity(opacity: 0.5, child: _control(context)),
+            )
+          : _control(context),
     );
   }
 
@@ -4541,6 +4559,7 @@ class _Outline extends StatelessWidget {
                   onSeek: onSeek,
                   onToggle: onToggle,
                   onChanged: onChanged,
+                  locked: layers[i].info.switches.locked,
                 ),
               ),
               ],

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -18,6 +18,7 @@ import 'package:uuid/uuid.dart';
 import 'package:lumit_flutter/panels/project_panel_frb.dart';
 import 'package:lumit_flutter/panels/layer_fold_frb.dart';
 import 'package:lumit_flutter/panels/timeline_panel_frb.dart';
+import 'package:lumit_flutter/panels/transform_rows_frb.dart';
 import 'package:lumit_flutter/state/timeline_columns.dart';
 import 'package:lumit_flutter/state/tools.dart';
 import 'package:lumit_flutter/src/rust/api/assets.dart';
@@ -3031,6 +3032,64 @@ void main() {
       await tester.pump();
       expect(find.byKey(ValueKey<String>('tl-rename-$id')), findsNothing,
           reason: 'a locked name does not open the editor');
+    });
+
+    /// **A locked layer's property rows are read-only too** (K-291). The lock
+    /// used to guard only the *gestures* — the bar, the razor, rename, reorder,
+    /// delete — while the fold-out's transform, effect and volume rows went on
+    /// editing the layer, so the switch did not mean what it says.
+    ///
+    /// Two halves, and this is the interface one: the rows are shown, and their
+    /// numbers are still the document's, but nothing on them can be touched. The
+    /// engine refuses the edit as well (`OpError::LayerLocked`, covered in
+    /// lumit-core), so this is what stops the interface offering a gesture that
+    /// would only be refused.
+    testWidgets("a locked layer's property rows cannot be touched",
+        (tester) async {
+      final p = withComp();
+      final layer = p.comp.addSolidLayer();
+      await mount(tester, p);
+      final id = layer.internallayerId;
+
+      // Twirl the layer open so its Transform rows are on screen.
+      await tester.tap(find.byKey(ValueKey<String>('tl-twirl-$id')));
+      await tester.pump();
+      await settleFrb(tester, minRounds: 4);
+      final transformGroup =
+          find.byKey(ValueKey<String>('tl-group-$id/transform'));
+      final groupRect = tester.getRect(transformGroup);
+      await tester.tapAt(Offset(groupRect.left + 6, groupRect.center.dy));
+      await tester.pump();
+      await settleFrb(tester, minRounds: 4);
+
+      final position = find.byType(TransformRowFrb);
+      expect(position, findsWidgets, reason: 'the transform rows are on screen');
+      expect(
+        find.ancestor(of: position.first, matching: find.byType(AbsorbPointer)),
+        findsNothing,
+        reason: 'an unlocked layer\'s rows are live',
+      );
+
+      await tester.tap(find.byKey(ValueKey<String>('tl-locked-$id')));
+      await tester.pump();
+      await settleFrb(tester, minRounds: 4);
+      expect(layer.getSwitches().locked, isTrue);
+
+      expect(position, findsWidgets,
+          reason: 'a locked row is shown, not hidden — the numbers still read');
+      expect(
+        find.ancestor(of: position.first, matching: find.byType(AbsorbPointer)),
+        findsWidgets,
+        reason: 'but nothing on it can be touched',
+      );
+      // The group heading stays live: twirling one open is navigation, not
+      // editing, and a locked layer you could not look inside would be worse.
+      final group = find.byKey(ValueKey<String>('tl-group-$id/transform'));
+      expect(
+        find.ancestor(of: group, matching: find.byType(AbsorbPointer)),
+        findsNothing,
+        reason: 'a group row is exempt',
+      );
     });
 
     /// Enter turns the selected layer's name into an editor (K-243); submitting


### PR DESCRIPTION
Closes the `docs/TODO.md` entry *"Lock guards the gestures, not the property rows"*, which carried its own urgency: *"do not leave the two disagreeing for long."*

Rebased onto `main` at K-290 and **renumbered K-284 → K-291** (main took K-284 for the waveform tiers).

## The hole

The Timeline guarded the **gestures** a locked layer offers — bar, razor, rename, reorder, delete — while the fold-out's transform, effect and volume rows went on editing it. The switch's own tooltip says *"Locked — no edits until unlocked"*, and it wasn't true.

## The open question, answered: enforce in the engine

The backlog left it as *"guard the rows or enforce in the engine ops; decide which."*

**In the engine.** One guard at the top of `apply` covers every op, every caller and every op yet to be written. A guard per row must be remembered each time a row is added — and forgetting one is precisely how this opened: the three families of row that leaked are the three *newest*. The refusal is `OpError::LayerLocked`, which crosses the bridge as an ordinary op error and needed no codegen.

**And guard the rows anyway**, for the interface's sake — not belt-and-braces for its own sake. Without it the UI would go on offering a gesture the engine would only refuse, which is a worse answer than not offering it. Group headings stay live: twirling one open is navigation, not editing, and a locked layer you couldn't look inside would be worse than one you can.

## Where the line is drawn

26 of the 29 layer-scoped ops are refused. Three are not:

| Accepted | Why |
|---|---|
| `SetLayerLocked` | or it could never be undone |
| `SetLayerShy` | a filter on the Timeline's list — no pixel, no timing |
| `SetLayerLabel` | a colour |

*"Locked means the composition does not change"* is a sentence a user can hold, and neither of the other two changes the composition. **This is the reversible half of the decision** — if you'd rather shy and label were also refused, that's a one-line change and the guard's shape doesn't depend on it.

## Two properties that make an applier-level guard safe

Both pinned by tests, because both would be quiet disasters if wrong:

- **Undo crosses a lock.** An edit can only have been made while the layer was unlocked, so the journal always holds the unlock *after* the edit, and walking back meets the unlock first.
- **A `Batch` is guarded by its members.** Each passes through `apply` on its way in, and a refusal rolls the whole batch back — so a batch stays all-or-nothing.

## Verification

Re-run after the rebase:

- 5 regression tests in `lumit-core` (refusal, every family, the three exemptions, batch, undo-across-lock) and 1 widget test. The widget test **fails without the row gating** (verified).
- Full Rust suite green (28 test binaries), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.
- The Flutter suite is CI-covered (no Dart toolchain in this container).

## The flake this used to carry

`bridge_call_budget_test.dart`'s Viewer-bar case waited a fixed number of rounds for ten renders instead of waiting for them to *finish*, so it passed alone and failed under the load of the full suite. That fix has since reached `main` by another route, so this branch **drops its copy and keeps main's** — the conflict it warned about, resolved.

## Docs

`02-DECISIONS.md` K-291, `07-UI-SPEC.md` §4 (what the lock means), `GUIDE.md` (plain-English section), TODO entry deleted.
