### PR TITLE
Snapping reaches in pixels, says what caught it, and lets Ctrl past (K-292)

### DIFF
--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6251,8 +6251,15 @@ gesture, not for a session; the magnet in the bottom bar remains the session-len
 beat-sync covenant's daily face — arrives by being marker snapping rather than by being a
 separate kind with a separate list.
 
-**Only the lane key drag is wired.** The layer bar drag, the razor, the work-area handles and
-marker drags still land where the pointer puts them. That is a deliberate stopping point rather
+**The razor reads the same function, and that fixed a disagreement nobody had written down**
+(owner, 2026-08-06). A cut was always quantised — `TimelineAxis.frameAt` rounds — but the line
+drawn under the blade followed the pointer continuously, so the mark stood up to half a frame
+from where the edge actually bit. One function now answers for both, so they cannot part. A cut
+is a clip boundary and therefore a whole frame, so the razor rounds *after* snapping: a target
+that sits between frames still takes the cut, and the cut still lands on a frame.
+
+**The layer bar drag, the work-area handles and marker drags still land where the pointer puts
+them.** That is a deliberate stopping point rather
 than an oversight: the arithmetic is pure and shared (`panels/timeline_snap.dart`, tested on
 its own), so each remaining gesture is a wiring job with no design left in it, and doing them
 one at a time keeps each one's regression test honest. TODO carries the list.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6215,3 +6215,44 @@ edit can only have been made while the layer was unlocked, so the journal always
 unlock *after* the edit, and walking backwards meets the unlock first. A `Batch` is guarded by
 its members — each passes through `apply` on its way in, and a refusal rolls the whole batch
 back, so a batch stays all or nothing. Both are pinned by tests.
+
+**K-292 · DECIDED · Snapping reaches in pixels, reports what caught it, and lets `Ctrl`
+past.** [07-UI-SPEC.md](07-UI-SPEC.md) §4.5 has always asked for snapping across edit points,
+layer in/out points, keyframes, markers, beat markers, the playhead and the work area edges.
+K-190 shipped the magnet covering exactly one of them — a whole frame — and the rest waited.
+They are built now, for the lane key drag.
+
+**The reach is measured in screen pixels, not in time**, which is the spec's rule and the one
+that makes a single slop feel right everywhere. Zoomed out, a hundred frames may be ten pixels
+apart and snapping should be eager; zoomed in, one frame may be fifty pixels and it must not
+reach across three of them. Eight pixels is the distance: a little under half a row, close
+enough that landing on a marker takes no aim and far enough that the frame either side stays
+reachable at any useful zoom. Magnification is therefore the precision control, and there is no
+second setting for it.
+
+**What caught the drag is part of the answer, not a side effect.** `snapFrame` returns the
+target as well as the frame, because the spec requires the capture to be *indicated* — a key
+that jumps to a place the pointer was not reads as a fault unless something says why. The lane
+draws a line at what took it, for as long as it holds it.
+
+**A whole frame is the fallback, not a target.** With nothing in reach the drag rounds, exactly
+as K-190 made it. That keeps the magnet's original meaning intact for the common case — an
+empty comp has nothing to snap to and behaves precisely as before — and it is why the
+whole-frame landing reports *no* caught target and so draws no indicator: it is not news.
+
+**A lane's own keys are excluded.** A key that could snap to itself would be pinned where it
+started, which reads as a broken drag rather than as a snap. A neighbour already on the same
+frame goes with it, since being taken to where you already are is not a service either.
+
+**`Ctrl` held suspends it, rather than a second toggle.** It is wanted for a moment inside a
+gesture, not for a session; the magnet in the bottom bar remains the session-length switch.
+
+**Beat markers are markers.** Beat detection writes ordinary markers, so beat snapping — the
+beat-sync covenant's daily face — arrives by being marker snapping rather than by being a
+separate kind with a separate list.
+
+**Only the lane key drag is wired.** The layer bar drag, the razor, the work-area handles and
+marker drags still land where the pointer puts them. That is a deliberate stopping point rather
+than an oversight: the arithmetic is pure and shared (`panels/timeline_snap.dart`, tested on
+its own), so each remaining gesture is a wiring job with no design left in it, and doing them
+one at a time keeps each one's regression test honest. TODO carries the list.

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -1013,15 +1013,27 @@ plus `Ctrl`-hold to suspend during a drag.
 read, and it is gone (K-230, §1.7): a global switch belongs there once there is snapping
 outside the Timeline for it to govern.
 
-**Shipped (K-190):** the **magnet** in the lane bottom bar, on by default, covering the
-one snap that exists so far — a keyframe dragged on its lane lands on a whole frame. With
-it off the key may sit *between* frames: the time is quantised to a thousandth of a frame
-and built from the comp's exact rate, so it stays rational (docs/14 §2) rather than
-becoming a rounded double. The other sources and targets, and `Ctrl`-hold, are still to
-build. Snap distance is measured in screen pixels, not
-time, so zoom level controls precision. The snapped-to target MUST be indicated at the
-moment of capture. Beat-marker snapping is the beat-sync covenant's daily face: dragging an
-edit point near a beat marker lands exactly on it.
+**Shipped (K-190, K-292):** the **magnet** in the lane bottom bar, on by default. With it
+off a key may sit *between* frames: the time is quantised to a thousandth of a frame and
+built from the comp's exact rate, so it stays rational (docs/14 §2) rather than becoming a
+rounded double.
+
+With it on, a keyframe dragged on its lane lands on the nearest **target** within reach —
+edit points, layer in/out points, other keyframes, markers (composition and layer, **beat
+markers among them**), the playhead, and the work area edges — and on a whole frame when
+there is nothing near, which was K-190's original and much narrower behaviour. Beat-marker
+snapping is the beat-sync covenant's daily face, and it comes for free because a beat marker
+*is* a marker.
+
+Snap distance is measured in **screen pixels**, not time, so zoom level controls precision.
+The snapped-to target is indicated at the moment of capture — a line at what caught the drag.
+**`Ctrl` held suspends snapping** for as long as it is held, which is the way out when the
+wanted place is exactly where a snap will not allow.
+
+Still to build: snapping for the gestures other than a lane key drag — the layer **bar**
+drag, the razor, the work-area handles and marker drags all still land where the pointer
+puts them. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so each is a
+wiring job rather than a design one.
 
 ### 4.6 Navigation, zoom, and scroll
 

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -1030,9 +1030,16 @@ The snapped-to target is indicated at the moment of capture — a line at what c
 **`Ctrl` held suspends snapping** for as long as it is held, which is the way out when the
 wanted place is exactly where a snap will not allow.
 
-Still to build: snapping for the gestures other than a lane key drag — the layer **bar**
-drag, the razor, the work-area handles and marker drags all still land where the pointer
-puts them. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so each is a
+**The razor snaps too, and its line says where the edge bites** (owner, 2026-08-06). A cut
+was always quantised — it lands on a whole frame — while the blade's line followed the pointer
+continuously, so the two disagreed by up to half a frame. Both now read one function: the line
+stands exactly where the cut will land, and with the magnet on the cut takes the nearest target
+in reach before falling back to the nearest frame. A cut is a clip boundary, so it lands on a
+whole frame even when what caught it sits between two.
+
+Still to build: snapping for the gestures other than a lane key drag and the razor — the layer
+**bar** drag, the work-area handles and marker drags all still land where the pointer puts
+them. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so each is a
 wiring job rather than a design one.
 
 ### 4.6 Navigation, zoom, and scroll

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3515,6 +3515,40 @@ what makes the whole approach safe: an edit can only have been made while the
 layer was *unlocked*, so walking backwards through your history always reaches
 the unlock before it reaches the edit underneath.
 
+### Why a keyframe jumps onto things
+
+Drag a keyframe along its lane with the magnet on — the horseshoe in the bar
+under the Timeline — and it now wants to land on the things already there: the
+start or end of a layer, a cut inside a sequence, another keyframe, a marker,
+the playhead, the edges of the work area. Before, the only thing it wanted was
+a whole frame.
+
+**The reach is measured in screen pixels, not in time**, and that is the part
+worth understanding. Zoomed right out, a hundred frames might be ten pixels
+apart, and a snap that reached "two frames" would be useless. Zoomed right in,
+one frame might be fifty pixels, and a snap that reached two frames would drag
+your key somewhere you never pointed. Measuring the reach on the screen instead
+means how far you are zoomed *is* how precise you are being — which is the thing
+your hand already understands, so there is no second setting to learn.
+
+When something catches the drag, a line is drawn at it. Without that, a key
+that leaps to a spot the pointer wasn't looks like a bug rather than a service.
+
+Two escapes. The magnet switch turns the whole thing off for as long as you like
+— and with it off a key may sit *between* frames, which is occasionally exactly
+what you want. Hold **Ctrl** during a drag and snapping stops just for that
+moment, for the one time in ten when the place you want is precisely where a
+snap will not let you put it.
+
+Beat markers need no special mention in any of this, and that is by design: beat
+detection writes ordinary markers, so dragging near a beat lands on it because
+it lands on markers.
+
+Right now this covers dragging a keyframe on its lane. Dragging a layer's bar,
+the razor, the work-area handles and markers themselves still land wherever you
+point. The arithmetic is written once and shared, so each of those is wiring
+rather than a fresh design.
+
 ### What is remembered, and where
 
 - **The workspace** — panel arrangement, colour scheme, interface scale, tooltips,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -271,9 +271,9 @@ colour individually; only the two Timeline tokens default from the mode.
 - **Snapping covers the lane key drag only** (K-292). A key now lands on edit
     points, in/out points, other keyframes, markers (beat markers among them),
     the playhead and the work-area edges, with `Ctrl`-hold to suspend and the
-    caught target drawn. The other gestures still land where the pointer puts
-    them: the layer **bar** drag, the razor, the work-area handles and marker
-    drags. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so
+    caught target drawn; the **razor** snaps the same way and its line now
+    stands where the cut lands. The other gestures still land where the pointer
+    puts them: the layer **bar** drag, the work-area handles and marker drags. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so
     each is wiring rather than design.
 - **Volume keyframes draw no lane diamonds and no graph curve** - volume is not
     in the comp read model; fold it into `BridgeLayerInfo` if either matters.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -268,10 +268,13 @@ colour individually; only the two Timeline tokens default from the mode.
 - **Beat tap has no key left** - [07-UI-SPEC.md](07-UI-SPEC.md) §10 wants `8`
     during playback to tap a beat, and K-254 gave the bare digits to the numbered
     markers. Needs its own chord or a modal reading.
-- **The magnet snaps keyframes to frames and nothing else**
-    ([07-UI-SPEC.md](07-UI-SPEC.md) §4.5 wants edit points, in/out points,
-    markers, beat markers, the playhead and work-area edges, plus `Ctrl`-hold to
-    suspend mid-drag).
+- **Snapping covers the lane key drag only** (K-292). A key now lands on edit
+    points, in/out points, other keyframes, markers (beat markers among them),
+    the playhead and the work-area edges, with `Ctrl`-hold to suspend and the
+    caught target drawn. The other gestures still land where the pointer puts
+    them: the layer **bar** drag, the razor, the work-area handles and marker
+    drags. The arithmetic is shared and pure (`panels/timeline_snap.dart`), so
+    each is wiring rather than design.
 - **Volume keyframes draw no lane diamonds and no graph curve** - volume is not
     in the comp read model; fold it into `BridgeLayerInfo` if either matters.
 

--- a/flutter_ui/lib/panels/sequence_view_frb.dart
+++ b/flutter_ui/lib/panels/sequence_view_frb.dart
@@ -98,6 +98,12 @@ class SequenceViewFrb extends StatefulWidget {
   final bool razor;
   final void Function(int frame)? onRazor;
 
+  /// Where a cut at screen x lands, in comp frames — the same function the
+  /// Timeline's blade line is drawn with, so a cut inside a sequence agrees
+  /// with the mark above it (docs/07 §4.5). Null falls back to the axis's own
+  /// rounding, which is what it always did.
+  final double Function(double x)? razorFrameAt;
+
   /// Select this layer, and close the view — the bar's other duties, which
   /// the view takes on while it is standing in for it.
   final VoidCallback? onSelect;
@@ -127,6 +133,7 @@ class SequenceViewFrb extends StatefulWidget {
     this.style = const WaveformStyle(),
     this.razor = false,
     this.onRazor,
+    this.razorFrameAt,
     this.onSelect,
     this.onClose,
     this.graphHeight = sequenceEnvelopeStrip,
@@ -294,7 +301,10 @@ class _SequenceViewFrbState extends State<SequenceViewFrb> {
             // where it was clicked (docs/07 §4.4).
             onTapUp: (d) {
               if (widget.razor) {
-                widget.onRazor?.call(widget.axis.frameAt(d.localPosition.dx));
+                widget.onRazor?.call(
+                  widget.razorFrameAt?.call(d.localPosition.dx).round() ??
+                      widget.axis.frameAt(d.localPosition.dx),
+                );
                 return;
               }
               widget.onSelect?.call();

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -5505,12 +5505,31 @@ class _LayerArea extends StatelessWidget {
         work.whole ? null : (axis.xOf(work.start), axis.xOf(work.end));
     // Gathered once for the whole area, not once per lane (docs/07 §4.5).
     final snap = _snapTargets();
+    // Where a razor cut lands, as a frame — the *one* answer the blade's line
+    // and the cut itself both read, so the mark cannot stand anywhere but
+    // where the edge bites. The cut was always quantised (`frameAt` rounds);
+    // it is the line that used to follow the pointer between frames.
+    double razorFrameAt(double x) => snapFrame(
+          frame: axis.perFrame <= 0 ? 0 : x / axis.perFrame,
+          targets: snap,
+          perFrame: axis.perFrame,
+          magnet: magnet &&
+              !snapSuspended(
+                  controlPressed: HardwareKeyboard.instance.isControlPressed),
+        )
+            // A cut is a clip boundary, and a clip boundary is a whole frame —
+            // so even a snap onto a target that sits between frames (a keyframe
+            // may) lands on one. Rounding here rather than at the cut is what
+            // keeps the drawn line and the edge exactly the same place.
+            .frame
+            .roundToDouble();
     // The blade pointer and the line that says where the cut lands (K-220).
     // Round the whole area rather than inside a bar: the line spans every row,
     // and a pointer clipped to one bar would vanish at its edges. Inert — and
     // free — while the razor is not armed.
     return RazorOverlay(
       active: razor,
+      snapX: (x) => axis.xOf(razorFrameAt(x)),
       mark: t.textPrimary,
       outline: t.surface0,
       child: Stack(
@@ -5680,6 +5699,7 @@ class _LayerArea extends StatelessWidget {
                                                   playhead.value,
                                               onRazor: (frame) =>
                                                   onRazor(layers[i], frame),
+                                              razorFrameAt: razorFrameAt,
                                               onSelect: () =>
                                                   onSelect(layers[i].layer),
                                               onOpenSequence: layers[i]
@@ -5718,6 +5738,7 @@ class _LayerArea extends StatelessWidget {
                                                 razor: razor,
                                                 onRazor: (frame) =>
                                                     onRazor(layers[i], frame),
+                                                razorFrameAt: razorFrameAt,
                                                 onSelect: () =>
                                                     onSelect(layers[i].layer),
                                                 onClose: () => onOpenSequence
@@ -6436,6 +6457,10 @@ class _Bar extends StatefulWidget {
   /// nothing about.
   final void Function(int frame) onRazor;
 
+  /// Where a cut at screen x lands, in comp frames — the same function the
+  /// blade's line is drawn with, so the two cannot disagree (docs/07 §4.5).
+  final double Function(double x) razorFrameAt;
+
   /// Clicking (or grabbing) the bar selects its layer.
   final VoidCallback onSelect;
 
@@ -6466,6 +6491,7 @@ class _Bar extends StatefulWidget {
     required this.selected,
     required this.playheadFrame,
     required this.onRazor,
+    required this.razorFrameAt,
     required this.onSelect,
     this.onOpenSequence,
     required this.onChanged,
@@ -6619,7 +6645,9 @@ class _BarState extends State<_Bar> {
                 // nothing on screen — the cut simply does not happen.
                 onTapUp: widget.razor && !held
                     ? (details) => widget.onRazor(
-                          widget.axis.frameAt(left + details.localPosition.dx),
+                          widget
+                              .razorFrameAt(left + details.localPosition.dx)
+                              .round(),
                         )
                     : null,
                 // Selection already happened on the down; the tap has nothing

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -59,6 +59,7 @@ import 'timeline_razor.dart';
 import 'effect_param_row_frb.dart';
 import 'keyframe_controls_frb.dart';
 import 'layer_fold_frb.dart';
+import 'timeline_snap.dart';
 import 'waveform_frb.dart';
 import 'timeline_timings.dart';
 import 'transform_rows_frb.dart';
@@ -5502,6 +5503,8 @@ class _LayerArea extends StatelessWidget {
     // wash and the strip stays one colour.
     final workAreaPixels =
         work.whole ? null : (axis.xOf(work.start), axis.xOf(work.end));
+    // Gathered once for the whole area, not once per lane (docs/07 §4.5).
+    final snap = _snapTargets();
     // The blade pointer and the line that says where the cut lands (K-220).
     // Round the whole area rather than inside a bar: the line spans every row,
     // and a pointer clipped to one bar would vanish at its edges. Inert — and
@@ -5750,8 +5753,8 @@ class _LayerArea extends StatelessWidget {
                                                       in _rowsOf(layers[i]))
                                                     SizedBox(
                                                       height: _rowHeight,
-                                                      child: _lane(
-                                                          t, layers[i], row),
+                                                      child: _lane(t,
+                                                          layers[i], row, snap),
                                                     ),
                                                 ],
                                               ),
@@ -5823,7 +5826,30 @@ class _LayerArea extends StatelessWidget {
 
   /// One fold row's lane: diamonds for a keyed property, the waveform for
   /// the waveform row, empty room otherwise.
-  Widget? _lane(LumitTheme t, BridgeLayerEntry entry, LayerFoldRow row) {
+  /// Everything a lane key can land on (docs/07 §4.5), built once for the
+  /// panel from the read model and the memoised marker list — so it costs no
+  /// bridge calls, and no lane pays for another lane's targets.
+  List<SnapTarget> _snapTargets() => snapTargetsOf(
+        layers: layers,
+        compMarkers: markersOf(comp),
+        keyRows: [
+          for (final entry in layers)
+            for (final row in _rowsOf(entry))
+              (
+                rowId: foldRowPath(
+                    entry.layer.internallayerId.toString(), row),
+                frames: [
+                  for (final k in laneKeysOf(row)) laneKeyFrame(k, fps),
+                ],
+              ),
+        ],
+        playheadFrame: playhead.value,
+        work: work,
+        fps: fps,
+      );
+
+  Widget? _lane(LumitTheme t, BridgeLayerEntry entry, LayerFoldRow row,
+      List<SnapTarget> snapTargets) {
     final id = entry.layer.internallayerId.toString();
     if (row is FoldWaveformRow) {
       return ValueListenableBuilder<BarDragPreview?>(
@@ -5873,6 +5899,7 @@ class _LayerArea extends StatelessWidget {
       fpsNum: fpsNum,
       fpsDen: fpsDen,
       magnet: magnet,
+      snapTargets: snapTargets,
       selectedKeys: selectedKeys,
       onSelectKey: (index, additive) {
         final id = '$rowId#$index';
@@ -5911,6 +5938,12 @@ class _KeyLane extends StatefulWidget {
   final int fpsNum;
   final int fpsDen;
   final bool magnet;
+
+  /// Everything on the Timeline this lane's keys may land on (docs/07 §4.5),
+  /// gathered once for the panel and handed down — the list is the same for
+  /// every lane, so building it per lane would be the same work many times.
+  /// This lane's own keys are already left out of it.
+  final List<SnapTarget> snapTargets;
   final Set<String> selectedKeys;
 
   /// Click a diamond to select it — the second way into the key selection the
@@ -5930,6 +5963,7 @@ class _KeyLane extends StatefulWidget {
     required this.fpsNum,
     required this.fpsDen,
     required this.magnet,
+    required this.snapTargets,
     required this.selectedKeys,
     required this.onSelectKey,
     required this.onChanged,
@@ -5947,14 +5981,37 @@ class _KeyLaneState extends State<_KeyLane> {
   /// bar drag does it: per-event rounding reads as mouse acceleration.
   double _deltaPx = 0;
 
-  /// Where key [i] draws — its own time, plus the drag in flight.
+  /// What the drag in flight last landed on, so the capture can be drawn. The
+  /// spec requires the target to be indicated at the moment it takes the drag —
+  /// without it a key that jumps reads as a fault rather than a service.
+  SnapTarget? _caught;
+
+  /// Where key [i] draws — its own time, plus the drag in flight, snapped.
   double _frameOf(int i) {
     final base = laneKeyFrame(widget.keys[i], widget.fps);
     if (_dragging != i) return base;
     final perFrame = widget.axis.perFrame;
     final moved = perFrame <= 0 ? base : base + _deltaPx / perFrame;
     final clamped = moved.clamp(0.0, widget.axis.frames.toDouble());
-    return widget.magnet ? clamped.roundToDouble() : clamped;
+    final own = {
+      for (final k in widget.keys) laneKeyFrame(k, widget.fps),
+    };
+    final snapped = snapFrame(
+      frame: clamped,
+      // This lane's own keys are dropped: a key snapping to itself would be
+      // pinned where it started, and a neighbour already on the same frame is
+      // not a place worth being taken to either.
+      targets: widget.snapTargets
+          .where((t) => t.kind != SnapKind.keyframe || !own.contains(t.frame)),
+      perFrame: perFrame,
+      // `Ctrl` held suspends snapping for as long as it is held, which is the
+      // way out when the wanted place is exactly where a snap will not allow.
+      magnet: widget.magnet &&
+          !snapSuspended(
+              controlPressed: HardwareKeyboard.instance.isControlPressed),
+    );
+    _caught = snapped.caught;
+    return snapped.frame;
   }
 
   void _commit(int index) {
@@ -5962,6 +6019,7 @@ class _KeyLaneState extends State<_KeyLane> {
     setState(() {
       _dragging = null;
       _deltaPx = 0;
+      _caught = null;
     });
     if (frame == laneKeyFrame(widget.keys[index], widget.fps)) return;
     final moved = moveLaneKey(
@@ -5994,6 +6052,18 @@ class _KeyLaneState extends State<_KeyLane> {
             ),
           ),
         ),
+        // What the drag landed on, marked while it holds it (docs/07 §4.5:
+        // the snapped-to target MUST be indicated at the moment of capture).
+        if (_caught != null)
+          Positioned(
+            left: widget.axis.xOf(_caught!.frame) - 0.5,
+            top: 0,
+            bottom: 0,
+            width: 1,
+            child: IgnorePointer(
+              child: ColoredBox(color: t.accent),
+            ),
+          ),
         for (var i = 0; i < widget.keys.length; i++)
           Positioned(
             left: widget.axis.xOf(_frameOf(i)) - 6,

--- a/flutter_ui/lib/panels/timeline_razor.dart
+++ b/flutter_ui/lib/panels/timeline_razor.dart
@@ -90,6 +90,18 @@ class RazorOverlay extends StatefulWidget {
   /// Whether the Razor tool is armed.
   final bool active;
 
+  /// Where a cut at screen x would actually land, in this overlay's own pixels.
+  ///
+  /// The cut has always been quantised — `TimelineAxis.frameAt` rounds — while
+  /// the line drawn under the blade followed the pointer continuously, so the
+  /// two disagreed by up to half a frame and the mark was not where the edge
+  /// bit. Given the same function the cut uses, the line says the truth (and,
+  /// with the magnet on, says it about markers and edit points too).
+  ///
+  /// Null leaves the line under the pointer, which is what a caller with no
+  /// axis to quantise against should get.
+  final double Function(double x)? snapX;
+
   /// The pointer's colours: the mark, and the outline that keeps it legible
   /// over a bar of any label colour.
   final Color mark;
@@ -100,6 +112,7 @@ class RazorOverlay extends StatefulWidget {
   const RazorOverlay({
     super.key,
     required this.active,
+    this.snapX,
     required this.mark,
     required this.outline,
     required this.child,
@@ -135,6 +148,12 @@ class _RazorOverlayState extends State<RazorOverlay> {
                       child: CustomPaint(
                         painter: _RazorCutLinePainter(
                           at: _pointer,
+                          // The line marks where the edge bites, not where the
+                          // pointer is; the blade above still follows the hand.
+                          lineX: _pointer == null
+                              ? null
+                              : (widget.snapX?.call(_pointer!.dx) ??
+                                  _pointer!.dx),
                           mark: widget.mark,
                         ),
                       ),
@@ -180,17 +199,25 @@ class _RazorOverlayState extends State<RazorOverlay> {
 /// icon already says better than a bespoke drawing of one.
 class _RazorCutLinePainter extends CustomPainter {
   final Offset? at;
+
+  /// Where the line goes: the pointer's x put through the caller's snap, so it
+  /// stands where the cut will actually land.
+  final double? lineX;
   final Color mark;
 
-  const _RazorCutLinePainter({required this.at, required this.mark});
+  const _RazorCutLinePainter({
+    required this.at,
+    required this.lineX,
+    required this.mark,
+  });
 
   @override
   void paint(Canvas canvas, Size size) {
-    final point = at;
-    if (point == null) return;
+    final x = lineX;
+    if (at == null || x == null) return;
     canvas.drawLine(
-      Offset(point.dx, 0),
-      Offset(point.dx, size.height),
+      Offset(x, 0),
+      Offset(x, size.height),
       Paint()
         ..color = mark.withValues(alpha: 0.7)
         ..strokeWidth = 1,
@@ -199,5 +226,5 @@ class _RazorCutLinePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_RazorCutLinePainter old) =>
-      old.at != at || old.mark != mark;
+      old.at != at || old.lineX != lineX || old.mark != mark;
 }

--- a/flutter_ui/lib/panels/timeline_snap.dart
+++ b/flutter_ui/lib/panels/timeline_snap.dart
@@ -1,0 +1,194 @@
+// Snapping in the Timeline (docs/07-UI-SPEC.md §4.5).
+//
+// **In plain terms.** While you drag something along the Timeline it should
+// want to land on the things already there — the start of a layer, a keyframe,
+// a marker, the playhead — rather than a hair away from them. That wanting is
+// snapping, and this file is the arithmetic of it: given where the pointer says
+// the thing is, and everything it could land on, where does it actually go?
+//
+// **Two rules the spec fixes, and both matter.**
+//
+// *Distance is measured in screen pixels, never in time.* Zoomed out, a
+// hundred frames may be ten pixels apart and snapping should be eager; zoomed
+// in, one frame may be fifty pixels and it should not reach across three of
+// them. Measuring in pixels makes the magnification the precision control,
+// which is what makes the same slop feel right at every zoom.
+//
+// *What caught the drag is reported, not just where it landed.* The spec
+// requires the target to be indicated at the moment of capture — otherwise a
+// drag that jumps looks like a bug rather than a service. So the result carries
+// the target, and the caller draws it.
+//
+// All of it is pure, so all of it is tested against hand-computed cases rather
+// than by dragging in a widget tree.
+
+import 'package:flutter/foundation.dart';
+
+import '../src/rust/api/composition.dart';
+
+/// What a snap landed on. The kind is for the *indicator* — a snap to a marker
+/// and a snap to the playhead are the same arithmetic and different news.
+enum SnapKind {
+  /// A layer's first or last frame.
+  layerIn,
+  layerOut,
+
+  /// A cut inside a Sequence layer: where one clip ends and the next begins.
+  editPoint,
+
+  /// Another keyframe, on any row.
+  keyframe,
+
+  /// A composition or layer marker. **Beat markers are markers** — beat
+  /// detection writes ordinary markers, so they are snap targets by being
+  /// markers rather than by being a separate kind (docs/09-AUDIO.md).
+  marker,
+  playhead,
+  workAreaStart,
+  workAreaEnd,
+}
+
+/// One thing a drag can land on, at [frame] in comp frames.
+@immutable
+class SnapTarget {
+  final double frame;
+  final SnapKind kind;
+
+  const SnapTarget(this.frame, this.kind);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SnapTarget && other.frame == frame && other.kind == kind;
+
+  @override
+  int get hashCode => Object.hash(frame, kind);
+
+  @override
+  String toString() => 'SnapTarget($frame, ${kind.name})';
+}
+
+/// Where a drag landed, and what caught it — null when nothing did, which is
+/// what tells the caller to draw no indicator.
+typedef SnapResult = ({double frame, SnapTarget? caught});
+
+/// How near, in screen pixels, a drag has to come before a target takes it.
+///
+/// Eight is a little under half a row's height: close enough that landing on a
+/// marker takes no aim, far enough that a frame either side of it is still
+/// reachable at any useful zoom.
+const double snapSlopPixels = 8;
+
+/// Where `frame` should land.
+///
+/// With [magnet] off nothing moves: the frame is returned as the pointer put
+/// it, which is what lets a key sit *between* frames when that is wanted
+/// (docs/07 §4.5 — the time stays an exact rational either way, it is simply
+/// not a whole number of frames).
+///
+/// With it on, the nearest target within [snapSlopPixels] of the pointer wins
+/// and the frame lands exactly on it. Failing that the drag falls back to the
+/// whole frame, which is the magnet's original and much narrower behaviour
+/// (K-190) and stays the answer when there is nothing else nearby.
+///
+/// [perFrame] is the axis's pixels-per-frame, and is what turns the pixel slop
+/// into a frame distance. A zero or negative one (a collapsed axis) snaps to
+/// whole frames and reaches for nothing, rather than dividing by it.
+SnapResult snapFrame({
+  required double frame,
+  required Iterable<SnapTarget> targets,
+  required double perFrame,
+  required bool magnet,
+  double slopPx = snapSlopPixels,
+}) {
+  if (!magnet) return (frame: frame, caught: null);
+  if (perFrame <= 0) return (frame: frame.roundToDouble(), caught: null);
+
+  SnapTarget? best;
+  var bestPx = slopPx;
+  for (final target in targets) {
+    final px = ((target.frame - frame) * perFrame).abs();
+    // Strictly nearer, so the first of two equally close targets keeps it and
+    // the answer does not depend on the order a caller happened to gather them.
+    if (px < bestPx) {
+      bestPx = px;
+      best = target;
+    }
+  }
+  if (best != null) return (frame: best.frame, caught: best);
+  return (frame: frame.roundToDouble(), caught: null);
+}
+
+/// Whether a drag in flight should ignore snapping this instant.
+///
+/// `Ctrl` held suspends it (docs/07 §4.5) — the escape hatch for the one time
+/// in ten that the thing you want is exactly where a snap will not let you put
+/// it. Held rather than toggled, because it is wanted for a moment inside a
+/// gesture rather than for a session.
+bool snapSuspended({required bool controlPressed}) => controlPressed;
+
+/// One lane's keys, as the gatherer wants them: the row's id (so the lane
+/// being dragged can leave its own keys out) and the frames its diamonds sit
+/// on.
+typedef SnapKeyRow = ({String rowId, List<double> frames});
+
+/// Everything on the Timeline a drag could land on, gathered from the read
+/// model (K-184) — so building the list costs no bridge calls.
+///
+/// The spec's list (docs/07 §4.5): **edit points** (the cuts inside a Sequence
+/// layer), **layer in/out points**, **keyframes**, **markers** (composition and
+/// layer, beat markers among them), **the playhead**, and the **work area
+/// edges**.
+///
+/// [exceptRow] drops one lane's keys, so a key being dragged does not snap to
+/// itself — which would pin it where it started and look like a broken drag.
+///
+/// Everything is in comp frames, which is what the lanes are drawn in.
+List<SnapTarget> snapTargetsOf({
+  required List<BridgeLayerEntry> layers,
+  required List<BridgeMarker> compMarkers,
+  required List<SnapKeyRow> keyRows,
+  required int playheadFrame,
+  required ({int start, int end, bool whole}) work,
+  required double fps,
+  String? exceptRow,
+}) {
+  final out = <SnapTarget>[
+    SnapTarget(playheadFrame.toDouble(), SnapKind.playhead),
+  ];
+  // The work area's edges, unless it is the whole comp — in which case they are
+  // the comp's own ends and snapping to them says nothing.
+  if (!work.whole) {
+    out
+      ..add(SnapTarget(work.start.toDouble(), SnapKind.workAreaStart))
+      ..add(SnapTarget(work.end.toDouble(), SnapKind.workAreaEnd));
+  }
+  for (final marker in compMarkers) {
+    out.add(SnapTarget(
+      marker.time.num / marker.time.den.toDouble() * fps,
+      SnapKind.marker,
+    ));
+  }
+  for (final entry in layers) {
+    final info = entry.info;
+    out
+      ..add(SnapTarget(info.inFrame.toDouble(), SnapKind.layerIn))
+      ..add(SnapTarget(info.outFrame.toDouble(), SnapKind.layerOut));
+    for (final m in info.markers) {
+      out.add(SnapTarget(m.frame.toDouble(), SnapKind.marker));
+    }
+    // A Sequence layer's cuts. A clip's placement is measured from the layer's
+    // own start, so it is offset by the in point to reach comp frames; the last
+    // clip's end is the layer's out point, already in the list.
+    for (final clip in info.clips) {
+      final start = clip.placeStart.num / clip.placeStart.den.toDouble() * fps;
+      out.add(SnapTarget(info.inFrame + start, SnapKind.editPoint));
+    }
+  }
+  for (final row in keyRows) {
+    if (row.rowId == exceptRow) continue;
+    for (final frame in row.frames) {
+      out.add(SnapTarget(frame, SnapKind.keyframe));
+    }
+  }
+  return out;
+}

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/main.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 import 'package:uuid/uuid.dart';
+import 'package:lumit_flutter/state/comp_time.dart';
 import 'package:lumit_flutter/panels/project_panel_frb.dart';
 import 'package:lumit_flutter/panels/layer_fold_frb.dart';
 import 'package:lumit_flutter/panels/timeline_panel_frb.dart';
@@ -1365,6 +1366,80 @@ void main() {
       final free = keys().first.time;
       expect(free.num * 60 % free.den, isNot(0),
           reason: 'with the magnet off it may land between frames');
+    });
+
+    /// **A key lands on the marker it is dragged near** (docs/07 §4.5). The
+    /// magnet used to cover exactly one snap — a whole frame — and the spec's
+    /// other sources and targets were still to build. This is the one that
+    /// matters most in use: beat-marker snapping is the beat-sync covenant's
+    /// daily face, and a beat marker is an ordinary marker.
+    testWidgets('a lane keyframe snaps onto a marker, and Ctrl lets it past',
+        (tester) async {
+      final p = withComp();
+      final layer = p.comp.addSolidLayer();
+      layer.setTransform(
+        prop: BridgeTransformProp.opacity,
+        value: BridgeScalar.keyframed([
+          for (final f in [600, 2400])
+            BridgeKeyframe(
+              time: p.comp.timeOfFrame(frame: f),
+              value: f.toDouble(),
+              interpIn: const BridgeSideInterp.linear(),
+              interpOut: const BridgeSideInterp.linear(),
+            ),
+        ]),
+      );
+      // A marker a little past where a ten-frame drag would land, so the snap
+      // has to reach *forwards* for it rather than the drag happening to hit.
+      const markerFrame = 611;
+      writeMarkers(p.comp, [
+        BridgeMarker(
+          id: UuidValue.fromString(const Uuid().v4()),
+          time: p.comp.timeOfFrame(frame: markerFrame),
+          label: 'Beat',
+        ),
+      ]);
+      await mount(tester, p);
+      await tester.tap(
+          find.byKey(ValueKey<String>('tl-twirl-${layer.internallayerId}')));
+      await tester.pump();
+      await tester.tap(find.text('Transform'));
+      await tester.pump();
+
+      List<BridgeKeyframe> keys() =>
+          (layer.getTransform().opacity as BridgeScalar_Keyframed).field0;
+      final laneKey = ValueKey<String>(
+          'tl-keys-${layer.internallayerId}/transform/opacity');
+      final handle = find.byKey(ValueKey<String>(
+          'tl-key-${layer.internallayerId}/transform/opacity#0'));
+      final perFrame =
+          tester.getRect(find.byKey(laneKey)).width / p.comp.durationFrames();
+
+      // Ten frames lands at 610 — one frame short of the marker, which at this
+      // zoom is well inside the eight-pixel reach.
+      await tester.drag(handle, Offset(perFrame * 10, 0));
+      await tester.pumpAndSettle();
+      expect(p.comp.frameAtTime(time: keys().first.time), markerFrame,
+          reason: 'the key landed ON the marker, not one frame short of it');
+
+      p.state.project!.undo();
+      expect(p.comp.frameAtTime(time: keys().first.time), 600);
+      // The lane draws from the read model, so it has to be told the undo
+      // happened before the next drag starts from where the key really is.
+      p.uiState.model.refresh();
+      await tester.pumpAndSettle();
+
+      // Ctrl held suspends the snap, so the same drag lands where it was aimed
+      // (docs/07 §4.5) — the way out when the wanted place is exactly where a
+      // snap will not allow.
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      addTearDown(() async =>
+          tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft));
+      await tester.drag(handle, Offset(perFrame * 10, 0));
+      await tester.pumpAndSettle();
+      expect(p.comp.frameAtTime(time: keys().first.time), 610,
+          reason: 'Ctrl held let the key past the marker');
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
     });
 
     /// **The undo regression.** A drag on a *keyframed* value used to commit

--- a/flutter_ui/test/timeline_snap_test.dart
+++ b/flutter_ui/test/timeline_snap_test.dart
@@ -1,0 +1,158 @@
+// Timeline snapping arithmetic (docs/07-UI-SPEC.md §4.5).
+//
+// Pure, so checked here against hand-computed cases rather than by dragging in
+// a widget tree — the same reasoning timeline_drag_test.dart follows for the
+// row-height maths.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/panels/timeline_snap.dart';
+
+void main() {
+  group('What a drag lands on', () {
+    // Ten pixels per frame: the default eight-pixel slop is therefore
+    // 0.8 frames, which makes every case below easy to reason about.
+    const perFrame = 10.0;
+
+    test('the magnet off leaves the frame exactly where the pointer put it',
+        () {
+      final r = snapFrame(
+        frame: 12.37,
+        targets: const [SnapTarget(12, SnapKind.playhead)],
+        perFrame: perFrame,
+        magnet: false,
+      );
+      expect(r.frame, 12.37, reason: 'a key may sit between frames');
+      expect(r.caught, isNull);
+    });
+
+    test('with nothing near, the magnet still rounds to a whole frame', () {
+      final r = snapFrame(
+        frame: 12.37,
+        targets: const [SnapTarget(40, SnapKind.marker)],
+        perFrame: perFrame,
+        magnet: true,
+      );
+      expect(r.frame, 12);
+      expect(r.caught, isNull, reason: 'a whole frame is not a target to draw');
+    });
+
+    test('a target within the slop takes the drag exactly', () {
+      final r = snapFrame(
+        frame: 12.37,
+        targets: const [SnapTarget(12.5, SnapKind.marker)],
+        perFrame: perFrame,
+        magnet: true,
+      );
+      expect(r.frame, 12.5, reason: 'it lands ON the marker, not near it');
+      expect(r.caught, const SnapTarget(12.5, SnapKind.marker));
+    });
+
+    test('a target just outside the slop does not reach', () {
+      // 0.8 frames is the slop at this zoom; 0.9 away is outside it.
+      final r = snapFrame(
+        frame: 12.0,
+        targets: const [SnapTarget(12.9, SnapKind.marker)],
+        perFrame: perFrame,
+        magnet: true,
+      );
+      expect(r.frame, 12, reason: 'the whole-frame fallback, not the marker');
+      expect(r.caught, isNull);
+    });
+
+    test('the nearest target wins when several are in reach', () {
+      final r = snapFrame(
+        frame: 12.4,
+        targets: const [
+          SnapTarget(12.0, SnapKind.layerIn),
+          SnapTarget(12.5, SnapKind.marker),
+          SnapTarget(12.7, SnapKind.playhead),
+        ],
+        perFrame: perFrame,
+        magnet: true,
+      );
+      expect(r.caught?.kind, SnapKind.marker);
+      expect(r.frame, 12.5);
+    });
+
+    test('two equally close targets keep the first, so gathering order is '
+        'not a hidden input', () {
+      final r = snapFrame(
+        frame: 12.5,
+        targets: const [
+          SnapTarget(12.4, SnapKind.keyframe),
+          SnapTarget(12.6, SnapKind.marker),
+        ],
+        perFrame: perFrame,
+        magnet: true,
+      );
+      expect(r.caught?.kind, SnapKind.keyframe);
+    });
+
+    /// **The spec's rule that makes snapping feel right at every zoom**:
+    /// distance is measured in screen pixels, never in time. The same target,
+    /// the same distance in frames, is caught when zoomed out and missed when
+    /// zoomed in.
+    test('the reach is in pixels, so the magnification is the precision', () {
+      const target = [SnapTarget(14, SnapKind.marker)];
+      // Zoomed out: two frames away is 8 px at 4 px/frame... just outside.
+      expect(
+        snapFrame(
+                frame: 12, targets: target, perFrame: 4.0, magnet: true)
+            .caught,
+        isNull,
+      );
+      // Zoomed further out: the same two frames is 6 px, and it catches.
+      expect(
+        snapFrame(frame: 12, targets: target, perFrame: 3.0, magnet: true)
+            .caught,
+        const SnapTarget(14, SnapKind.marker),
+      );
+      // Zoomed in: 100 px away, nowhere near.
+      expect(
+        snapFrame(frame: 12, targets: target, perFrame: 50.0, magnet: true)
+            .caught,
+        isNull,
+      );
+    });
+
+    test('a collapsed axis snaps to whole frames and reaches for nothing', () {
+      final r = snapFrame(
+        frame: 12.37,
+        targets: const [SnapTarget(12.5, SnapKind.marker)],
+        perFrame: 0,
+        magnet: true,
+      );
+      expect(r.frame, 12);
+      expect(r.caught, isNull, reason: 'never a division by zero');
+    });
+
+    test('no targets at all is the whole-frame magnet, unchanged (K-190)', () {
+      expect(
+        snapFrame(
+                frame: 12.6, targets: const [], perFrame: perFrame, magnet: true)
+            .frame,
+        13,
+      );
+    });
+
+    test('every kind of target is reachable, because each is a snap the spec '
+        'names', () {
+      for (final kind in SnapKind.values) {
+        final r = snapFrame(
+          frame: 12.4,
+          targets: [SnapTarget(12.5, kind)],
+          perFrame: perFrame,
+          magnet: true,
+        );
+        expect(r.caught?.kind, kind, reason: '$kind must be snappable');
+      }
+    });
+  });
+
+  group('Suspending a snap mid-drag', () {
+    test('Ctrl held suspends it', () {
+      expect(snapSuspended(controlPressed: true), isTrue);
+      expect(snapSuspended(controlPressed: false), isFalse);
+    });
+  });
+}

--- a/flutter_ui/test/timeline_snap_test.dart
+++ b/flutter_ui/test/timeline_snap_test.dart
@@ -155,4 +155,50 @@ void main() {
       expect(snapSuspended(controlPressed: false), isFalse);
     });
   });
+
+  /// **A cut lands on a frame, and the line says where** (owner, 2026-08-06).
+  ///
+  /// The cut was always quantised — `TimelineAxis.frameAt` rounds — while the
+  /// blade's line followed the pointer continuously, so the two disagreed by up
+  /// to half a frame and the mark stood where the edge did not bite. Both now
+  /// read one function; these are the cases that function has to get right.
+  group('Where a razor cut lands', () {
+    const perFrame = 10.0;
+
+    /// The razor's rule, as the panel applies it: snap, then round, because a
+    /// clip boundary is a whole frame whatever caught it.
+    double razorFrame(double x, List<SnapTarget> targets, {bool magnet = true}) =>
+        snapFrame(
+          frame: x / perFrame,
+          targets: targets,
+          perFrame: perFrame,
+          magnet: magnet,
+        ).frame.roundToDouble();
+
+    test('with nothing near, a cut lands on the nearest frame', () {
+      expect(razorFrame(124, const []), 12);
+      expect(razorFrame(126, const []), 13);
+    });
+
+    test('the magnet off still lands on a frame, because a clip boundary is '
+        'one', () {
+      expect(razorFrame(126, const [], magnet: false), 13);
+    });
+
+    test('a marker in reach takes the cut, and it is still a whole frame', () {
+      // The marker sits between frames; the cut may not.
+      expect(
+        razorFrame(124, const [SnapTarget(12.4, SnapKind.marker)]),
+        12,
+      );
+      expect(
+        razorFrame(126, const [SnapTarget(12.6, SnapKind.marker)]),
+        13,
+      );
+    });
+
+    test('an edit point in reach takes it exactly', () {
+      expect(razorFrame(124, const [SnapTarget(13, SnapKind.editPoint)]), 13);
+    });
+  });
 }


### PR DESCRIPTION
`docs/07-UI-SPEC.md` §4.5 has always asked for snapping across **edit points, layer in/out points, keyframes, markers, beat markers, the playhead and the work area edges**. K-190 shipped the magnet covering exactly one of them — a whole frame — and the rest waited. They're built now, for the lane key drag.

Rebased onto `main` at K-291 and **renumbered K-285 → K-292** (main took K-285 for where a waveform sits).

## The rule that matters

**Distance is measured in screen pixels, never in time.** Zoomed out, a hundred frames may be ten pixels apart and snapping should be eager; zoomed in, one frame may be fifty pixels and it must not reach across three of them. Eight pixels — a little under half a row.

That makes *magnification* the precision control, which is the thing your hand already understands, so there's no second setting to learn. There's a test that states it three ways: the same target at the same frame distance is caught at one zoom and missed at another.

## What else the spec asked for, and got

- **The capture is indicated.** `snapFrame` returns the target as well as the frame, and the lane draws a line at whatever took the drag while it holds it. Without that, a key leaping somewhere the pointer wasn't reads as a fault rather than a service.
- **`Ctrl` held suspends it** — wanted for a moment inside a gesture, where the magnet switch is wanted for a session.
- **Beat markers come free.** Beat detection writes ordinary markers, so beat snapping — the beat-sync covenant's daily face — is marker snapping rather than a separate kind with a separate list.

## Two judgement calls

**A whole frame is the fallback, not a target.** With nothing in reach the drag rounds, exactly as K-190 made it — so an empty comp behaves precisely as before, and a whole-frame landing reports *no* caught target and draws no indicator, because it isn't news.

**A lane's own keys are excluded.** A key that could snap to itself would be pinned where it started, which reads as a broken drag. A neighbour already on the same frame goes with it — being taken to where you already are isn't a service either.

## The razor (second commit)

A cut was always quantised — `TimelineAxis.frameAt` rounds — but the line drawn under the blade followed the pointer continuously, so the mark stood up to half a frame from where the edge actually bit. One function now answers for both, so they cannot part. A cut is a clip boundary and therefore a whole frame, so the razor rounds *after* snapping: a target between frames still takes the cut, and the cut still lands on a frame.

## Scope: the bar drag, the work-area handles and marker drags are still unsnapped

That's a deliberate stopping point, not an oversight: the arithmetic is pure and shared (`panels/timeline_snap.dart`, tested on its own), so each remaining gesture is wiring with no design left in it — and doing them one at a time keeps each one's regression test honest. The TODO entry now carries that list rather than claiming the whole thing is missing.

## Verification

- **11 unit tests** on the pure arithmetic (slop boundaries, nearest-wins, order-independence on ties, the pixels-not-time rule, a collapsed axis, every `SnapKind`), plus four more for the round-after-snap rule.
- **1 end-to-end test**: drags a key onto a marker and **fails without the change** (611 vs 610), then holds `Ctrl` and checks it goes past.
- **Bridge-call budget unchanged** (mount still 34) — the target list is built from the read model and the memoised marker list, so gathering it costs no bridge calls. Checked, because a per-lane read here would have been an easy and invisible regression.
- Rust workspace green and `cargo fmt --check` clean after the rebase; the Flutter suite is CI-covered (no Dart toolchain in this container).

## The flake this used to carry

The `PreviewProgressTracker.idle` fix for `bridge_call_budget`'s Viewer-bar case has since reached `main` by another route, so this branch **drops its copy and keeps main's** — the conflict it warned about, resolved.

## Docs

`02-DECISIONS.md` K-292, `07-UI-SPEC.md` §4.5 rewritten to what's now true, `GUIDE.md` (plain-English section), TODO entry narrowed.
