### PR TITLE
Hand back what the engine drops, and a debug report that found it (K-294, K-295)

### DIFF
--- a/crates/lumit-bridge/src/api/cache.rs
+++ b/crates/lumit-bridge/src/api/cache.rs
@@ -74,11 +74,17 @@ pub struct BridgeMemoryReport {
     pub process_bytes: u64,
     /// Finished frames held in ordinary memory.
     pub frame_cache_bytes: u64,
-    /// Frames held on the graphics card. On a machine with unified memory (every
-    /// Apple Silicon Mac) these are part of `process_bytes` too; on a discrete
-    /// card they are not, which is why they are reported apart rather than
-    /// summed for you.
+    /// Frames held on the graphics card.
     pub vram_cache_bytes: u64,
+    /// Whether the card's memory *is* this process's memory — true on every
+    /// Apple Silicon Mac and on any integrated adapter.
+    ///
+    /// When it is, `vram_cache_bytes` is counted against `process_bytes` like
+    /// any other tier; when it is not, the card's frames are somewhere else
+    /// entirely and counting them would understate what is unaccounted for.
+    /// Getting this backwards is how a cache doing exactly its job read as
+    /// gigabytes nobody could explain.
+    pub unified_memory: bool,
     /// Decoded source frames held for the compositor.
     pub decode_cache_bytes: u64,
     /// How many media decoders are open. Counted, not weighed: what a decoder
@@ -133,14 +139,20 @@ pub fn memory_report() -> BridgeMemoryReport {
     let park = crate::framecache::disk::pending_parks();
     let (gpu_allocated, gpu_reserved, gpu_textures, gpu_buffers) = crate::framecache::gpu::stats();
     let process = crate::api::system::resident_memory_bytes();
-    // VRAM is deliberately not subtracted: on a discrete card it is not in the
-    // process at all, and on unified memory it is — counting it either way
-    // would be wrong on half the machines Lumit runs on.
-    let accounted = (frame_cache as u64).saturating_add(decode);
+    // On unified memory the card's frames are inside this process, so they are
+    // accounted like any other tier; on a discrete card they are not in it at
+    // all and must not be. The adapter says which, rather than the platform:
+    // a Mac with an external card would answer differently, and so should the
+    // report.
+    let unified = crate::framecache::gpu::unified();
+    let accounted = (frame_cache as u64)
+        .saturating_add(decode)
+        .saturating_add(if unified { vram } else { 0 });
     BridgeMemoryReport {
         process_bytes: process,
         frame_cache_bytes: frame_cache as u64,
         vram_cache_bytes: vram,
+        unified_memory: unified,
         decode_cache_bytes: decode,
         open_decoders: decoders,
         park_queue_frames: park,

--- a/crates/lumit-bridge/src/api/cache.rs
+++ b/crates/lumit-bridge/src/api/cache.rs
@@ -55,6 +55,72 @@ pub fn cache_stats() -> BridgeCacheStats {
     read()
 }
 
+/// Where this process's memory has gone: what each tier admits to holding, and
+/// what the operating system says the process holds (K-295).
+///
+/// **The field that matters is [`Self::unaccounted_bytes`].** Every tier here
+/// is byte-budgeted and evicts to stay inside its budget, so a report where the
+/// tiers add up to their budgets and the process is a hundred times larger is
+/// not a cache problem at all — it is memory nobody in this list is counting,
+/// which is a different search entirely. Lumit has twice been reported holding
+/// tens of gigabytes (K-277 and after it), and both times that question took
+/// days to answer from the outside. It is one call from the inside.
+#[frb(non_opaque)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BridgeMemoryReport {
+    /// What the operating system says this process holds — Activity Monitor's
+    /// **Memory** on macOS, the working set on Windows, `VmRSS` on Linux. 0
+    /// where the platform will not say ([`crate::api::system::resident_memory_bytes`]).
+    pub process_bytes: u64,
+    /// Finished frames held in ordinary memory.
+    pub frame_cache_bytes: u64,
+    /// Frames held on the graphics card. On a machine with unified memory (every
+    /// Apple Silicon Mac) these are part of `process_bytes` too; on a discrete
+    /// card they are not, which is why they are reported apart rather than
+    /// summed for you.
+    pub vram_cache_bytes: u64,
+    /// Decoded source frames held for the compositor.
+    pub decode_cache_bytes: u64,
+    /// How many media decoders are open. Counted, not weighed: what a decoder
+    /// holds is FFmpeg's and the driver's business, and a made-up number of
+    /// bytes would be worse than an honest count.
+    pub open_decoders: u64,
+    /// How many frames are waiting to be written to disk — the write-behind
+    /// queue K-277 bounded at eight. A count rather than bytes on purpose: each
+    /// waiting frame shares its allocation with the frame cache above (one
+    /// `Arc`, both tiers), so charging it twice would make the report lie in
+    /// the one direction that matters.
+    pub park_queue_frames: u64,
+    /// `process_bytes` less everything above that lives in ordinary memory.
+    /// Saturating at zero, since the platform's number and ours are read a
+    /// moment apart and a small negative is meaningless.
+    pub unaccounted_bytes: u64,
+}
+
+/// Read the memory report. Cheap: five atomics, one lock and one syscall.
+#[frb(sync)]
+#[must_use]
+pub fn memory_report() -> BridgeMemoryReport {
+    let (frame_cache, _, _, _, _) = crate::framecache::stats();
+    let (vram, _) = crate::framecache::vram::stats();
+    let (decode, decoders) = crate::framecache::decode::stats();
+    let park = crate::framecache::disk::pending_parks();
+    let process = crate::api::system::resident_memory_bytes();
+    // VRAM is deliberately not subtracted: on a discrete card it is not in the
+    // process at all, and on unified memory it is — counting it either way
+    // would be wrong on half the machines Lumit runs on.
+    let accounted = (frame_cache as u64).saturating_add(decode);
+    BridgeMemoryReport {
+        process_bytes: process,
+        frame_cache_bytes: frame_cache as u64,
+        vram_cache_bytes: vram,
+        decode_cache_bytes: decode,
+        open_decoders: decoders,
+        park_queue_frames: park,
+        unaccounted_bytes: process.saturating_sub(accounted),
+    }
+}
+
 /// Resize the cache, returning what it holds afterwards.
 ///
 /// Shrinking evicts oldest-first straight away rather than waiting for the next

--- a/crates/lumit-bridge/src/api/cache.rs
+++ b/crates/lumit-bridge/src/api/cache.rs
@@ -100,9 +100,23 @@ pub struct BridgeMemoryReport {
     ///
     /// The gap between this and `gpu_allocated_bytes` is memory that has been
     /// released by the engine and not handed back by the driver: free, and
-    /// still ours. That is the shape of "discarded but not deleted", and it is
-    /// invisible to every other number in this report.
+    /// still ours.
+    ///
+    /// **Both byte figures are 0 on macOS**, where Metal keeps no such
+    /// accounting and wgpu therefore reports none — which is the platform the
+    /// question was asked on. Read the two counts below there.
     pub gpu_reserved_bytes: u64,
+    /// How many textures the driver is holding for the render device right now.
+    ///
+    /// **This is the figure that works everywhere, Metal included.** The engine
+    /// holds a handful at rest — the frames in the card's cache, the pooled
+    /// upload textures, the shared present targets, and each frame's
+    /// intermediates while it is being made. Thousands of them means frames the
+    /// engine dropped were never destroyed, which is a different fault from any
+    /// cache being too large and is not visible in any other number here.
+    pub gpu_textures: u64,
+    /// How many buffers the driver is holding, for the same reason.
+    pub gpu_buffers: u64,
     /// `process_bytes` less everything above that lives in ordinary memory.
     /// Saturating at zero, since the platform's number and ours are read a
     /// moment apart and a small negative is meaningless.
@@ -117,7 +131,7 @@ pub fn memory_report() -> BridgeMemoryReport {
     let (vram, _) = crate::framecache::vram::stats();
     let (decode, decoders) = crate::framecache::decode::stats();
     let park = crate::framecache::disk::pending_parks();
-    let (gpu_allocated, gpu_reserved) = crate::framecache::gpu::stats();
+    let (gpu_allocated, gpu_reserved, gpu_textures, gpu_buffers) = crate::framecache::gpu::stats();
     let process = crate::api::system::resident_memory_bytes();
     // VRAM is deliberately not subtracted: on a discrete card it is not in the
     // process at all, and on unified memory it is — counting it either way
@@ -132,6 +146,8 @@ pub fn memory_report() -> BridgeMemoryReport {
         park_queue_frames: park,
         gpu_allocated_bytes: gpu_allocated,
         gpu_reserved_bytes: gpu_reserved,
+        gpu_textures,
+        gpu_buffers,
         unaccounted_bytes: process.saturating_sub(accounted),
     }
 }

--- a/crates/lumit-bridge/src/api/cache.rs
+++ b/crates/lumit-bridge/src/api/cache.rs
@@ -91,6 +91,18 @@ pub struct BridgeMemoryReport {
     /// `Arc`, both tiers), so charging it twice would make the report lie in
     /// the one direction that matters.
     pub park_queue_frames: u64,
+    /// What the graphics driver holds for the render device, in use. On
+    /// unified memory (every Apple Silicon Mac) this is inside
+    /// `process_bytes`; on a discrete card it is not.
+    pub gpu_allocated_bytes: u64,
+    /// What the graphics driver has **reserved** — the blocks those
+    /// allocations were carved from, including the free room inside them.
+    ///
+    /// The gap between this and `gpu_allocated_bytes` is memory that has been
+    /// released by the engine and not handed back by the driver: free, and
+    /// still ours. That is the shape of "discarded but not deleted", and it is
+    /// invisible to every other number in this report.
+    pub gpu_reserved_bytes: u64,
     /// `process_bytes` less everything above that lives in ordinary memory.
     /// Saturating at zero, since the platform's number and ours are read a
     /// moment apart and a small negative is meaningless.
@@ -105,6 +117,7 @@ pub fn memory_report() -> BridgeMemoryReport {
     let (vram, _) = crate::framecache::vram::stats();
     let (decode, decoders) = crate::framecache::decode::stats();
     let park = crate::framecache::disk::pending_parks();
+    let (gpu_allocated, gpu_reserved) = crate::framecache::gpu::stats();
     let process = crate::api::system::resident_memory_bytes();
     // VRAM is deliberately not subtracted: on a discrete card it is not in the
     // process at all, and on unified memory it is — counting it either way
@@ -117,6 +130,8 @@ pub fn memory_report() -> BridgeMemoryReport {
         decode_cache_bytes: decode,
         open_decoders: decoders,
         park_queue_frames: park,
+        gpu_allocated_bytes: gpu_allocated,
+        gpu_reserved_bytes: gpu_reserved,
         unaccounted_bytes: process.saturating_sub(accounted),
     }
 }

--- a/crates/lumit-bridge/src/api/cache.rs
+++ b/crates/lumit-bridge/src/api/cache.rs
@@ -56,7 +56,7 @@ pub fn cache_stats() -> BridgeCacheStats {
 }
 
 /// Where this process's memory has gone: what each tier admits to holding, and
-/// what the operating system says the process holds (K-295).
+/// what the operating system says the process holds (K-294).
 ///
 /// **The field that matters is [`Self::unaccounted_bytes`].** Every tier here
 /// is byte-budgeted and evicts to stay inside its budget, so a report where the

--- a/crates/lumit-bridge/src/api/system.rs
+++ b/crates/lumit-bridge/src/api/system.rs
@@ -22,6 +22,142 @@
 
 use flutter_rust_bridge::frb;
 
+/// What this process is actually holding, in bytes, or 0 where it cannot be
+/// asked — the number the operating system's own monitor shows.
+///
+/// **Why this exists.** Lumit has now twice been reported holding tens of
+/// gigabytes (K-277, and again after it), and each time the first question took
+/// days to answer: is a cache doing exactly what it was told, or is something
+/// holding memory nobody is counting? Every tier already reports its own bytes;
+/// what was missing was the total to weigh them against. The difference between
+/// the two is the whole diagnosis, so it is worth one syscall.
+///
+/// Each platform's nearest equivalent of "what the task manager says":
+/// `PROCESS_MEMORY_COUNTERS.WorkingSetSize` on Windows, `VmRSS` from
+/// `/proc/self/status` on Linux, and `phys_footprint` from `TASK_VM_INFO` on
+/// macOS — which is the number Activity Monitor prints under **Memory**, and so
+/// the one a user reads back to us. Resident set size would have been the
+/// obvious macOS choice and is the wrong one: it omits the compressed pages and
+/// the IOSurface and Metal allocations a graphics application lives on, which
+/// is most of what we would be hunting.
+#[frb(sync)]
+#[must_use]
+pub fn resident_memory_bytes() -> u64 {
+    #[cfg(windows)]
+    {
+        use windows::Win32::System::ProcessStatus::{
+            GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+        };
+        use windows::Win32::System::Threading::GetCurrentProcess;
+        let mut counters = PROCESS_MEMORY_COUNTERS {
+            cb: u32::try_from(std::mem::size_of::<PROCESS_MEMORY_COUNTERS>()).unwrap_or(0),
+            ..Default::default()
+        };
+        // SAFETY: `counters` is a correctly sized, zeroed struct with its `cb`
+        // set, and the pseudo-handle from `GetCurrentProcess` needs no closing.
+        // The result is checked before the struct is trusted.
+        if unsafe { GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, counters.cb) }.is_ok()
+        {
+            return counters.WorkingSetSize as u64;
+        }
+        0
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+            return 0;
+        };
+        for line in status.lines() {
+            let Some(rest) = line.strip_prefix("VmRSS:") else {
+                continue;
+            };
+            // "VmRSS:   123456 kB"
+            let kb = rest.split_whitespace().next().unwrap_or("");
+            if let Ok(kb) = kb.parse::<u64>() {
+                return kb * 1024;
+            }
+        }
+        0
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // `task_info` with `TASK_VM_INFO` fills a struct whose 40th and 41st
+        // 64-bit fields are `phys_footprint` and `min_address`; only the first
+        // is wanted, and the struct is read through its documented layout
+        // rather than a binding crate this workspace does not otherwise need.
+        #[repr(C)]
+        #[derive(Default, Clone, Copy)]
+        struct TaskVmInfo {
+            virtual_size: u64,
+            region_count: i32,
+            page_size: i32,
+            resident_size: u64,
+            resident_size_peak: u64,
+            device: u64,
+            device_peak: u64,
+            internal: u64,
+            internal_peak: u64,
+            external: u64,
+            external_peak: u64,
+            reusable: u64,
+            reusable_peak: u64,
+            purgeable_volatile_pmap: u64,
+            purgeable_volatile_resident: u64,
+            purgeable_volatile_virtual: u64,
+            compressed: u64,
+            compressed_peak: u64,
+            compressed_lifetime: u64,
+            phys_footprint: u64,
+        }
+
+        extern "C" {
+            fn mach_task_self() -> u32;
+            fn task_info(
+                target_task: u32,
+                flavor: u32,
+                task_info_out: *mut std::os::raw::c_void,
+                task_info_count: *mut u32,
+            ) -> std::os::raw::c_int;
+        }
+
+        /// `TASK_VM_INFO`, from `mach/task_info.h`.
+        const TASK_VM_INFO: u32 = 22;
+
+        let mut info = TaskVmInfo::default();
+        // The count is in 32-bit words, which is what the flavour's
+        // `TASK_VM_INFO_COUNT` macro computes.
+        let mut count =
+            u32::try_from(std::mem::size_of::<TaskVmInfo>() / std::mem::size_of::<u32>())
+                .unwrap_or(0);
+        // SAFETY: `info` is a zeroed struct of exactly the layout the flavour
+        // fills and `count` says how much room it has, so the kernel writes at
+        // most that; it truncates rather than overruns when the running kernel's
+        // struct is longer. `mach_task_self` needs no release. The return code
+        // is checked before the value is trusted.
+        let ret = unsafe {
+            task_info(
+                mach_task_self(),
+                TASK_VM_INFO,
+                std::ptr::addr_of_mut!(info).cast(),
+                &mut count,
+            )
+        };
+        if ret == 0 && info.phys_footprint > 0 {
+            return info.phys_footprint;
+        }
+        // A kernel that answered a shorter struct than `phys_footprint` reaches
+        // still answered the resident size, which is better than nothing.
+        if ret == 0 {
+            return info.resident_size;
+        }
+        0
+    }
+    #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+    {
+        0
+    }
+}
+
 /// The machine's installed memory in bytes, or 0 where it cannot be asked.
 #[frb(sync)]
 pub fn system_memory_bytes() -> u64 {

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -2090,6 +2090,69 @@ fn the_razor_cuts_and_deletes_without_moving_the_other_clips() {
     );
 }
 
+/// The memory report answers without a project, and its arithmetic holds
+/// (K-295).
+///
+/// The point of the report is the *unaccounted* figure — what the process holds
+/// that no tier here admits to — so what is pinned is that it is derived from
+/// the two numbers it claims to be derived from, and that a platform which will
+/// not say how big the process is says so with a zero rather than a guess.
+#[test]
+fn the_memory_report_answers_and_its_arithmetic_holds() {
+    use crate::api::cache::memory_report;
+
+    let report = memory_report();
+
+    // Every desktop this ships on can answer; a platform that cannot returns 0
+    // rather than inventing, and then there is nothing to check.
+    if report.process_bytes == 0 {
+        return;
+    }
+
+    let accounted = report.frame_cache_bytes + report.decode_cache_bytes;
+    assert_eq!(
+        report.unaccounted_bytes,
+        report.process_bytes.saturating_sub(accounted),
+        "unaccounted is the process less the tiers that live in ordinary memory"
+    );
+    assert!(
+        report.unaccounted_bytes <= report.process_bytes,
+        "a part cannot exceed the whole"
+    );
+    // The graphics card's frames are reported apart rather than folded in:
+    // on a discrete card they are not in the process at all.
+    assert!(
+        report.vram_cache_bytes == 0 || report.unaccounted_bytes < report.process_bytes + 1,
+        "VRAM is reported, not subtracted"
+    );
+    assert!(
+        report.park_queue_frames <= lumit_render::diskio::MAX_PENDING_PARKS as u64,
+        "the write-behind queue is bounded (K-277), and the report shows it"
+    );
+}
+
+/// A process that is holding memory answers a plausible size for itself — the
+/// syscall behind the report is wired, not a stub returning zero on the
+/// platform running the tests.
+#[test]
+fn the_process_reports_its_own_size() {
+    let bytes = crate::api::system::resident_memory_bytes();
+    // Bound rather than asserted inline: `cfg!` is a literal, and an assert on
+    // one is a constant expression clippy rightly refuses.
+    let desktop = cfg!(any(windows, target_os = "linux", target_os = "macos"));
+    if bytes == 0 {
+        // Only an unsupported platform may answer nothing.
+        assert!(!desktop, "every desktop target answers its own size");
+        return;
+    }
+    // A test process holding less than a megabyte, or more than a terabyte, is
+    // a misread struct rather than a real reading.
+    assert!(
+        bytes > (1 << 20) && bytes < (1 << 40),
+        "a plausible process size, not a misread field: {bytes} bytes"
+    );
+}
+
 /// The cache readout answers without a project and never panics — the Settings
 /// window can show it before anything is open.
 #[test]

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -2091,7 +2091,7 @@ fn the_razor_cuts_and_deletes_without_moving_the_other_clips() {
 }
 
 /// The memory report answers without a project, and its arithmetic holds
-/// (K-295).
+/// (K-294).
 ///
 /// The point of the report is the *unaccounted* figure — what the process holds
 /// that no tier here admits to — so what is pinned is that it is derived from

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -2109,7 +2109,13 @@ fn the_memory_report_answers_and_its_arithmetic_holds() {
         return;
     }
 
-    let accounted = report.frame_cache_bytes + report.decode_cache_bytes;
+    let accounted = report.frame_cache_bytes
+        + report.decode_cache_bytes
+        + if report.unified_memory {
+            report.vram_cache_bytes
+        } else {
+            0
+        };
     assert_eq!(
         report.unaccounted_bytes,
         report.process_bytes.saturating_sub(accounted),
@@ -2119,12 +2125,19 @@ fn the_memory_report_answers_and_its_arithmetic_holds() {
         report.unaccounted_bytes <= report.process_bytes,
         "a part cannot exceed the whole"
     );
-    // The graphics card's frames are reported apart rather than folded in:
-    // on a discrete card they are not in the process at all.
-    assert!(
-        report.vram_cache_bytes == 0 || report.unaccounted_bytes < report.process_bytes + 1,
-        "VRAM is reported, not subtracted"
-    );
+    // The card's frames count against the process only where they are in it.
+    // Getting this backwards makes a cache doing its job read as a leak, which
+    // is the one way this report can actively mislead.
+    if !report.unified_memory {
+        assert_eq!(
+            report.unaccounted_bytes,
+            report
+                .process_bytes
+                .saturating_sub(report.frame_cache_bytes + report.decode_cache_bytes),
+            "a discrete card's frames are not in this process, so they are not \
+             subtracted from it"
+        );
+    }
     assert!(
         report.park_queue_frames <= lumit_render::diskio::MAX_PENDING_PARKS as u64,
         "the write-behind queue is bounded (K-277), and the report shows it"

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -259,6 +259,9 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     let (decoded_bytes, decoders) = state.renderer.decode_memory();
     crate::framecache::decode::publish(decoded_bytes as u64, decoders as u64);
     crate::framecache::disk::publish_pending_parks(state.disk.pending_parks() as u64);
+    if let Some((allocated, reserved)) = state.renderer.gpu_allocator_bytes() {
+        crate::framecache::gpu::publish(allocated, reserved);
+    }
     let (used, _, entries) = state.renderer.frame_texture_stats();
     if (used as u64, entries as u64) != state.published_vram {
         state.published_vram = (used as u64, entries as u64);

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -259,9 +259,13 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     let (decoded_bytes, decoders) = state.renderer.decode_memory();
     crate::framecache::decode::publish(decoded_bytes as u64, decoders as u64);
     crate::framecache::disk::publish_pending_parks(state.disk.pending_parks() as u64);
-    if let Some((allocated, reserved)) = state.renderer.gpu_allocator_bytes() {
-        crate::framecache::gpu::publish(allocated, reserved);
-    }
+    // The driver's own accounting. The byte figures are Vulkan and D3D12 only
+    // — Metal keeps none — so the live-object counts ride with them: those
+    // every backend keeps, and they are what says whether a dropped frame was
+    // actually destroyed (K-293).
+    let (allocated, reserved) = state.renderer.gpu_allocator_bytes().unwrap_or((0, 0));
+    let (textures, buffers) = state.renderer.gpu_live_objects();
+    crate::framecache::gpu::publish(allocated, reserved, textures, buffers);
     let (used, _, entries) = state.renderer.frame_texture_stats();
     if (used as u64, entries as u64) != state.published_vram {
         state.published_vram = (used as u64, entries as u64);

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -253,6 +253,12 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
         state.fill_exhausted = false;
     }
     crate::framecache::publish_comp_decodes(state.renderer.decoded_frames());
+    // The decoded-frame pool's share of the memory report (K-295). Published on
+    // the same turn as the rest, so the numbers a report adds up were all read
+    // at one moment rather than across a second of drift.
+    let (decoded_bytes, decoders) = state.renderer.decode_memory();
+    crate::framecache::decode::publish(decoded_bytes as u64, decoders as u64);
+    crate::framecache::disk::publish_pending_parks(state.disk.pending_parks() as u64);
     let (used, _, entries) = state.renderer.frame_texture_stats();
     if (used as u64, entries as u64) != state.published_vram {
         state.published_vram = (used as u64, entries as u64);

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -253,13 +253,13 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
         state.fill_exhausted = false;
     }
     crate::framecache::publish_comp_decodes(state.renderer.decoded_frames());
-    // The decoded-frame pool's share of the memory report (K-295). Published on
+    // The decoded-frame pool's share of the memory report (K-294). Published on
     // the same turn as the rest, so the numbers a report adds up were all read
     // at one moment rather than across a second of drift.
     let (decoded_bytes, decoders) = state.renderer.decode_memory();
     crate::framecache::decode::publish(decoded_bytes as u64, decoders as u64);
     crate::framecache::disk::publish_pending_parks(state.disk.pending_parks() as u64);
-    // Hand back what this turn dropped (K-294). A frame that has been evicted,
+    // Hand back what this turn dropped (K-295). A frame that has been evicted,
     // a read-back that has been taken, an intermediate the compositor finished
     // with: all of them are only *marked* destroyed when they are dropped, and
     // the driver reclaims them on the device's next maintain. Rendering into a
@@ -273,7 +273,7 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     // The driver's own accounting. The byte figures are Vulkan and D3D12 only
     // — Metal keeps none — so the live-object counts ride with them: those
     // every backend keeps, and they are what says whether a dropped frame was
-    // actually destroyed (K-293).
+    // actually destroyed (K-294).
     let (allocated, reserved) = state.renderer.gpu_allocator_bytes().unwrap_or((0, 0));
     let (textures, buffers) = state.renderer.gpu_live_objects();
     crate::framecache::gpu::publish(allocated, reserved, textures, buffers);

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -259,6 +259,17 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     let (decoded_bytes, decoders) = state.renderer.decode_memory();
     crate::framecache::decode::publish(decoded_bytes as u64, decoders as u64);
     crate::framecache::disk::publish_pending_parks(state.disk.pending_parks() as u64);
+    // Hand back what this turn dropped (K-294). A frame that has been evicted,
+    // a read-back that has been taken, an intermediate the compositor finished
+    // with: all of them are only *marked* destroyed when they are dropped, and
+    // the driver reclaims them on the device's next maintain. Rendering into a
+    // cache on a worker thread never asks for one, so without this line they
+    // sat un-freed until something else happened to poll — which is how the
+    // editor reached tens of gigabytes while idle.
+    //
+    // Non-blocking, and once a turn: it drains what has already finished.
+    state.renderer.reclaim_gpu();
+
     // The driver's own accounting. The byte figures are Vulkan and D3D12 only
     // — Metal keeps none — so the live-object counts ride with them: those
     // every backend keeps, and they are what says whether a dropped frame was
@@ -266,6 +277,7 @@ fn sync_caches(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
     let (allocated, reserved) = state.renderer.gpu_allocator_bytes().unwrap_or((0, 0));
     let (textures, buffers) = state.renderer.gpu_live_objects();
     crate::framecache::gpu::publish(allocated, reserved, textures, buffers);
+    crate::framecache::gpu::publish_unified(state.renderer.unified_memory());
     let (used, _, entries) = state.renderer.frame_texture_stats();
     if (used as u64, entries as u64) != state.published_vram {
         state.published_vram = (used as u64, entries as u64);

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -565,6 +565,16 @@ pub(crate) mod gpu {
     static RESERVED: AtomicU64 = AtomicU64::new(0);
     static TEXTURES: AtomicU64 = AtomicU64::new(0);
     static BUFFERS: AtomicU64 = AtomicU64::new(0);
+    /// Whether the card draws from this process's own memory.
+    static UNIFIED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    pub(crate) fn publish_unified(unified: bool) {
+        UNIFIED.store(unified, Ordering::Relaxed);
+    }
+
+    pub(crate) fn unified() -> bool {
+        UNIFIED.load(Ordering::Relaxed)
+    }
 
     pub(crate) fn publish(allocated: u64, reserved: u64, textures: u64, buffers: u64) {
         ALLOCATED.store(allocated, Ordering::Relaxed);

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -555,6 +555,30 @@ pub(crate) mod decode {
     }
 }
 
+/// What the graphics driver holds for the worker's device, as it last
+/// published — the layer under every tier in this file, and the one nothing
+/// could see until now.
+pub(crate) mod gpu {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static ALLOCATED: AtomicU64 = AtomicU64::new(0);
+    static RESERVED: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) fn publish(allocated: u64, reserved: u64) {
+        ALLOCATED.store(allocated, Ordering::Relaxed);
+        RESERVED.store(reserved, Ordering::Relaxed);
+    }
+
+    /// `(allocated_bytes, reserved_bytes)`; both 0 on a backend that keeps no
+    /// such accounting.
+    pub(crate) fn stats() -> (u64, u64) {
+        (
+            ALLOCATED.load(Ordering::Relaxed),
+            RESERVED.load(Ordering::Relaxed),
+        )
+    }
+}
+
 pub(crate) mod disk {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -627,7 +627,7 @@ pub(crate) mod disk {
     /// The wanted location, and a counter the worker watches so a change is
     /// noticed exactly once.
     /// How many frames are in the write-behind queue, as the worker last
-    /// published — the depth K-277 bounded, in the memory report (K-295).
+    /// published — the depth K-277 bounded, in the memory report (K-294).
     static PENDING_PARKS: AtomicU64 = AtomicU64::new(0);
 
     pub(crate) fn publish_pending_parks(n: u64) {
@@ -793,6 +793,25 @@ mod tests {
     /// compares them. What the name MEANS — and the guarantee that an edit which
     /// cannot change a pixel produces the same name — is `lumit-render`'s to
     /// prove, and it does (`cache::tests`, `headless::tests`).
+    /// One test at a time through the process-wide cache.
+    ///
+    /// These tests share the one `CACHE` this module owns — they `clear()` it,
+    /// put frames in it and read them back — and cargo runs them in parallel
+    /// threads of one process. Two of them interleaving is a test clearing
+    /// another's frames out from under it, which shows up as one unrelated case
+    /// failing every so often and passing on a re-run: the worst kind, because
+    /// it teaches everybody to re-run rather than to look. Caught on this
+    /// branch's own suite (K-294), pre-existing rather than new.
+    ///
+    /// The lock is taken for the body of every test that touches the global; a
+    /// poisoned lock is recovered rather than propagated, so one genuine
+    /// failure does not cascade into "all the others failed too".
+    static CACHE_TESTS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn cache_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        CACHE_TESTS.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     const A: FrameKey = 1;
     const B: FrameKey = 2;
     const C: FrameKey = 3;
@@ -829,6 +848,7 @@ mod tests {
     /// local cache (deterministic, no GPU, no shared global).
     #[test]
     fn a_cached_frame_is_served_without_re_rendering() {
+        let _guard = cache_test_guard();
         let mut cache = Cache::new(DEFAULT_BUDGET_BYTES);
         let comp = uuid::Uuid::now_v7();
         let renders = std::cell::Cell::new(0u32);
@@ -860,6 +880,7 @@ mod tests {
     /// empties itself on every commit.
     #[test]
     fn a_changed_frame_name_misses_and_an_unchanged_one_hits() {
+        let _guard = cache_test_guard();
         let mut cache = Cache::new(DEFAULT_BUDGET_BYTES);
         let comp = uuid::Uuid::now_v7();
         cache.put(A, entry(16, at(comp, 0, 1000)));
@@ -877,6 +898,7 @@ mod tests {
     /// The byte budget evicts the least-recently-used frame first.
     #[test]
     fn the_budget_evicts_least_recently_used() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         // Budget holds exactly two 16-byte frames.
         let mut cache = Cache::new(32);
@@ -898,6 +920,7 @@ mod tests {
     /// Shrinking the budget evicts immediately; clearing empties the cache.
     #[test]
     fn resizing_and_clearing_free_frames() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         let mut cache = Cache::new(64);
         cache.put(A, entry(16, at(comp, 0, 1000)));
@@ -915,6 +938,7 @@ mod tests {
     /// A frame larger than the whole budget is refused rather than thrashing.
     #[test]
     fn an_oversized_frame_is_not_cached() {
+        let _guard = cache_test_guard();
         let mut cache = Cache::new(16);
         cache.put(A, entry(64, at(uuid::Uuid::now_v7(), 0, 1000)));
         assert_eq!(cache.stats().2, 0, "oversized frame skipped");
@@ -923,6 +947,7 @@ mod tests {
     /// The global FFI-facing controls round-trip: clear, set budget, stats.
     #[test]
     fn global_controls_round_trip() {
+        let _guard = cache_test_guard();
         clear();
         set_budget(123 * 1024 * 1024);
         let (used, budget, _entries, _hits, _misses) = stats();
@@ -940,6 +965,7 @@ mod tests {
     /// beside each entry is for.
     #[test]
     fn the_finest_held_picture_of_a_frame_is_reusable() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         let other = uuid::Uuid::now_v7();
         clear();
@@ -967,6 +993,7 @@ mod tests {
     /// arrived, so the trip back up the ladder is still conversion-free.
     #[test]
     fn a_demoted_bgra_frame_reaches_the_scopes_as_rgba() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         clear();
         with_cache(|c| {
@@ -1000,6 +1027,7 @@ mod tests {
     /// rate.
     #[test]
     fn a_disk_load_is_banked_in_memory_for_the_next_pass() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         clear();
         let bytes = Arc::new(vec![9u8; 16]);
@@ -1017,6 +1045,7 @@ mod tests {
     /// handed over, or the bar would promise frames that do not exist.
     #[test]
     fn the_bar_reads_only_the_strip_it_asked_for() {
+        let _guard = cache_test_guard();
         let comp = uuid::Uuid::now_v7();
         let other = uuid::Uuid::now_v7();
         bar::publish(comp, 1000, vec![2, 2, 1, 4, 0]);

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -530,6 +530,31 @@ pub(crate) mod vram {
 /// The disk tier's controls and mirror — the same shape as [`vram`], because the
 /// tier lives on the worker's IO thread and the settings ops run on whichever
 /// thread frb gave them.
+/// The decoded-source-frame pool's numbers, as the worker last published them.
+///
+/// Published rather than asked, for the same reason [`vram`] is: the pool lives
+/// on the worker's renderer, and a settings window must not reach across the
+/// loop to read it (K-184's rule, on the other side of the bridge).
+pub(crate) mod decode {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static USED: AtomicU64 = AtomicU64::new(0);
+    static DECODERS: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) fn publish(used: u64, decoders: u64) {
+        USED.store(used, Ordering::Relaxed);
+        DECODERS.store(decoders, Ordering::Relaxed);
+    }
+
+    /// `(used_bytes, open_decoders)`.
+    pub(crate) fn stats() -> (u64, u64) {
+        (
+            USED.load(Ordering::Relaxed),
+            DECODERS.load(Ordering::Relaxed),
+        )
+    }
+}
+
 pub(crate) mod disk {
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -560,6 +585,18 @@ pub(crate) mod disk {
     static ENTRIES: AtomicU64 = AtomicU64::new(0);
     /// The wanted location, and a counter the worker watches so a change is
     /// noticed exactly once.
+    /// How many frames are in the write-behind queue, as the worker last
+    /// published — the depth K-277 bounded, in the memory report (K-295).
+    static PENDING_PARKS: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) fn publish_pending_parks(n: u64) {
+        PENDING_PARKS.store(n, Ordering::Relaxed);
+    }
+
+    pub(crate) fn pending_parks() -> u64 {
+        PENDING_PARKS.load(Ordering::Relaxed)
+    }
+
     static LOCATION: Mutex<Option<(u64, Location)>> = Mutex::new(None);
     static LOCATION_EPOCH: AtomicU64 = AtomicU64::new(0);
     /// The folder the tier actually resolved to, for Settings to show. `None`

--- a/crates/lumit-bridge/src/framecache.rs
+++ b/crates/lumit-bridge/src/framecache.rs
@@ -563,18 +563,25 @@ pub(crate) mod gpu {
 
     static ALLOCATED: AtomicU64 = AtomicU64::new(0);
     static RESERVED: AtomicU64 = AtomicU64::new(0);
+    static TEXTURES: AtomicU64 = AtomicU64::new(0);
+    static BUFFERS: AtomicU64 = AtomicU64::new(0);
 
-    pub(crate) fn publish(allocated: u64, reserved: u64) {
+    pub(crate) fn publish(allocated: u64, reserved: u64, textures: u64, buffers: u64) {
         ALLOCATED.store(allocated, Ordering::Relaxed);
         RESERVED.store(reserved, Ordering::Relaxed);
+        TEXTURES.store(textures, Ordering::Relaxed);
+        BUFFERS.store(buffers, Ordering::Relaxed);
     }
 
-    /// `(allocated_bytes, reserved_bytes)`; both 0 on a backend that keeps no
-    /// such accounting.
-    pub(crate) fn stats() -> (u64, u64) {
+    /// `(allocated_bytes, reserved_bytes, textures, buffers)`. The two byte
+    /// figures are 0 on a backend that keeps no allocator accounting (Metal);
+    /// the two counts are kept by every backend.
+    pub(crate) fn stats() -> (u64, u64, u64, u64) {
         (
             ALLOCATED.load(Ordering::Relaxed),
             RESERVED.load(Ordering::Relaxed),
+            TEXTURES.load(Ordering::Relaxed),
+            BUFFERS.load(Ordering::Relaxed),
         )
     }
 }

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -41,7 +41,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1647207360;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1097566226;
 
 // Section: executor
 
@@ -6120,6 +6120,35 @@ fn wire__crate__api__effect__list_presets_impl(
         },
     )
 }
+fn wire__crate__api__cache__memory_report_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "memory_report",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::cache::memory_report())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__shell__playback_tier_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -6846,6 +6875,35 @@ fn wire__crate__api__shell__reset_realtime_impl(
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok = Result::<_, ()>::Ok(crate::api::shell::reset_realtime())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__system__resident_memory_bytes_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "resident_memory_bytes",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::system::resident_memory_bytes())?;
                 Ok(output_ok)
             })())
         },
@@ -8152,6 +8210,28 @@ impl SseDecode for crate::api::footage::BridgeMediaInfo {
             fps_num: var_fpsNum,
             fps_den: var_fpsDen,
             duration: var_duration,
+        };
+    }
+}
+
+impl SseDecode for crate::api::cache::BridgeMemoryReport {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_processBytes = <u64>::sse_decode(deserializer);
+        let mut var_frameCacheBytes = <u64>::sse_decode(deserializer);
+        let mut var_vramCacheBytes = <u64>::sse_decode(deserializer);
+        let mut var_decodeCacheBytes = <u64>::sse_decode(deserializer);
+        let mut var_openDecoders = <u64>::sse_decode(deserializer);
+        let mut var_parkQueueFrames = <u64>::sse_decode(deserializer);
+        let mut var_unaccountedBytes = <u64>::sse_decode(deserializer);
+        return crate::api::cache::BridgeMemoryReport {
+            process_bytes: var_processBytes,
+            frame_cache_bytes: var_frameCacheBytes,
+            vram_cache_bytes: var_vramCacheBytes,
+            decode_cache_bytes: var_decodeCacheBytes,
+            open_decoders: var_openDecoders,
+            park_queue_frames: var_parkQueueFrames,
+            unaccounted_bytes: var_unaccountedBytes,
         };
     }
 }
@@ -9764,7 +9844,7 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        196 => wire__crate__api__project__project_reference_save_impl(
+        197 => wire__crate__api__project__project_reference_save_impl(
             port,
             ptr,
             rust_vec_len,
@@ -9949,42 +10029,44 @@ fn pde_ffi_dispatcher_sync_impl(
 178 => wire__crate__api__effect__list_parameter_groups_impl(ptr, rust_vec_len, data_len),
 179 => wire__crate__api__effect__list_parameters_impl(ptr, rust_vec_len, data_len),
 180 => wire__crate__api__effect__list_presets_impl(ptr, rust_vec_len, data_len),
-181 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
-182 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
-183 => wire__crate__api__project__project_reference_anti_aliasing_impl(ptr, rust_vec_len, data_len),
-184 => wire__crate__api__project__project_reference_anti_aliasing_in_use_impl(ptr, rust_vec_len, data_len),
-185 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
-186 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
-187 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
-188 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
-189 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
-190 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
-191 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
-192 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
-193 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
-194 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
-195 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
-197 => wire__crate__api__project__project_reference_set_anti_aliasing_impl(ptr, rust_vec_len, data_len),
-198 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
-199 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
-200 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
-201 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
-202 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
-203 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
-204 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
-205 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
-206 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
-207 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
-208 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
-209 => wire__crate__api__cache__set_render_profiling_impl(ptr, rust_vec_len, data_len),
-210 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
-211 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
-212 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
-213 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
-214 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
-215 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
-216 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
-217 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
+181 => wire__crate__api__cache__memory_report_impl(ptr, rust_vec_len, data_len),
+182 => wire__crate__api__shell__playback_tier_impl(ptr, rust_vec_len, data_len),
+183 => wire__crate__api__effect__presets_dir_path_impl(ptr, rust_vec_len, data_len),
+184 => wire__crate__api__project__project_reference_anti_aliasing_impl(ptr, rust_vec_len, data_len),
+185 => wire__crate__api__project__project_reference_anti_aliasing_in_use_impl(ptr, rust_vec_len, data_len),
+186 => wire__crate__api__project__project_reference_autosave_impl(ptr, rust_vec_len, data_len),
+187 => wire__crate__api__project__project_reference_cache_location_impl(ptr, rust_vec_len, data_len),
+188 => wire__crate__api__project__project_reference_get_items_impl(ptr, rust_vec_len, data_len),
+189 => wire__crate__api__project__project_reference_history_impl(ptr, rust_vec_len, data_len),
+190 => wire__crate__api__project__project_reference_import_footage_impl(ptr, rust_vec_len, data_len),
+191 => wire__crate__api__project__project_reference_is_dirty_impl(ptr, rust_vec_len, data_len),
+192 => wire__crate__api__project__project_reference_new_composition_impl(ptr, rust_vec_len, data_len),
+193 => wire__crate__api__project__project_reference_next_comp_name_impl(ptr, rust_vec_len, data_len),
+194 => wire__crate__api__project__project_reference_path_impl(ptr, rust_vec_len, data_len),
+195 => wire__crate__api__project__project_reference_redo_impl(ptr, rust_vec_len, data_len),
+196 => wire__crate__api__project__project_reference_restore_journal_impl(ptr, rust_vec_len, data_len),
+198 => wire__crate__api__project__project_reference_set_anti_aliasing_impl(ptr, rust_vec_len, data_len),
+199 => wire__crate__api__project__project_reference_set_cache_location_impl(ptr, rust_vec_len, data_len),
+200 => wire__crate__api__project__project_reference_set_ui_state_impl(ptr, rust_vec_len, data_len),
+201 => wire__crate__api__project__project_reference_start_worker_impl(ptr, rust_vec_len, data_len),
+202 => wire__crate__api__project__project_reference_ui_state_impl(ptr, rust_vec_len, data_len),
+203 => wire__crate__api__project__project_reference_undo_impl(ptr, rust_vec_len, data_len),
+204 => wire__crate__api__shell__reset_realtime_impl(ptr, rust_vec_len, data_len),
+205 => wire__crate__api__system__resident_memory_bytes_impl(ptr, rust_vec_len, data_len),
+206 => wire__crate__api__system__restore_frozen_cursor_impl(ptr, rust_vec_len, data_len),
+207 => wire__crate__api__effect__sample_scalar_impl(ptr, rust_vec_len, data_len),
+208 => wire__crate__api__cache__set_cache_budget_impl(ptr, rust_vec_len, data_len),
+209 => wire__crate__api__cache__set_disk_cache_budget_impl(ptr, rust_vec_len, data_len),
+210 => wire__crate__api__cache__set_disk_cache_location_impl(ptr, rust_vec_len, data_len),
+211 => wire__crate__api__cache__set_render_profiling_impl(ptr, rust_vec_len, data_len),
+212 => wire__crate__api__cache__set_vram_cache_budget_impl(ptr, rust_vec_len, data_len),
+213 => wire__crate__api__solid__solid_reference_get_definition_impl(ptr, rust_vec_len, data_len),
+214 => wire__crate__api__solid__solid_reference_set_definition_impl(ptr, rust_vec_len, data_len),
+215 => wire__crate__api__system__system_memory_bytes_impl(ptr, rust_vec_len, data_len),
+216 => wire__crate__api__system__thaw_cursor_impl(ptr, rust_vec_len, data_len),
+217 => wire__crate__api__system__video_memory_bytes_impl(ptr, rust_vec_len, data_len),
+218 => wire__crate__api__cache__viewer_transport_impl(ptr, rust_vec_len, data_len),
+219 => wire__crate__api__cache__vram_cache_stats_impl(ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -11041,6 +11123,32 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::footage::BridgeMediaInfo>
     for crate::api::footage::BridgeMediaInfo
 {
     fn into_into_dart(self) -> crate::api::footage::BridgeMediaInfo {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::cache::BridgeMemoryReport {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.process_bytes.into_into_dart().into_dart(),
+            self.frame_cache_bytes.into_into_dart().into_dart(),
+            self.vram_cache_bytes.into_into_dart().into_dart(),
+            self.decode_cache_bytes.into_into_dart().into_dart(),
+            self.open_decoders.into_into_dart().into_dart(),
+            self.park_queue_frames.into_into_dart().into_dart(),
+            self.unaccounted_bytes.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::cache::BridgeMemoryReport
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::cache::BridgeMemoryReport>
+    for crate::api::cache::BridgeMemoryReport
+{
+    fn into_into_dart(self) -> crate::api::cache::BridgeMemoryReport {
         self
     }
 }
@@ -12774,6 +12882,19 @@ impl SseEncode for crate::api::footage::BridgeMediaInfo {
         <u32>::sse_encode(self.fps_num, serializer);
         <u32>::sse_encode(self.fps_den, serializer);
         <crate::api::effect::BridgeRational>::sse_encode(self.duration, serializer);
+    }
+}
+
+impl SseEncode for crate::api::cache::BridgeMemoryReport {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.process_bytes, serializer);
+        <u64>::sse_encode(self.frame_cache_bytes, serializer);
+        <u64>::sse_encode(self.vram_cache_bytes, serializer);
+        <u64>::sse_encode(self.decode_cache_bytes, serializer);
+        <u64>::sse_encode(self.open_decoders, serializer);
+        <u64>::sse_encode(self.park_queue_frames, serializer);
+        <u64>::sse_encode(self.unaccounted_bytes, serializer);
     }
 }
 

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -8223,6 +8223,8 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
         let mut var_decodeCacheBytes = <u64>::sse_decode(deserializer);
         let mut var_openDecoders = <u64>::sse_decode(deserializer);
         let mut var_parkQueueFrames = <u64>::sse_decode(deserializer);
+        let mut var_gpuAllocatedBytes = <u64>::sse_decode(deserializer);
+        let mut var_gpuReservedBytes = <u64>::sse_decode(deserializer);
         let mut var_unaccountedBytes = <u64>::sse_decode(deserializer);
         return crate::api::cache::BridgeMemoryReport {
             process_bytes: var_processBytes,
@@ -8231,6 +8233,8 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
             decode_cache_bytes: var_decodeCacheBytes,
             open_decoders: var_openDecoders,
             park_queue_frames: var_parkQueueFrames,
+            gpu_allocated_bytes: var_gpuAllocatedBytes,
+            gpu_reserved_bytes: var_gpuReservedBytes,
             unaccounted_bytes: var_unaccountedBytes,
         };
     }
@@ -11136,6 +11140,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::cache::BridgeMemoryReport {
             self.decode_cache_bytes.into_into_dart().into_dart(),
             self.open_decoders.into_into_dart().into_dart(),
             self.park_queue_frames.into_into_dart().into_dart(),
+            self.gpu_allocated_bytes.into_into_dart().into_dart(),
+            self.gpu_reserved_bytes.into_into_dart().into_dart(),
             self.unaccounted_bytes.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -12894,6 +12900,8 @@ impl SseEncode for crate::api::cache::BridgeMemoryReport {
         <u64>::sse_encode(self.decode_cache_bytes, serializer);
         <u64>::sse_encode(self.open_decoders, serializer);
         <u64>::sse_encode(self.park_queue_frames, serializer);
+        <u64>::sse_encode(self.gpu_allocated_bytes, serializer);
+        <u64>::sse_encode(self.gpu_reserved_bytes, serializer);
         <u64>::sse_encode(self.unaccounted_bytes, serializer);
     }
 }

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -8225,6 +8225,8 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
         let mut var_parkQueueFrames = <u64>::sse_decode(deserializer);
         let mut var_gpuAllocatedBytes = <u64>::sse_decode(deserializer);
         let mut var_gpuReservedBytes = <u64>::sse_decode(deserializer);
+        let mut var_gpuTextures = <u64>::sse_decode(deserializer);
+        let mut var_gpuBuffers = <u64>::sse_decode(deserializer);
         let mut var_unaccountedBytes = <u64>::sse_decode(deserializer);
         return crate::api::cache::BridgeMemoryReport {
             process_bytes: var_processBytes,
@@ -8235,6 +8237,8 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
             park_queue_frames: var_parkQueueFrames,
             gpu_allocated_bytes: var_gpuAllocatedBytes,
             gpu_reserved_bytes: var_gpuReservedBytes,
+            gpu_textures: var_gpuTextures,
+            gpu_buffers: var_gpuBuffers,
             unaccounted_bytes: var_unaccountedBytes,
         };
     }
@@ -11142,6 +11146,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::cache::BridgeMemoryReport {
             self.park_queue_frames.into_into_dart().into_dart(),
             self.gpu_allocated_bytes.into_into_dart().into_dart(),
             self.gpu_reserved_bytes.into_into_dart().into_dart(),
+            self.gpu_textures.into_into_dart().into_dart(),
+            self.gpu_buffers.into_into_dart().into_dart(),
             self.unaccounted_bytes.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -12902,6 +12908,8 @@ impl SseEncode for crate::api::cache::BridgeMemoryReport {
         <u64>::sse_encode(self.park_queue_frames, serializer);
         <u64>::sse_encode(self.gpu_allocated_bytes, serializer);
         <u64>::sse_encode(self.gpu_reserved_bytes, serializer);
+        <u64>::sse_encode(self.gpu_textures, serializer);
+        <u64>::sse_encode(self.gpu_buffers, serializer);
         <u64>::sse_encode(self.unaccounted_bytes, serializer);
     }
 }

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -8220,6 +8220,7 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
         let mut var_processBytes = <u64>::sse_decode(deserializer);
         let mut var_frameCacheBytes = <u64>::sse_decode(deserializer);
         let mut var_vramCacheBytes = <u64>::sse_decode(deserializer);
+        let mut var_unifiedMemory = <bool>::sse_decode(deserializer);
         let mut var_decodeCacheBytes = <u64>::sse_decode(deserializer);
         let mut var_openDecoders = <u64>::sse_decode(deserializer);
         let mut var_parkQueueFrames = <u64>::sse_decode(deserializer);
@@ -8232,6 +8233,7 @@ impl SseDecode for crate::api::cache::BridgeMemoryReport {
             process_bytes: var_processBytes,
             frame_cache_bytes: var_frameCacheBytes,
             vram_cache_bytes: var_vramCacheBytes,
+            unified_memory: var_unifiedMemory,
             decode_cache_bytes: var_decodeCacheBytes,
             open_decoders: var_openDecoders,
             park_queue_frames: var_parkQueueFrames,
@@ -11141,6 +11143,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::cache::BridgeMemoryReport {
             self.process_bytes.into_into_dart().into_dart(),
             self.frame_cache_bytes.into_into_dart().into_dart(),
             self.vram_cache_bytes.into_into_dart().into_dart(),
+            self.unified_memory.into_into_dart().into_dart(),
             self.decode_cache_bytes.into_into_dart().into_dart(),
             self.open_decoders.into_into_dart().into_dart(),
             self.park_queue_frames.into_into_dart().into_dart(),
@@ -12903,6 +12906,7 @@ impl SseEncode for crate::api::cache::BridgeMemoryReport {
         <u64>::sse_encode(self.process_bytes, serializer);
         <u64>::sse_encode(self.frame_cache_bytes, serializer);
         <u64>::sse_encode(self.vram_cache_bytes, serializer);
+        <bool>::sse_encode(self.unified_memory, serializer);
         <u64>::sse_encode(self.decode_cache_bytes, serializer);
         <u64>::sse_encode(self.open_decoders, serializer);
         <u64>::sse_encode(self.park_queue_frames, serializer);

--- a/crates/lumit-gpu/Cargo.toml
+++ b/crates/lumit-gpu/Cargo.toml
@@ -13,7 +13,12 @@ glam = "0.29"
 half = "2"
 pollster = "0.4"
 thiserror = "2"
-wgpu = "24"
+# `counters` turns on wgpu's live-object tallies — how many textures and
+# buffers the driver is holding right now, which is what says whether a frame
+# the engine dropped was actually destroyed (K-293). Every backend keeps them;
+# unlike the allocator report, which is Vulkan and D3D12 only and answers
+# nothing at all on Metal, where the memory question was asked.
+wgpu = { version = "24", features = ["counters"] }
 
 # The Windows-only, zero-copy Viewer path (K-177). Off by default so every
 # existing build is byte-for-byte unchanged; the bridge turns it on to build the

--- a/crates/lumit-gpu/Cargo.toml
+++ b/crates/lumit-gpu/Cargo.toml
@@ -15,7 +15,7 @@ pollster = "0.4"
 thiserror = "2"
 # `counters` turns on wgpu's live-object tallies — how many textures and
 # buffers the driver is holding right now, which is what says whether a frame
-# the engine dropped was actually destroyed (K-293). Every backend keeps them;
+# the engine dropped was actually destroyed (K-294). Every backend keeps them;
 # unlike the allocator report, which is Vulkan and D3D12 only and answers
 # nothing at all on Metal, where the memory question was asked.
 wgpu = { version = "24", features = ["counters"] }

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -91,6 +91,14 @@ pub struct GpuContext {
     /// unshared and the honest scope for the question: what did *this* render
     /// hand over.
     ///
+    /// Whether the graphics memory and the system memory are the same memory —
+    /// an integrated or software adapter, which is every Apple Silicon Mac.
+    ///
+    /// It decides one thing, and that one thing matters: whether the frames
+    /// held on the card are *inside* this process's total or beside it. Report
+    /// them the wrong way round and a cache doing exactly its job reads as
+    /// gigabytes nobody can account for (K-293).
+    pub unified_memory: bool,
     /// Shared with every [`Self::clone_handle`] of this context, because they
     /// are handles on the *same* device and queue: the realiser keeps one of
     /// its own, and a count that missed what went through it would be counting
@@ -305,6 +313,10 @@ impl GpuContext {
             device,
             queue,
             software: false,
+            // Not knowable from a device alone, and the safe answer for a
+            // memory report is the one that does not claim the card's frames
+            // are inside this process when they may not be.
+            unified_memory: false,
             sample_flags: wgpu::TextureFormatFeatureFlags::empty(),
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),
@@ -332,6 +344,7 @@ impl GpuContext {
             device: self.device.clone(),
             queue: self.queue.clone(),
             software: self.software,
+            unified_memory: self.unified_memory,
             sample_flags: self.sample_flags,
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),
@@ -394,6 +407,29 @@ impl GpuContext {
             counters.hal.textures.read() as u64,
             counters.hal.buffers.read() as u64,
         )
+    }
+
+    /// Give the driver a turn to hand back what the engine has dropped.
+    ///
+    /// **Why this has to be called, and called regularly.** Dropping a texture
+    /// or a buffer does not free it: wgpu marks it destroyed and reclaims it on
+    /// the device's next *maintain*. A renderer that draws to a window gets
+    /// maintains for free from presenting; this engine renders into caches, on
+    /// a worker thread, and idles — so nothing was making that turn happen, and
+    /// dropped frames sat un-freed until something asked the device a question
+    /// for its own reasons.
+    ///
+    /// Reported twice from a Mac at tens of gigabytes (K-277, K-293): the
+    /// second reading caught it in the act — 5 000-odd live buffers and 6 GB
+    /// held, then 8 buffers and 2.9 GB moments later, because opening a panel
+    /// happened to poll. Memory that comes back only when the user does
+    /// something unrelated is a leak in every sense that matters.
+    ///
+    /// Non-blocking: this drains what has already finished and returns. It is
+    /// cheap enough to call on every turn of the worker's loop, which is
+    /// exactly what it is for.
+    pub fn reclaim(&self) {
+        self.device.poll(wgpu::Maintain::Poll);
     }
 
     /// Start batching: from here until the matching [`Self::end_frame`], every
@@ -509,6 +545,13 @@ impl GpuContext {
             adapter.get_info().device_type,
             wgpu::DeviceType::Cpu | wgpu::DeviceType::Other
         );
+        // Integrated and software adapters draw from system memory; a discrete
+        // card has its own. Metal reports Apple Silicon as integrated, which is
+        // the case this exists for.
+        let unified_memory = !matches!(
+            adapter.get_info().device_type,
+            wgpu::DeviceType::DiscreteGpu
+        );
         // The Linux DMA-BUF path needs the external-memory device extensions
         // enabled at device-creation time, which wgpu's default Vulkan device does
         // not do (K-177). Open the device ourselves with them appended; if the
@@ -577,6 +620,7 @@ impl GpuContext {
             device,
             queue,
             software,
+            unified_memory,
             sample_flags,
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -368,12 +368,32 @@ impl GpuContext {
     /// and a large gap between them is memory that is free and still ours —
     /// which is exactly the shape of "discarded but not deleted".
     ///
-    /// `None` where the backend keeps no such accounting.
+    /// `None` where the backend keeps no such accounting — which is **every
+    /// Mac**: the allocator report is Vulkan and D3D12 only, and Metal does its
+    /// own allocation. Read [`Self::live_objects`] and [`Self::device_bytes`]
+    /// there, which is why both exist.
     #[must_use]
     pub fn allocator_bytes(&self) -> Option<(u64, u64)> {
         self.device
             .generate_allocator_report()
             .map(|r| (r.total_allocated_bytes, r.total_reserved_bytes))
+    }
+
+    /// How many textures and buffers the driver is holding for this device
+    /// right now — `(textures, buffers)`.
+    ///
+    /// Every backend keeps these, Metal included, which is what makes them the
+    /// honest question on the platform where the memory was actually lost. A
+    /// cache holding eight frames beside a driver holding four thousand
+    /// textures is not a cache problem and not an allocator subtlety: it is
+    /// objects the engine dropped that were never destroyed.
+    #[must_use]
+    pub fn live_objects(&self) -> (u64, u64) {
+        let counters = self.device.get_internal_counters();
+        (
+            counters.hal.textures.read() as u64,
+            counters.hal.buffers.read() as u64,
+        )
     }
 
     /// Start batching: from here until the matching [`Self::end_frame`], every
@@ -1158,6 +1178,54 @@ impl ColourEngine {
         drop(data);
         buffer.unmap();
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod counter_tests {
+    use super::*;
+
+    /// The live-object count moves with what is actually alive (K-293).
+    ///
+    /// This is the figure the memory report leans on for Metal, where the
+    /// allocator report answers nothing, so a build where the counters were
+    /// compiled out would leave that row reading zero for ever — true-looking
+    /// and useless. Making a texture and dropping it proves the tally is wired.
+    #[test]
+    fn the_live_texture_count_follows_what_is_alive() {
+        let Ok(ctx) = GpuContext::headless() else {
+            no_adapter();
+            return;
+        };
+        let (before, _) = ctx.live_objects();
+        let made = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("counter-probe"),
+            size: wgpu::Extent3d {
+                width: 64,
+                height: 64,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: WORKING_FORMAT,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let (during, _) = ctx.live_objects();
+        assert!(
+            during > before,
+            "a new texture is counted: {before} then {during}"
+        );
+        drop(made);
+        // Destruction is deferred until the device is given a turn — which is
+        // the very behaviour this row exists to expose.
+        ctx.device.poll(wgpu::Maintain::Poll);
+        let (after, _) = ctx.live_objects();
+        assert!(
+            after <= during,
+            "and dropping it does not raise the count: {during} then {after}"
+        );
     }
 }
 

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -97,7 +97,7 @@ pub struct GpuContext {
     /// It decides one thing, and that one thing matters: whether the frames
     /// held on the card are *inside* this process's total or beside it. Report
     /// them the wrong way round and a cache doing exactly its job reads as
-    /// gigabytes nobody can account for (K-293).
+    /// gigabytes nobody can account for (K-294).
     pub unified_memory: bool,
     /// Shared with every [`Self::clone_handle`] of this context, because they
     /// are handles on the *same* device and queue: the realiser keeps one of
@@ -372,7 +372,7 @@ impl GpuContext {
 
     /// What the graphics driver is holding for this device: bytes live in
     /// allocations, and bytes reserved in the blocks they were carved from
-    /// (K-293's follow-up).
+    /// (K-294's follow-up).
     ///
     /// **Why the second number matters more than the first.** An allocator
     /// hands out blocks and sub-allocates within them; freeing every allocation
@@ -419,7 +419,7 @@ impl GpuContext {
     /// dropped frames sat un-freed until something asked the device a question
     /// for its own reasons.
     ///
-    /// Reported twice from a Mac at tens of gigabytes (K-277, K-293): the
+    /// Reported twice from a Mac at tens of gigabytes (K-277, K-294): the
     /// second reading caught it in the act — 5 000-odd live buffers and 6 GB
     /// held, then 8 buffers and 2.9 GB moments later, because opening a panel
     /// happened to poll. Memory that comes back only when the user does
@@ -1229,7 +1229,7 @@ impl ColourEngine {
 mod counter_tests {
     use super::*;
 
-    /// The live-object count moves with what is actually alive (K-293).
+    /// The live-object count moves with what is actually alive (K-294).
     ///
     /// This is the figure the memory report leans on for Metal, where the
     /// allocator report answers nothing, so a build where the counters were

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -357,6 +357,25 @@ impl GpuContext {
         self.submits.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// What the graphics driver is holding for this device: bytes live in
+    /// allocations, and bytes reserved in the blocks they were carved from
+    /// (K-293's follow-up).
+    ///
+    /// **Why the second number matters more than the first.** An allocator
+    /// hands out blocks and sub-allocates within them; freeing every allocation
+    /// in a block does not necessarily hand the block back. `reserved` is what
+    /// the process is actually holding, `allocated` what it is actually using,
+    /// and a large gap between them is memory that is free and still ours —
+    /// which is exactly the shape of "discarded but not deleted".
+    ///
+    /// `None` where the backend keeps no such accounting.
+    #[must_use]
+    pub fn allocator_bytes(&self) -> Option<(u64, u64)> {
+        self.device
+            .generate_allocator_report()
+            .map(|r| (r.total_allocated_bytes, r.total_reserved_bytes))
+    }
+
     /// Start batching: from here until the matching [`Self::end_frame`], every
     /// [`Self::encoder`] records into one command buffer and nothing is
     /// submitted.

--- a/crates/lumit-render/src/decode.rs
+++ b/crates/lumit-render/src/decode.rs
@@ -270,7 +270,7 @@ impl DecodePool {
     }
 
     /// What the decoded-frame cache is holding, and how many decoders are
-    /// open — the pool's share of the memory report (K-295).
+    /// open — the pool's share of the memory report (K-294).
     ///
     /// The decoders are counted rather than measured: what a `VideoDecoder`
     /// holds is FFmpeg's business (and, with hardware decode, the driver's), so

--- a/crates/lumit-render/src/decode.rs
+++ b/crates/lumit-render/src/decode.rs
@@ -269,6 +269,17 @@ impl DecodePool {
         self.comp_decodes
     }
 
+    /// What the decoded-frame cache is holding, and how many decoders are
+    /// open — the pool's share of the memory report (K-295).
+    ///
+    /// The decoders are counted rather than measured: what a `VideoDecoder`
+    /// holds is FFmpeg's business (and, with hardware decode, the driver's), so
+    /// a number of them is honest where a number of bytes would be invented.
+    #[must_use]
+    pub fn memory(&self) -> (usize, usize) {
+        (self.frame_cache.used_bytes(), self.decoders.len())
+    }
+
     /// Resize the decoded-frame cache (its slice of the one RAM budget).
     pub fn set_budget(&mut self, bytes: usize) {
         self.frame_cache.set_budget(bytes);

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -943,6 +943,13 @@ impl HeadlessRenderer {
         self.gpu.allocator_bytes()
     }
 
+    /// How many textures and buffers the driver is still holding for this
+    /// renderer — see [`lumit_gpu::GpuContext::live_objects`].
+    #[must_use]
+    pub fn gpu_live_objects(&self) -> (u64, u64) {
+        self.gpu.live_objects()
+    }
+
     /// Resize the decoded-source-frame cache (Settings → Performance).
     pub fn set_decode_budget(&mut self, bytes: usize) {
         self.pool.set_budget(bytes);

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -936,6 +936,13 @@ impl HeadlessRenderer {
         self.pool.memory()
     }
 
+    /// What the graphics driver holds for this renderer's device — see
+    /// [`lumit_gpu::GpuContext::allocator_bytes`].
+    #[must_use]
+    pub fn gpu_allocator_bytes(&self) -> Option<(u64, u64)> {
+        self.gpu.allocator_bytes()
+    }
+
     /// Resize the decoded-source-frame cache (Settings → Performance).
     pub fn set_decode_budget(&mut self, bytes: usize) {
         self.pool.set_budget(bytes);

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -929,6 +929,13 @@ impl HeadlessRenderer {
         self.retained = None;
     }
 
+    /// The decoded-frame cache's bytes and how many decoders are open — see
+    /// [`crate::decode::DecodePool::memory`].
+    #[must_use]
+    pub fn decode_memory(&self) -> (usize, usize) {
+        self.pool.memory()
+    }
+
     /// Resize the decoded-source-frame cache (Settings → Performance).
     pub fn set_decode_budget(&mut self, bytes: usize) {
         self.pool.set_budget(bytes);

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -943,11 +943,24 @@ impl HeadlessRenderer {
         self.gpu.allocator_bytes()
     }
 
+    /// Whether the card's memory is this process's memory — see
+    /// [`lumit_gpu::GpuContext::unified_memory`].
+    #[must_use]
+    pub fn unified_memory(&self) -> bool {
+        self.gpu.unified_memory
+    }
+
     /// How many textures and buffers the driver is still holding for this
     /// renderer — see [`lumit_gpu::GpuContext::live_objects`].
     #[must_use]
     pub fn gpu_live_objects(&self) -> (u64, u64) {
         self.gpu.live_objects()
+    }
+
+    /// Give the driver a turn to reclaim what has been dropped — see
+    /// [`lumit_gpu::GpuContext::reclaim`]. Called once per worker turn.
+    pub fn reclaim_gpu(&self) {
+        self.gpu.reclaim();
     }
 
     /// Resize the decoded-source-frame cache (Settings → Performance).
@@ -3245,6 +3258,80 @@ mod tests {
             comp.layers.insert(0, layer);
         }
         (solid, layer_id)
+    }
+
+    /// **What the engine drops, the driver gets back** (K-294).
+    ///
+    /// The failure this pins is not a slow leak: it is memory that comes back
+    /// only when something unrelated happens. Dropping a texture or a buffer
+    /// marks it destroyed; the driver reclaims it on the device's next
+    /// maintain, and an engine that renders into a cache on a worker thread —
+    /// never presenting, often idle — asks for one only by accident. Reported
+    /// from a Mac twice, the second time caught mid-act: 5 000 live buffers and
+    /// 6 GB, then 8 buffers and 2.9 GB moments later because a panel was
+    /// opened.
+    ///
+    /// **This test earns its keep on macOS**, where the reclamation actually
+    /// went wrong and where no allocator report exists to see it — the counts
+    /// are what every backend keeps. It renders far more frames than the cache
+    /// can hold, so the great majority are evicted and dropped, and then asks
+    /// the driver what it still has. A handful is right; hundreds means the
+    /// dropped ones were never handed back.
+    #[test]
+    fn what_the_engine_drops_the_driver_gets_back() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                lumit_gpu::no_adapter();
+                return;
+            }
+        };
+        // A budget of a few frames, so nearly every render below is evicted.
+        r.set_frame_texture_budget(32 * 1024 * 1024);
+        let (cw, ch) = (960u32, 540u32);
+        let (doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.8, 0.1, 0.1, 1.0]));
+        let store = DocumentStore::new(doc);
+        let doc = store.snapshot();
+
+        let (textures_before, buffers_before) = r.gpu_live_objects();
+        for i in 0..120u64 {
+            // A name of its own per frame: every render is a new entry, so the
+            // store must evict, exactly as a long session makes it.
+            let _ = r
+                .render_prepared_named(&doc, comp_id, 0, Quality::default(), true, Some(i as u128))
+                .expect("render");
+            // The worker's own turn does this once a loop; the whole point is
+            // that it is what makes the dropping stick.
+            r.reclaim_gpu();
+        }
+        let (textures, buffers) = r.gpu_live_objects();
+
+        // What the engine legitimately holds at rest: the frames still in the
+        // card's cache, the pooled upload textures, the shared present targets,
+        // and one frame's intermediates. Tens, not the hundred-and-twenty
+        // frames that went through, and nothing like the thousands a session
+        // reached before this.
+        // Measured at 18 textures and 8 buffers on the software rasteriser CI
+        // runs, against 2 and 5 before the loop; the ceilings are generous
+        // enough for a busier backend's own bookkeeping and nowhere near the
+        // hundred-and-twenty frames that went through, which is the number a
+        // driver that never reclaimed would be sitting on.
+        assert!(
+            textures < 64,
+            "120 rendered frames must not leave a texture each behind: \
+             {textures_before} before, {textures} after"
+        );
+        assert!(
+            buffers < 64,
+            "nor a buffer each: {buffers_before} before, {buffers} after"
+        );
+        // And the card's cache is the thing that decides how many frames are
+        // held, not the number of frames that have been made.
+        let (used, budget, _) = r.frame_texture_stats();
+        assert!(
+            used <= budget,
+            "the cache stays inside its budget: {used} of {budget}"
+        );
     }
 
     /// **A frame is one command buffer, however many layers it has.**

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -3260,7 +3260,7 @@ mod tests {
         (solid, layer_id)
     }
 
-    /// **What the engine drops, the driver gets back** (K-294).
+    /// **What the engine drops, the driver gets back** (K-295).
     ///
     /// The failure this pins is not a slow leak: it is memory that comes back
     /// only when something unrelated happens. Dropping a texture or a buffer

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6391,6 +6391,12 @@ worth a syscall.
   one — it leaves out the compressed pages and the IOSurface and Metal allocations a
   graphics application lives on, which is most of what would be hunted. `phys_footprint`
   is what Activity Monitor prints under *Memory*, and so the number a user reads back.
+- **The graphics driver's own accounting rides beside the tiers**, in use and reserved
+  (`Device::generate_allocator_report`). The first reading in anger made the case: 12 GB
+  held, 11 GB of it unaccounted, with ~405 frames decoded — which cleared every
+  byte-budgeted tier at a glance and left the layer underneath, where the tiers' own
+  numbers cannot reach. Reserved-minus-in-use is the shape of "discarded but not deleted",
+  and it is now a number rather than a theory.
 - **VRAM is reported apart, never subtracted**: on unified memory it is inside the process
   and on a discrete card it is not, so folding it in is wrong on half the machines Lumit
   runs on. **Nothing is counted twice** — a frame in the write-behind queue shares its

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6420,3 +6420,48 @@ worth a syscall.
 This is a diagnostic, and it is deliberately not a fix: it does not reclaim a byte. It is
 the instrument the next report is read with, written down in docs/13 §7.0.1 as a standing
 rule — a tier that holds memory and does not report it is not finished.
+
+**K-294 · DECIDED · What the engine drops, the driver hands back on the next turn: the
+worker reclaims once a loop.** From the owner's readings on 2026-08-06, which caught the
+fault in the act: 6 GB held with **around 5 500 live graphics buffers**, then 2.9 GB and
+**8 buffers** moments later — because switching back to a settings page happened to make
+the device do a maintain. Memory that comes back only when the user does something
+unrelated is a leak in every sense that matters to the person whose machine it is.
+
+**The mechanism.** Dropping a texture or a buffer does not free it. wgpu marks it
+destroyed and hands the memory back on the device's next *maintain*, which a renderer
+drawing into a window gets for free from presenting. This engine renders into caches, on a
+worker thread, and spends most of its time idle: the frame cache evicts, read-backs
+finish, a composite's intermediates go out of scope — and none of that asked the device
+for anything, so the memory sat marked-and-not-returned until something else polled for
+its own reasons. The idle fill and the idle backup make that worse rather than better,
+because they are what produces the dropped objects while nothing presents.
+
+**The fix is one line and a rule.** `GpuContext::reclaim` — a non-blocking
+`Maintain::Poll` — on every turn of the worker's loop. It drains what has already
+finished, costs nothing when there is nothing to drain, and makes reclamation a property
+of time passing rather than of the user opening a panel.
+
+**The rule this writes down** (docs/13 §7.0.2): an engine that renders without presenting
+MUST maintain its device on a schedule of its own. Anything that only frees memory as a
+side effect of an unrelated call is not freeing memory.
+
+Two things fell out of the same readings and are fixed with it:
+
+- **Frames on the card are counted against the process where the card's memory *is* the
+  process's memory.** K-293 reported VRAM apart from every tier on the grounds that a
+  discrete card's frames are not in the process — true, but on the Apple Silicon Mac doing
+  the reporting they are, so a cache doing exactly its job showed up inside the
+  unaccounted figure and looked like the fault. The adapter now says which kind of memory
+  it has (`unified_memory`, integrated or software), and the report counts accordingly.
+  The rule generalises: a report that can mislead in the direction of "this is the bug" is
+  worse than one that says less.
+- **The memory section is a debug-build instrument** (owner, 2026-08-06). It is for
+  hunting a fault, not a setting anybody should be asked to interpret; `kDebugMode` gates
+  both the section and the call behind it, so a release build neither draws it nor asks.
+
+**Verified** by `what_the_engine_drops_the_driver_gets_back`, which renders far more
+frames than the cache can hold and then asks the driver what it still has: tens, not one
+per frame. It runs on every platform the suite runs on, and the one that matters is
+**macOS** — where the reclamation went wrong, and where no allocator report exists to see
+it, which is why the gate is a count of live objects rather than a number of bytes.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6391,12 +6391,23 @@ worth a syscall.
   one — it leaves out the compressed pages and the IOSurface and Metal allocations a
   graphics application lives on, which is most of what would be hunted. `phys_footprint`
   is what Activity Monitor prints under *Memory*, and so the number a user reads back.
-- **The graphics driver's own accounting rides beside the tiers**, in use and reserved
-  (`Device::generate_allocator_report`). The first reading in anger made the case: 12 GB
-  held, 11 GB of it unaccounted, with ~405 frames decoded — which cleared every
-  byte-budgeted tier at a glance and left the layer underneath, where the tiers' own
-  numbers cannot reach. Reserved-minus-in-use is the shape of "discarded but not deleted",
-  and it is now a number rather than a theory.
+- **The graphics driver's own accounting rides beside the tiers.** The first reading in
+  anger made the case: 12 GB held, 11 GB of it unaccounted, with ~405 frames decoded —
+  which cleared every byte-budgeted tier at a glance and left the layer underneath, where
+  the tiers' own numbers cannot reach.
+  - It was first written as bytes alone (`Device::generate_allocator_report`), and on the
+    Mac it was written for it read **"not reported by this driver"**: that report is
+    Vulkan and D3D12 only, and Metal does its own allocation. An instrument that works
+    only where there is no problem is not an instrument, so the report now leads with
+    **live object counts** — how many textures and buffers the driver is holding — which
+    every backend keeps. A handful at rest against thousands is exactly the difference
+    between a cache doing its job and frames the engine dropped never being destroyed.
+  - The byte figures stay for the platforms that have them, and that row is **not drawn**
+    where they are zero: a zero nobody can distinguish from a real answer is worse than a
+    missing row (docs/15-DESIGN.md — the honest gap).
+  - The counts are pinned by a test that makes a texture, drops it, and checks the tally
+    follows: compiled without wgpu's `counters` feature they would read zero for ever,
+    which is the failure this row could not afford.
 - **VRAM is reported apart, never subtracted**: on unified memory it is inside the process
   and on a discrete card it is not, so folding it in is wrong on half the machines Lumit
   runs on. **Nothing is counted twice** — a frame in the write-behind queue shares its

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6366,7 +6366,7 @@ The − / + / Fit buttons are gone: the slider's two ends *are* Fit and full zoo
 also says where you are between them, which three buttons never did. `HouseSlider` gained a
 width and a value-hiding option rather than a second slider being written for a toolbar.
 
-**K-295 · DECIDED · Memory is reported, not guessed at: every tier's bytes beside the
+**K-294 · DECIDED · Memory is reported, not guessed at: every tier's bytes beside the
 process's own, and the difference named.** From the owner (2026-08-06), after a second
 report of Lumit holding tens of gigabytes on a Mac — 85 GB, following the 81 GB that
 K-277 bounded the write-behind queue for.
@@ -6421,7 +6421,7 @@ This is a diagnostic, and it is deliberately not a fix: it does not reclaim a by
 the instrument the next report is read with, written down in docs/13 §7.0.1 as a standing
 rule — a tier that holds memory and does not report it is not finished.
 
-**K-294 · DECIDED · What the engine drops, the driver hands back on the next turn: the
+**K-295 · DECIDED · What the engine drops, the driver hands back on the next turn: the
 worker reclaims once a loop.** From the owner's readings on 2026-08-06, which caught the
 fault in the act: 6 GB held with **around 5 500 live graphics buffers**, then 2.9 GB and
 **8 buffers** moments later — because switching back to a settings page happened to make
@@ -6449,7 +6449,7 @@ side effect of an unrelated call is not freeing memory.
 Two things fell out of the same readings and are fixed with it:
 
 - **Frames on the card are counted against the process where the card's memory *is* the
-  process's memory.** K-293 reported VRAM apart from every tier on the grounds that a
+  process's memory.** K-294 reported VRAM apart from every tier on the grounds that a
   discrete card's frames are not in the process — true, but on the Apple Silicon Mac doing
   the reporting they are, so a cache doing exactly its job showed up inside the
   unaccounted figure and looked like the fault. The adapter now says which kind of memory

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6365,3 +6365,41 @@ deliberately painter-drawn glyph, and this is one.
 The − / + / Fit buttons are gone: the slider's two ends *are* Fit and full zoom, and a slider
 also says where you are between them, which three buttons never did. `HouseSlider` gained a
 width and a value-hiding option rather than a second slider being written for a toolbar.
+
+**K-295 · DECIDED · Memory is reported, not guessed at: every tier's bytes beside the
+process's own, and the difference named.** From the owner (2026-08-06), after a second
+report of Lumit holding tens of gigabytes on a Mac — 85 GB, following the 81 GB that
+K-277 bounded the write-behind queue for.
+
+The first question either time was the same, and neither time could it be answered from
+outside the process: **is a cache doing exactly what it was told, or is something holding
+memory nobody is counting?** Every tier already knew its own bytes and every one of them
+is byte-budgeted; what was missing was the total to weigh them against. So Settings ▸
+Performance opens with a **Memory** section: what the operating system says the process
+holds, what the frame cache and the decoded-frame cache hold, how many decoders are open,
+how deep the write-behind queue is, and **what is left over**.
+
+The left-over figure is the point. If the tiers sit at their budgets and the process is a
+hundred times larger, the search is not in this list at all — it is memory held below us
+(graphics allocations the driver has not reclaimed, a decoder's own buffers) and that is a
+different hunt with different tools. Turning a week of guessing into one screenshot is
+worth a syscall.
+
+- `resident_memory_bytes` asks each platform for its nearest equivalent of what the task
+  manager shows: `WorkingSetSize` on Windows, `VmRSS` on Linux, and **`phys_footprint`
+  from `TASK_VM_INFO`** on macOS. Resident size is the obvious macOS answer and the wrong
+  one — it leaves out the compressed pages and the IOSurface and Metal allocations a
+  graphics application lives on, which is most of what would be hunted. `phys_footprint`
+  is what Activity Monitor prints under *Memory*, and so the number a user reads back.
+- **VRAM is reported apart, never subtracted**: on unified memory it is inside the process
+  and on a discrete card it is not, so folding it in is wrong on half the machines Lumit
+  runs on. **Nothing is counted twice** — a frame in the write-behind queue shares its
+  allocation with the frame cache, so the queue reports a count. **What cannot be weighed
+  is counted** — an open decoder's buffers belong to FFmpeg and the driver, so the report
+  says how many are open rather than inventing bytes.
+- A platform that cannot answer returns 0 and the interface says "not known here". The
+  honest gap, per docs/15-DESIGN.md, beats a plausible number.
+
+This is a diagnostic, and it is deliberately not a fix: it does not reclaim a byte. It is
+the instrument the next report is read with, written down in docs/13 §7.0.1 as a standing
+rule — a tier that holds memory and does not report it is not finished.

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -254,6 +254,12 @@ Rules the report keeps, so its arithmetic can be trusted:
 - **VRAM is reported, never subtracted.** On unified memory (every Apple Silicon Mac) the
   card's frames are part of the process; on a discrete card they are not. Folding them in
   either way would be wrong on half the machines Lumit runs on.
+- **The graphics driver reports what it holds, in use and reserved.** A tier's own bytes
+  say what the engine *asked* for; the driver's reserved figure says what it is still
+  holding on the engine's behalf. The gap between the two is memory the engine has
+  released and the driver has not handed back — free, and still ours — which no other
+  number in the report can see. It is the first thing to read when the unaccounted figure
+  is large.
 - **Nothing is counted twice.** A frame waiting in the write-behind queue shares its
   allocation with the frame cache (one `Arc`, both tiers), so the queue reports a *count*
   of frames rather than bytes.

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -235,6 +235,33 @@ lives on `GpuContext` and is shared only with the handles of that same device, s
 measurement sees is one renderer's own submissions. Any future budget counted this way MUST be
 scoped the same: a number two tests can both write is not a measurement.
 
+### 7.0.1 The memory report (K-295)
+
+**Every tier that holds memory MUST report its bytes, and the process MUST report its
+total, in one place the user can read.** Settings ▸ Performance ▸ Memory shows what the
+operating system says Lumit is holding, what each byte-budgeted tier admits to, how many
+media decoders are open, and — the figure the section exists for — **what is left over**.
+
+This is a diagnostic obligation, not a nicety. Lumit has twice been reported holding tens
+of gigabytes (K-277, and again after it), and both times the first question — *is a cache
+doing what it was told, or is something holding memory nobody counts?* — took days to
+answer from outside the process. It is one syscall and five atomics from inside. A report
+whose tiers sit at their budgets while the process is a hundred times larger says the
+search is not in this list, which is the most valuable thing it can say.
+
+Rules the report keeps, so its arithmetic can be trusted:
+
+- **VRAM is reported, never subtracted.** On unified memory (every Apple Silicon Mac) the
+  card's frames are part of the process; on a discrete card they are not. Folding them in
+  either way would be wrong on half the machines Lumit runs on.
+- **Nothing is counted twice.** A frame waiting in the write-behind queue shares its
+  allocation with the frame cache (one `Arc`, both tiers), so the queue reports a *count*
+  of frames rather than bytes.
+- **What cannot be weighed is counted.** What an open media decoder holds is FFmpeg's and
+  the driver's business; the report says how many are open rather than inventing a size.
+- **A platform that cannot answer says zero**, and the interface says "not known here"
+  rather than printing a guess.
+
 ### 7.1 Per-node profiler
 
 A built-in profiler, surfaced in the UI — After Effects' composition profiler done properly:

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -272,6 +272,24 @@ Rules the report keeps, so its arithmetic can be trusted:
 - **A platform that cannot answer says zero**, and the interface says "not known here"
   rather than printing a guess.
 
+### 7.0.2 Reclaiming what has been dropped (K-294)
+
+**An engine that renders without presenting MUST maintain its graphics device on a
+schedule of its own.** Dropping a texture or a buffer only *marks* it destroyed; the
+driver hands the memory back on the device's next maintain. A renderer that draws to a
+window gets those for free from presenting — Lumit renders into caches, on a worker
+thread, and idles, so it gets none.
+
+The worker calls `GpuContext::reclaim` (a non-blocking `Maintain::Poll`) once per turn.
+It is cheap when there is nothing to drain, and it makes reclamation a property of time
+passing rather than of the user happening to open a panel — which is exactly what was
+observed before it: 5 500 live buffers and 6 GB held, then 8 buffers and 2.9 GB the moment
+something else polled.
+
+Anything that frees memory only as a side effect of an unrelated call is not freeing
+memory. The regression gate is `what_the_engine_drops_the_driver_gets_back`, which renders
+many times the cache's capacity and then asks the driver how many objects it still holds.
+
 ### 7.1 Per-node profiler
 
 A built-in profiler, surfaced in the UI — After Effects' composition profiler done properly:

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -235,7 +235,7 @@ lives on `GpuContext` and is shared only with the handles of that same device, s
 measurement sees is one renderer's own submissions. Any future budget counted this way MUST be
 scoped the same: a number two tests can both write is not a measurement.
 
-### 7.0.1 The memory report (K-295)
+### 7.0.1 The memory report (K-294)
 
 **Every tier that holds memory MUST report its bytes, and the process MUST report its
 total, in one place the user can read.** Settings ▸ Performance ▸ Memory shows what the
@@ -272,7 +272,7 @@ Rules the report keeps, so its arithmetic can be trusted:
 - **A platform that cannot answer says zero**, and the interface says "not known here"
   rather than printing a guess.
 
-### 7.0.2 Reclaiming what has been dropped (K-294)
+### 7.0.2 Reclaiming what has been dropped (K-295)
 
 **An engine that renders without presenting MUST maintain its graphics device on a
 schedule of its own.** Dropping a texture or a buffer only *marks* it destroyed; the

--- a/docs/13-PERFORMANCE-RULES.md
+++ b/docs/13-PERFORMANCE-RULES.md
@@ -254,12 +254,16 @@ Rules the report keeps, so its arithmetic can be trusted:
 - **VRAM is reported, never subtracted.** On unified memory (every Apple Silicon Mac) the
   card's frames are part of the process; on a discrete card they are not. Folding them in
   either way would be wrong on half the machines Lumit runs on.
-- **The graphics driver reports what it holds, in use and reserved.** A tier's own bytes
-  say what the engine *asked* for; the driver's reserved figure says what it is still
-  holding on the engine's behalf. The gap between the two is memory the engine has
-  released and the driver has not handed back — free, and still ours — which no other
-  number in the report can see. It is the first thing to read when the unaccounted figure
-  is large.
+- **The graphics driver reports what it holds.** Two ways, because one of them does not
+  exist everywhere. **Live objects** — how many textures and buffers the driver still has
+  — are kept by every backend, Metal included, and a handful at rest against thousands is
+  the difference between a cache doing its job and frames the engine dropped never being
+  destroyed. **Bytes in use and reserved** come from the allocator report, which is Vulkan
+  and D3D12 only: on macOS it answers nothing at all, so that row is not drawn there
+  rather than printing zeroes somebody might reason from. The first draft of this reported
+  only the bytes, and on the one platform the question had been asked on it read *"not
+  reported by this driver"* — a hole is worth knowing about, but a report that only works
+  where there is no problem is not an instrument.
 - **Nothing is counted twice.** A frame waiting in the write-behind queue shares its
   allocation with the frame cache (one `Arc`, both tiers), so the queue reports a *count*
   of frames rather than bytes.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3784,7 +3784,25 @@ Linux. A count is a count on every machine, and it happens to be the sharper
 question anyway: it distinguishes a big cache from a leak, which bytes alone
 cannot.
 
-It does not free a single byte. It is the instrument, not the repair.
+The report is a **debug-build tool**: it is there while a fault is being hunted,
+and a shipped Lumit does not show it. Asking somebody editing a video to
+interpret a live texture count is handing them the engineering instead of the
+tool.
+
+### And the repair it found (K-294)
+
+Here is what the instrument caught. Telling the graphics card "I have finished
+with this picture" does not give the memory back. It marks it finished, and the
+memory returns the next time the program asks the card to tidy up. A program
+that is drawing to a window asks constantly, without meaning to, because showing
+a frame *is* asking. Lumit spends much of its time drawing into its caches
+instead — no window, no asking, and so a pile of finished pictures nobody had
+collected.
+
+That is why the memory came back when the owner switched panels: the switch
+happened to ask. Now the engine asks once per turn of its own loop, whether
+anything is on screen or not, which costs nothing when there is nothing to
+collect and means the pile is never more than a moment old.
 
 ## 10. The app icon and the brand files
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3736,7 +3736,7 @@ Viewer's degradation badge (the "Half" chip that appears when playback has had t
 soften the picture) keeps its empty slot when it is not showing, so it does not
 shove the bar sideways as it comes and goes.
 
-### Where the memory went (K-295)
+### Where the memory went (K-294)
 
 **The problem this solves.** Twice now Lumit has been found holding tens of
 gigabytes of memory on a Mac. Both times the hard part was not fixing it — it
@@ -3789,7 +3789,7 @@ and a shipped Lumit does not show it. Asking somebody editing a video to
 interpret a live texture count is handing them the engineering instead of the
 tool.
 
-### And the repair it found (K-294)
+### And the repair it found (K-295)
 
 Here is what the instrument caught. Telling the graphics card "I have finished
 with this picture" does not give the memory back. It marks it finished, and the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3736,6 +3736,42 @@ Viewer's degradation badge (the "Half" chip that appears when playback has had t
 soften the picture) keeps its empty slot when it is not showing, so it does not
 shove the bar sideways as it comes and goes.
 
+### Where the memory went (K-295)
+
+**The problem this solves.** Twice now Lumit has been found holding tens of
+gigabytes of memory on a Mac. Both times the hard part was not fixing it — it
+was working out *what* was holding it. Lumit keeps several stores of pictures:
+finished frames in memory, finished frames on the graphics card, decoded frames
+from video files, frames queued to be written to disk. Each has a budget and
+each throws things away to stay inside it. So either one of them was misbehaving,
+or something outside all of them was holding memory nobody was counting — and
+from outside the program those two look identical.
+
+**The fix is a subtraction.** Settings ▸ Performance now opens with a Memory
+section: the total the operating system says Lumit is holding, then what each
+store admits to, and then the difference. If the stores add up to half a gigabyte
+and the total says eighty-five, the answer is "none of these" — which sounds like
+nothing but is most of the investigation, because it rules out everything with a
+budget and points at the layers underneath (the graphics driver, the video
+decoders).
+
+Three details that keep the arithmetic honest, all of which were tempting to get
+wrong:
+
+- **Frames on the graphics card are shown but not subtracted.** On an Apple
+  Silicon Mac the graphics memory *is* the system memory, so those frames are
+  already inside the total; on a PC with a separate graphics card they are not.
+  Subtracting them would be right on one machine and wrong on the other, so the
+  report shows the figure and lets you read it.
+- **Nothing is counted twice.** A frame waiting to be written to disk is the
+  same piece of memory as the copy in the frame cache — one picture, two lists —
+  so the queue reports how many frames are waiting, not how many bytes.
+- **What cannot be measured is counted instead.** Nobody outside FFmpeg knows how
+  much memory an open video decoder holds, so the report says how many are open
+  rather than inventing a number.
+
+It does not free a single byte. It is the instrument, not the repair.
+
 ## 10. The app icon and the brand files
 
 The icon you see in the taskbar is not one picture — it is a small bag of

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3770,12 +3770,19 @@ wrong:
   much memory an open video decoder holds, so the report says how many are open
   rather than inventing a number.
 
-One more row asks the **graphics driver** what it is holding, and splits it in
-two: how much it has reserved from the system, and how much of that is actually
-in use. Memory that has been given back by Lumit but not by the driver sits in
-the gap between those two numbers, and nothing else in the window can see it.
-On a Mac, where the graphics memory and the system memory are the same memory,
-that gap is part of the total at the top.
+One more row asks the **graphics driver** how many pictures and buffers it is
+still holding for Lumit. A handful is normal: the frames kept on the card, and
+the working pictures of whatever frame is being made right now. Thousands would
+mean pictures Lumit had finished with were never actually destroyed — which is a
+different fault from any cache being too big, and on a Mac that memory is inside
+the total at the top.
+
+Counting them, rather than measuring them, is deliberate. The first version of
+this row asked the driver for bytes, and on a Mac the answer was "not reported
+by this driver" — that particular question only has an answer on Windows and
+Linux. A count is a count on every machine, and it happens to be the sharper
+question anyway: it distinguishes a big cache from a leak, which bytes alone
+cannot.
 
 It does not free a single byte. It is the instrument, not the repair.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3770,6 +3770,13 @@ wrong:
   much memory an open video decoder holds, so the report says how many are open
   rather than inventing a number.
 
+One more row asks the **graphics driver** what it is holding, and splits it in
+two: how much it has reserved from the system, and how much of that is actually
+in use. Memory that has been given back by Lumit but not by the driver sits in
+the gap between those two numbers, and nothing else in the window can see it.
+On a Mac, where the graphics memory and the system memory are the same memory,
+that gap is part of the total at the top.
+
 It does not free a single byte. It is the instrument, not the repair.
 
 ## 10. The app icon and the brand files

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -877,7 +877,7 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         ),
       ]),
       ..._diskCache(t, ui),
-      // Where the memory has gone (K-295). Last on the page, under the tiers
+      // Where the memory has gone (K-294). Last on the page, under the tiers
       // it weighs: each section above reports one store, and this one reports
       // the whole process and what none of them accounts for. Read downwards it
       // is the summing-up, and it leaves every control above where the hand

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -752,8 +752,63 @@ class _SettingsWindowState extends State<_SettingsWindow> {
     final stats = cacheStats();
     final vram = vramCacheStats();
     final tier = playbackTier();
+    final memory = memoryReport();
 
     return [
+      // Where the memory has gone (K-295). First on the page, above the tiers
+      // it weighs, because "Lumit is holding 85 GB" is the question this page
+      // is opened to answer and the tiers below are each only a part of it.
+      settingsSection(t, 'Memory', [
+        settingsRow(
+          t,
+          'This process',
+          'What the system says Lumit is holding, all in — the number '
+              'Activity Monitor and Task Manager show.',
+          Text(
+            memory.processBytes == BigInt.zero
+                ? 'not known here'
+                : _bytes(memory.processBytes),
+            key: const ValueKey('settings-memory-process'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Not held by any cache',
+          'The process, less the finished frames and decoded frames below. '
+              'A large number here is not a cache to shrink: it is memory '
+              'nothing in this window is counting, and it is worth reporting.',
+          Text(
+            memory.processBytes == BigInt.zero
+                ? '—'
+                : _bytes(memory.unaccountedBytes),
+            key: const ValueKey('settings-memory-unaccounted'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Open media decoders',
+          'One per footage item in play. Each holds buffers of its own that '
+              'no budget here covers.',
+          Text(
+            '${memory.openDecoders}',
+            key: const ValueKey('settings-memory-decoders'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Frames waiting to be written',
+          'The write-behind queue to the disk cache, which is bounded at '
+              'eight frames.',
+          Text(
+            '${memory.parkQueueFrames}',
+            key: const ValueKey('settings-memory-parks'),
+            style: t.small,
+          ),
+        ),
+      ]),
       settingsSection(t, 'Playback', [
         settingsRow(
           t,
@@ -1119,6 +1174,14 @@ class _SettingsWindowState extends State<_SettingsWindow> {
   /// A round figure for a sentence: "32 GB", or megabytes when it is small.
   static String _gib(double mib) =>
       mib >= 1024 ? '${(mib / 1024).round()} GB' : '${mib.round()} MB';
+
+  /// Bytes as a person reads them — MB up to a gigabyte, GB above, one
+  /// decimal so 85.4 GB does not print as 85.
+  static String _bytes(BigInt bytes) {
+    final b = bytes.toDouble();
+    if (b >= 1 << 30) return '${(b / (1 << 30)).toStringAsFixed(1)} GB';
+    return '${(b / (1 << 20)).toStringAsFixed(0)} MB';
+  }
 
   static String _mib(int bytes) => (bytes / (1 << 20)).toStringAsFixed(0);
 

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -755,60 +755,6 @@ class _SettingsWindowState extends State<_SettingsWindow> {
     final memory = memoryReport();
 
     return [
-      // Where the memory has gone (K-295). First on the page, above the tiers
-      // it weighs, because "Lumit is holding 85 GB" is the question this page
-      // is opened to answer and the tiers below are each only a part of it.
-      settingsSection(t, 'Memory', [
-        settingsRow(
-          t,
-          'This process',
-          'What the system says Lumit is holding, all in — the number '
-              'Activity Monitor and Task Manager show.',
-          Text(
-            memory.processBytes == BigInt.zero
-                ? 'not known here'
-                : _bytes(memory.processBytes),
-            key: const ValueKey('settings-memory-process'),
-            style: t.small,
-          ),
-        ),
-        settingsRow(
-          t,
-          'Not held by any cache',
-          'The process, less the finished frames and decoded frames below. '
-              'A large number here is not a cache to shrink: it is memory '
-              'nothing in this window is counting, and it is worth reporting.',
-          Text(
-            memory.processBytes == BigInt.zero
-                ? '—'
-                : _bytes(memory.unaccountedBytes),
-            key: const ValueKey('settings-memory-unaccounted'),
-            style: t.small,
-          ),
-        ),
-        settingsRow(
-          t,
-          'Open media decoders',
-          'One per footage item in play. Each holds buffers of its own that '
-              'no budget here covers.',
-          Text(
-            '${memory.openDecoders}',
-            key: const ValueKey('settings-memory-decoders'),
-            style: t.small,
-          ),
-        ),
-        settingsRow(
-          t,
-          'Frames waiting to be written',
-          'The write-behind queue to the disk cache, which is bounded at '
-              'eight frames.',
-          Text(
-            '${memory.parkQueueFrames}',
-            key: const ValueKey('settings-memory-parks'),
-            style: t.small,
-          ),
-        ),
-      ]),
       settingsSection(t, 'Playback', [
         settingsRow(
           t,
@@ -928,6 +874,78 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         ),
       ]),
       ..._diskCache(t, ui),
+      // Where the memory has gone (K-295). Last on the page, under the tiers
+      // it weighs: each section above reports one store, and this one reports
+      // the whole process and what none of them accounts for. Read downwards it
+      // is the summing-up, and it leaves every control above where the hand
+      // already knows to find it.
+      settingsSection(t, 'Memory', [
+        settingsRow(
+          t,
+          'This process',
+          'What the system says Lumit is holding, all in — the number '
+              'Activity Monitor and Task Manager show.',
+          Text(
+            memory.processBytes == BigInt.zero
+                ? 'not known here'
+                : _bytes(memory.processBytes),
+            key: const ValueKey('settings-memory-process'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Not held by any cache',
+          'The process, less the finished frames and decoded frames below. '
+              'A large number here is not a cache to shrink: it is memory '
+              'nothing in this window is counting, and it is worth reporting.',
+          Text(
+            memory.processBytes == BigInt.zero
+                ? '—'
+                : _bytes(memory.unaccountedBytes),
+            key: const ValueKey('settings-memory-unaccounted'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Held by the graphics driver',
+          'What the driver has reserved for Lumit, and how much of it is '
+              'actually in use. A large gap is memory the engine has released '
+              'and the driver has not handed back — on a Mac that is inside '
+              'the total above.',
+          Text(
+            memory.gpuReservedBytes == BigInt.zero
+                ? 'not reported by this driver'
+                : '${_bytes(memory.gpuReservedBytes)} reserved, '
+                    '${_bytes(memory.gpuAllocatedBytes)} in use',
+            key: const ValueKey('settings-memory-gpu'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Open media decoders',
+          'One per footage item in play. Each holds buffers of its own that '
+              'no budget here covers.',
+          Text(
+            '${memory.openDecoders}',
+            key: const ValueKey('settings-memory-decoders'),
+            style: t.small,
+          ),
+        ),
+        settingsRow(
+          t,
+          'Frames waiting to be written',
+          'The write-behind queue to the disk cache, which is bounded at '
+              'eight frames.',
+          Text(
+            '${memory.parkQueueFrames}',
+            key: const ValueKey('settings-memory-parks'),
+            style: t.small,
+          ),
+        ),
+      ]),
     ];
   }
 

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -910,19 +910,33 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         settingsRow(
           t,
           'Held by the graphics driver',
-          'What the driver has reserved for Lumit, and how much of it is '
-              'actually in use. A large gap is memory the engine has released '
-              'and the driver has not handed back — on a Mac that is inside '
-              'the total above.',
+          'Pictures and buffers the driver still has for Lumit. A handful is '
+              'normal — the frames on the card, the ones being made. Thousands '
+              'means pictures the engine finished with were never destroyed, '
+              'and on a Mac that memory is inside the total above.',
           Text(
-            memory.gpuReservedBytes == BigInt.zero
-                ? 'not reported by this driver'
-                : '${_bytes(memory.gpuReservedBytes)} reserved, '
-                    '${_bytes(memory.gpuAllocatedBytes)} in use',
+            '${memory.gpuTextures} pictures, ${memory.gpuBuffers} buffers',
             key: const ValueKey('settings-memory-gpu'),
             style: t.small,
           ),
         ),
+        // The byte figures are Vulkan and D3D12 only, so the row is not drawn
+        // at all on a Mac rather than printing two zeroes and inviting the
+        // reader to draw a conclusion from them.
+        if (memory.gpuReservedBytes != BigInt.zero)
+          settingsRow(
+            t,
+            'Graphics memory reserved',
+            'What the driver has taken from the system for those, and how much '
+                'of it is in use. The gap is memory Lumit has released and the '
+                'driver has not handed back.',
+            Text(
+              '${_bytes(memory.gpuReservedBytes)} reserved, '
+              '${_bytes(memory.gpuAllocatedBytes)} in use',
+              key: const ValueKey('settings-memory-gpu-bytes'),
+              style: t.small,
+            ),
+          ),
         settingsRow(
           t,
           'Open media decoders',

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -27,6 +27,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:lumit_flutter/main.dart';
@@ -752,7 +753,9 @@ class _SettingsWindowState extends State<_SettingsWindow> {
     final stats = cacheStats();
     final vram = vramCacheStats();
     final tier = playbackTier();
-    final memory = memoryReport();
+    // Only read when it is going to be drawn: the report is a debug-build
+    // instrument, and a release build should not be making the call at all.
+    final memory = kDebugMode ? memoryReport() : null;
 
     return [
       settingsSection(t, 'Playback', [
@@ -879,7 +882,13 @@ class _SettingsWindowState extends State<_SettingsWindow> {
       // the whole process and what none of them accounts for. Read downwards it
       // is the summing-up, and it leaves every control above where the hand
       // already knows to find it.
-      settingsSection(t, 'Memory', [
+      //
+      // **Debug builds only** (owner, 2026-08-06). It is an instrument for
+      // hunting a fault, not a setting: a shipped editor asking its user to
+      // interpret live texture counts has handed them the engineering rather
+      // than the tool. `kDebugMode` is false in both profile and release
+      // builds, so what ships is the page without it.
+      if (memory != null) settingsSection(t, 'Memory', [
         settingsRow(
           t,
           'This process',
@@ -896,9 +905,10 @@ class _SettingsWindowState extends State<_SettingsWindow> {
         settingsRow(
           t,
           'Not held by any cache',
-          'The process, less the finished frames and decoded frames below. '
-              'A large number here is not a cache to shrink: it is memory '
-              'nothing in this window is counting, and it is worth reporting.',
+          'The process, less every store above that is inside it — which on '
+              'this machine includes the frames on the card. A large number '
+              'here is not a cache to shrink: it is memory nothing in this '
+              'window is counting, and it is worth reporting.',
           Text(
             memory.processBytes == BigInt.zero
                 ? '—'

--- a/flutter_ui/lib/src/rust/api/cache.dart
+++ b/flutter_ui/lib/src/rust/api/cache.dart
@@ -222,11 +222,18 @@ class BridgeMemoryReport {
   /// Finished frames held in ordinary memory.
   final BigInt frameCacheBytes;
 
-  /// Frames held on the graphics card. On a machine with unified memory (every
-  /// Apple Silicon Mac) these are part of `process_bytes` too; on a discrete
-  /// card they are not, which is why they are reported apart rather than
-  /// summed for you.
+  /// Frames held on the graphics card.
   final BigInt vramCacheBytes;
+
+  /// Whether the card's memory *is* this process's memory — true on every
+  /// Apple Silicon Mac and on any integrated adapter.
+  ///
+  /// When it is, `vram_cache_bytes` is counted against `process_bytes` like
+  /// any other tier; when it is not, the card's frames are somewhere else
+  /// entirely and counting them would understate what is unaccounted for.
+  /// Getting this backwards is how a cache doing exactly its job read as
+  /// gigabytes nobody could explain.
+  final bool unifiedMemory;
 
   /// Decoded source frames held for the compositor.
   final BigInt decodeCacheBytes;
@@ -282,6 +289,7 @@ class BridgeMemoryReport {
     required this.processBytes,
     required this.frameCacheBytes,
     required this.vramCacheBytes,
+    required this.unifiedMemory,
     required this.decodeCacheBytes,
     required this.openDecoders,
     required this.parkQueueFrames,
@@ -297,6 +305,7 @@ class BridgeMemoryReport {
       processBytes.hashCode ^
       frameCacheBytes.hashCode ^
       vramCacheBytes.hashCode ^
+      unifiedMemory.hashCode ^
       decodeCacheBytes.hashCode ^
       openDecoders.hashCode ^
       parkQueueFrames.hashCode ^
@@ -314,6 +323,7 @@ class BridgeMemoryReport {
           processBytes == other.processBytes &&
           frameCacheBytes == other.frameCacheBytes &&
           vramCacheBytes == other.vramCacheBytes &&
+          unifiedMemory == other.unifiedMemory &&
           decodeCacheBytes == other.decodeCacheBytes &&
           openDecoders == other.openDecoders &&
           parkQueueFrames == other.parkQueueFrames &&

--- a/flutter_ui/lib/src/rust/api/cache.dart
+++ b/flutter_ui/lib/src/rust/api/cache.dart
@@ -253,9 +253,25 @@ class BridgeMemoryReport {
   ///
   /// The gap between this and `gpu_allocated_bytes` is memory that has been
   /// released by the engine and not handed back by the driver: free, and
-  /// still ours. That is the shape of "discarded but not deleted", and it is
-  /// invisible to every other number in this report.
+  /// still ours.
+  ///
+  /// **Both byte figures are 0 on macOS**, where Metal keeps no such
+  /// accounting and wgpu therefore reports none — which is the platform the
+  /// question was asked on. Read the two counts below there.
   final BigInt gpuReservedBytes;
+
+  /// How many textures the driver is holding for the render device right now.
+  ///
+  /// **This is the figure that works everywhere, Metal included.** The engine
+  /// holds a handful at rest — the frames in the card's cache, the pooled
+  /// upload textures, the shared present targets, and each frame's
+  /// intermediates while it is being made. Thousands of them means frames the
+  /// engine dropped were never destroyed, which is a different fault from any
+  /// cache being too large and is not visible in any other number here.
+  final BigInt gpuTextures;
+
+  /// How many buffers the driver is holding, for the same reason.
+  final BigInt gpuBuffers;
 
   /// `process_bytes` less everything above that lives in ordinary memory.
   /// Saturating at zero, since the platform's number and ours are read a
@@ -271,6 +287,8 @@ class BridgeMemoryReport {
     required this.parkQueueFrames,
     required this.gpuAllocatedBytes,
     required this.gpuReservedBytes,
+    required this.gpuTextures,
+    required this.gpuBuffers,
     required this.unaccountedBytes,
   });
 
@@ -284,6 +302,8 @@ class BridgeMemoryReport {
       parkQueueFrames.hashCode ^
       gpuAllocatedBytes.hashCode ^
       gpuReservedBytes.hashCode ^
+      gpuTextures.hashCode ^
+      gpuBuffers.hashCode ^
       unaccountedBytes.hashCode;
 
   @override
@@ -299,6 +319,8 @@ class BridgeMemoryReport {
           parkQueueFrames == other.parkQueueFrames &&
           gpuAllocatedBytes == other.gpuAllocatedBytes &&
           gpuReservedBytes == other.gpuReservedBytes &&
+          gpuTextures == other.gpuTextures &&
+          gpuBuffers == other.gpuBuffers &&
           unaccountedBytes == other.unaccountedBytes;
 }
 

--- a/flutter_ui/lib/src/rust/api/cache.dart
+++ b/flutter_ui/lib/src/rust/api/cache.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `read`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 /// The cache's live numbers.
 ///
@@ -16,6 +16,10 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 /// even so: the lock it takes is the one a render holds.
 BridgeCacheStats cacheStats() =>
     BridgeLib.instance.api.crateApiCacheCacheStats();
+
+/// Read the memory report. Cheap: five atomics, one lock and one syscall.
+BridgeMemoryReport memoryReport() =>
+    BridgeLib.instance.api.crateApiCacheMemoryReport();
 
 /// Resize the cache, returning what it holds afterwards.
 ///
@@ -197,6 +201,85 @@ class BridgeDiskCacheStats {
           budgetBytes == other.budgetBytes &&
           entries == other.entries &&
           root == other.root;
+}
+
+/// Where this process's memory has gone: what each tier admits to holding, and
+/// what the operating system says the process holds (K-295).
+///
+/// **The field that matters is [`Self::unaccounted_bytes`].** Every tier here
+/// is byte-budgeted and evicts to stay inside its budget, so a report where the
+/// tiers add up to their budgets and the process is a hundred times larger is
+/// not a cache problem at all — it is memory nobody in this list is counting,
+/// which is a different search entirely. Lumit has twice been reported holding
+/// tens of gigabytes (K-277 and after it), and both times that question took
+/// days to answer from the outside. It is one call from the inside.
+class BridgeMemoryReport {
+  /// What the operating system says this process holds — Activity Monitor's
+  /// **Memory** on macOS, the working set on Windows, `VmRSS` on Linux. 0
+  /// where the platform will not say ([`crate::api::system::resident_memory_bytes`]).
+  final BigInt processBytes;
+
+  /// Finished frames held in ordinary memory.
+  final BigInt frameCacheBytes;
+
+  /// Frames held on the graphics card. On a machine with unified memory (every
+  /// Apple Silicon Mac) these are part of `process_bytes` too; on a discrete
+  /// card they are not, which is why they are reported apart rather than
+  /// summed for you.
+  final BigInt vramCacheBytes;
+
+  /// Decoded source frames held for the compositor.
+  final BigInt decodeCacheBytes;
+
+  /// How many media decoders are open. Counted, not weighed: what a decoder
+  /// holds is FFmpeg's and the driver's business, and a made-up number of
+  /// bytes would be worse than an honest count.
+  final BigInt openDecoders;
+
+  /// How many frames are waiting to be written to disk — the write-behind
+  /// queue K-277 bounded at eight. A count rather than bytes on purpose: each
+  /// waiting frame shares its allocation with the frame cache above (one
+  /// `Arc`, both tiers), so charging it twice would make the report lie in
+  /// the one direction that matters.
+  final BigInt parkQueueFrames;
+
+  /// `process_bytes` less everything above that lives in ordinary memory.
+  /// Saturating at zero, since the platform's number and ours are read a
+  /// moment apart and a small negative is meaningless.
+  final BigInt unaccountedBytes;
+
+  const BridgeMemoryReport({
+    required this.processBytes,
+    required this.frameCacheBytes,
+    required this.vramCacheBytes,
+    required this.decodeCacheBytes,
+    required this.openDecoders,
+    required this.parkQueueFrames,
+    required this.unaccountedBytes,
+  });
+
+  @override
+  int get hashCode =>
+      processBytes.hashCode ^
+      frameCacheBytes.hashCode ^
+      vramCacheBytes.hashCode ^
+      decodeCacheBytes.hashCode ^
+      openDecoders.hashCode ^
+      parkQueueFrames.hashCode ^
+      unaccountedBytes.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BridgeMemoryReport &&
+          runtimeType == other.runtimeType &&
+          processBytes == other.processBytes &&
+          frameCacheBytes == other.frameCacheBytes &&
+          vramCacheBytes == other.vramCacheBytes &&
+          decodeCacheBytes == other.decodeCacheBytes &&
+          openDecoders == other.openDecoders &&
+          parkQueueFrames == other.parkQueueFrames &&
+          unaccountedBytes == other.unaccountedBytes;
 }
 
 /// A cache location as a pair: which of the three, and the folder that goes with

--- a/flutter_ui/lib/src/rust/api/cache.dart
+++ b/flutter_ui/lib/src/rust/api/cache.dart
@@ -204,7 +204,7 @@ class BridgeDiskCacheStats {
 }
 
 /// Where this process's memory has gone: what each tier admits to holding, and
-/// what the operating system says the process holds (K-295).
+/// what the operating system says the process holds (K-294).
 ///
 /// **The field that matters is [`Self::unaccounted_bytes`].** Every tier here
 /// is byte-budgeted and evicts to stay inside its budget, so a report where the

--- a/flutter_ui/lib/src/rust/api/cache.dart
+++ b/flutter_ui/lib/src/rust/api/cache.dart
@@ -243,6 +243,20 @@ class BridgeMemoryReport {
   /// the one direction that matters.
   final BigInt parkQueueFrames;
 
+  /// What the graphics driver holds for the render device, in use. On
+  /// unified memory (every Apple Silicon Mac) this is inside
+  /// `process_bytes`; on a discrete card it is not.
+  final BigInt gpuAllocatedBytes;
+
+  /// What the graphics driver has **reserved** — the blocks those
+  /// allocations were carved from, including the free room inside them.
+  ///
+  /// The gap between this and `gpu_allocated_bytes` is memory that has been
+  /// released by the engine and not handed back by the driver: free, and
+  /// still ours. That is the shape of "discarded but not deleted", and it is
+  /// invisible to every other number in this report.
+  final BigInt gpuReservedBytes;
+
   /// `process_bytes` less everything above that lives in ordinary memory.
   /// Saturating at zero, since the platform's number and ours are read a
   /// moment apart and a small negative is meaningless.
@@ -255,6 +269,8 @@ class BridgeMemoryReport {
     required this.decodeCacheBytes,
     required this.openDecoders,
     required this.parkQueueFrames,
+    required this.gpuAllocatedBytes,
+    required this.gpuReservedBytes,
     required this.unaccountedBytes,
   });
 
@@ -266,6 +282,8 @@ class BridgeMemoryReport {
       decodeCacheBytes.hashCode ^
       openDecoders.hashCode ^
       parkQueueFrames.hashCode ^
+      gpuAllocatedBytes.hashCode ^
+      gpuReservedBytes.hashCode ^
       unaccountedBytes.hashCode;
 
   @override
@@ -279,6 +297,8 @@ class BridgeMemoryReport {
           decodeCacheBytes == other.decodeCacheBytes &&
           openDecoders == other.openDecoders &&
           parkQueueFrames == other.parkQueueFrames &&
+          gpuAllocatedBytes == other.gpuAllocatedBytes &&
+          gpuReservedBytes == other.gpuReservedBytes &&
           unaccountedBytes == other.unaccountedBytes;
 }
 

--- a/flutter_ui/lib/src/rust/api/system.dart
+++ b/flutter_ui/lib/src/rust/api/system.dart
@@ -6,6 +6,27 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+/// What this process is actually holding, in bytes, or 0 where it cannot be
+/// asked — the number the operating system's own monitor shows.
+///
+/// **Why this exists.** Lumit has now twice been reported holding tens of
+/// gigabytes (K-277, and again after it), and each time the first question took
+/// days to answer: is a cache doing exactly what it was told, or is something
+/// holding memory nobody is counting? Every tier already reports its own bytes;
+/// what was missing was the total to weigh them against. The difference between
+/// the two is the whole diagnosis, so it is worth one syscall.
+///
+/// Each platform's nearest equivalent of "what the task manager says":
+/// `PROCESS_MEMORY_COUNTERS.WorkingSetSize` on Windows, `VmRSS` from
+/// `/proc/self/status` on Linux, and `phys_footprint` from `TASK_VM_INFO` on
+/// macOS — which is the number Activity Monitor prints under **Memory**, and so
+/// the one a user reads back to us. Resident set size would have been the
+/// obvious macOS choice and is the wrong one: it omits the compressed pages and
+/// the IOSurface and Metal allocations a graphics application lives on, which
+/// is most of what we would be hunting.
+BigInt residentMemoryBytes() =>
+    BridgeLib.instance.api.crateApiSystemResidentMemoryBytes();
+
 /// The machine's installed memory in bytes, or 0 where it cannot be asked.
 BigInt systemMemoryBytes() =>
     BridgeLib.instance.api.crateApiSystemSystemMemoryBytes();

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -7732,20 +7732,21 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 11)
-      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
+    if (arr.length != 12)
+      throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
     return BridgeMemoryReport(
       processBytes: dco_decode_u_64(arr[0]),
       frameCacheBytes: dco_decode_u_64(arr[1]),
       vramCacheBytes: dco_decode_u_64(arr[2]),
-      decodeCacheBytes: dco_decode_u_64(arr[3]),
-      openDecoders: dco_decode_u_64(arr[4]),
-      parkQueueFrames: dco_decode_u_64(arr[5]),
-      gpuAllocatedBytes: dco_decode_u_64(arr[6]),
-      gpuReservedBytes: dco_decode_u_64(arr[7]),
-      gpuTextures: dco_decode_u_64(arr[8]),
-      gpuBuffers: dco_decode_u_64(arr[9]),
-      unaccountedBytes: dco_decode_u_64(arr[10]),
+      unifiedMemory: dco_decode_bool(arr[3]),
+      decodeCacheBytes: dco_decode_u_64(arr[4]),
+      openDecoders: dco_decode_u_64(arr[5]),
+      parkQueueFrames: dco_decode_u_64(arr[6]),
+      gpuAllocatedBytes: dco_decode_u_64(arr[7]),
+      gpuReservedBytes: dco_decode_u_64(arr[8]),
+      gpuTextures: dco_decode_u_64(arr[9]),
+      gpuBuffers: dco_decode_u_64(arr[10]),
+      unaccountedBytes: dco_decode_u_64(arr[11]),
     );
   }
 
@@ -9738,6 +9739,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_processBytes = sse_decode_u_64(deserializer);
     var var_frameCacheBytes = sse_decode_u_64(deserializer);
     var var_vramCacheBytes = sse_decode_u_64(deserializer);
+    var var_unifiedMemory = sse_decode_bool(deserializer);
     var var_decodeCacheBytes = sse_decode_u_64(deserializer);
     var var_openDecoders = sse_decode_u_64(deserializer);
     var var_parkQueueFrames = sse_decode_u_64(deserializer);
@@ -9750,6 +9752,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         processBytes: var_processBytes,
         frameCacheBytes: var_frameCacheBytes,
         vramCacheBytes: var_vramCacheBytes,
+        unifiedMemory: var_unifiedMemory,
         decodeCacheBytes: var_decodeCacheBytes,
         openDecoders: var_openDecoders,
         parkQueueFrames: var_parkQueueFrames,
@@ -11920,6 +11923,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_u_64(self.processBytes, serializer);
     sse_encode_u_64(self.frameCacheBytes, serializer);
     sse_encode_u_64(self.vramCacheBytes, serializer);
+    sse_encode_bool(self.unifiedMemory, serializer);
     sse_encode_u_64(self.decodeCacheBytes, serializer);
     sse_encode_u_64(self.openDecoders, serializer);
     sse_encode_u_64(self.parkQueueFrames, serializer);

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -7732,8 +7732,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7)
-      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 9)
+      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
     return BridgeMemoryReport(
       processBytes: dco_decode_u_64(arr[0]),
       frameCacheBytes: dco_decode_u_64(arr[1]),
@@ -7741,7 +7741,9 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       decodeCacheBytes: dco_decode_u_64(arr[3]),
       openDecoders: dco_decode_u_64(arr[4]),
       parkQueueFrames: dco_decode_u_64(arr[5]),
-      unaccountedBytes: dco_decode_u_64(arr[6]),
+      gpuAllocatedBytes: dco_decode_u_64(arr[6]),
+      gpuReservedBytes: dco_decode_u_64(arr[7]),
+      unaccountedBytes: dco_decode_u_64(arr[8]),
     );
   }
 
@@ -9737,6 +9739,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_decodeCacheBytes = sse_decode_u_64(deserializer);
     var var_openDecoders = sse_decode_u_64(deserializer);
     var var_parkQueueFrames = sse_decode_u_64(deserializer);
+    var var_gpuAllocatedBytes = sse_decode_u_64(deserializer);
+    var var_gpuReservedBytes = sse_decode_u_64(deserializer);
     var var_unaccountedBytes = sse_decode_u_64(deserializer);
     return BridgeMemoryReport(
         processBytes: var_processBytes,
@@ -9745,6 +9749,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         decodeCacheBytes: var_decodeCacheBytes,
         openDecoders: var_openDecoders,
         parkQueueFrames: var_parkQueueFrames,
+        gpuAllocatedBytes: var_gpuAllocatedBytes,
+        gpuReservedBytes: var_gpuReservedBytes,
         unaccountedBytes: var_unaccountedBytes);
   }
 
@@ -11911,6 +11917,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_u_64(self.decodeCacheBytes, serializer);
     sse_encode_u_64(self.openDecoders, serializer);
     sse_encode_u_64(self.parkQueueFrames, serializer);
+    sse_encode_u_64(self.gpuAllocatedBytes, serializer);
+    sse_encode_u_64(self.gpuReservedBytes, serializer);
     sse_encode_u_64(self.unaccountedBytes, serializer);
   }
 

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -7732,8 +7732,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 11)
+      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return BridgeMemoryReport(
       processBytes: dco_decode_u_64(arr[0]),
       frameCacheBytes: dco_decode_u_64(arr[1]),
@@ -7743,7 +7743,9 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       parkQueueFrames: dco_decode_u_64(arr[5]),
       gpuAllocatedBytes: dco_decode_u_64(arr[6]),
       gpuReservedBytes: dco_decode_u_64(arr[7]),
-      unaccountedBytes: dco_decode_u_64(arr[8]),
+      gpuTextures: dco_decode_u_64(arr[8]),
+      gpuBuffers: dco_decode_u_64(arr[9]),
+      unaccountedBytes: dco_decode_u_64(arr[10]),
     );
   }
 
@@ -9741,6 +9743,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_parkQueueFrames = sse_decode_u_64(deserializer);
     var var_gpuAllocatedBytes = sse_decode_u_64(deserializer);
     var var_gpuReservedBytes = sse_decode_u_64(deserializer);
+    var var_gpuTextures = sse_decode_u_64(deserializer);
+    var var_gpuBuffers = sse_decode_u_64(deserializer);
     var var_unaccountedBytes = sse_decode_u_64(deserializer);
     return BridgeMemoryReport(
         processBytes: var_processBytes,
@@ -9751,6 +9755,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         parkQueueFrames: var_parkQueueFrames,
         gpuAllocatedBytes: var_gpuAllocatedBytes,
         gpuReservedBytes: var_gpuReservedBytes,
+        gpuTextures: var_gpuTextures,
+        gpuBuffers: var_gpuBuffers,
         unaccountedBytes: var_unaccountedBytes);
   }
 
@@ -11919,6 +11925,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_u_64(self.parkQueueFrames, serializer);
     sse_encode_u_64(self.gpuAllocatedBytes, serializer);
     sse_encode_u_64(self.gpuReservedBytes, serializer);
+    sse_encode_u_64(self.gpuTextures, serializer);
+    sse_encode_u_64(self.gpuBuffers, serializer);
     sse_encode_u_64(self.unaccountedBytes, serializer);
   }
 

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -87,7 +87,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -1647207360;
+  int get rustContentHash => -1097566226;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -714,6 +714,8 @@ abstract class BridgeLibApi extends BaseApi {
 
   List<BridgePresetInfo> crateApiEffectListPresets();
 
+  BridgeMemoryReport crateApiCacheMemoryReport();
+
   BridgePlaybackTier crateApiShellPlaybackTier();
 
   String? crateApiEffectPresetsDirPath();
@@ -779,6 +781,8 @@ abstract class BridgeLibApi extends BaseApi {
   void crateApiProjectProjectReferenceUndo({required ProjectReference that});
 
   BridgePlaybackTier crateApiShellResetRealtime();
+
+  BigInt crateApiSystemResidentMemoryBytes();
 
   void crateApiSystemRestoreFrozenCursor();
 
@@ -5796,11 +5800,33 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
-  BridgePlaybackTier crateApiShellPlaybackTier() {
+  BridgeMemoryReport crateApiCacheMemoryReport() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 181)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bridge_memory_report,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiCacheMemoryReportConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCacheMemoryReportConstMeta => const TaskConstMeta(
+        debugName: "memory_report",
+        argNames: [],
+      );
+
+  @override
+  BridgePlaybackTier crateApiShellPlaybackTier() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -5822,7 +5848,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 182)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -5847,7 +5873,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 183)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -5873,7 +5899,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 184)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 185)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_32,
@@ -5904,7 +5930,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
         sse_encode_u_32(keep, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 185)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -5930,7 +5956,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 186)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 187)!;
       },
       codec: SseCodec(
         decodeSuccessData:
@@ -5957,7 +5983,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 187)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 188)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_item_reference,
@@ -5983,7 +6009,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 188)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_history,
@@ -6010,7 +6036,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 189)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_footage_reference,
@@ -6036,7 +6062,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 190)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -6066,7 +6092,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(name, serializer);
         sse_encode_opt_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 191)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 192)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_composition_reference,
@@ -6092,7 +6118,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 192)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -6118,7 +6144,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 193)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -6143,7 +6169,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 194)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6170,7 +6196,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(projectPath, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 195)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 196)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_recovery,
@@ -6198,7 +6224,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_String(path, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 196, port: port_);
+            funcId: 197, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -6225,7 +6251,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_u_32(samples, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 197)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6253,7 +6279,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_box_autoadd_bridge_project_cache_location(
             location, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 198)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6280,7 +6306,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_opt_String(uiState, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 199)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6308,7 +6334,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
         sse_encode_StreamSink_worker_response_Sse(onReponse, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 200)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6334,7 +6360,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 201)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -6359,7 +6385,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_project_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 202)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6383,7 +6409,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 203)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_playback_tier,
@@ -6401,11 +6427,34 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
+  BigInt crateApiSystemResidentMemoryBytes() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 205)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_u_64,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiSystemResidentMemoryBytesConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiSystemResidentMemoryBytesConstMeta =>
+      const TaskConstMeta(
+        debugName: "resident_memory_bytes",
+        argNames: [],
+      );
+
+  @override
   void crateApiSystemRestoreFrozenCursor() {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 204)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 206)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6431,7 +6480,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_bridge_scalar(scalar, serializer);
         sse_encode_box_autoadd_bridge_rational(time, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 205)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 207)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_64,
@@ -6454,7 +6503,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 206)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 208)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_cache_stats,
@@ -6479,7 +6528,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 207)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 209)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6505,7 +6554,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bridge_cache_location(location, serializer);
         sse_encode_String(folder, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 208)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 210)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_disk_cache_stats,
@@ -6529,7 +6578,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 209)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 211)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6554,7 +6603,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_u_64(bytes, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 210)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 212)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -6579,7 +6628,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 211)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 213)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_solid_def,
@@ -6606,7 +6655,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_solid_reference(that, serializer);
         sse_encode_box_autoadd_bridge_solid_def(definition, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 212)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 214)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6630,7 +6679,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 213)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 215)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6653,7 +6702,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 214)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 216)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -6675,7 +6724,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 215)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 217)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_u_64,
@@ -6698,7 +6747,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 216)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 218)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_viewer_transport,
@@ -6721,7 +6770,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 217)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 219)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bridge_vram_cache_stats,
@@ -7676,6 +7725,23 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       fpsNum: dco_decode_u_32(arr[2]),
       fpsDen: dco_decode_u_32(arr[3]),
       duration: dco_decode_bridge_rational(arr[4]),
+    );
+  }
+
+  @protected
+  BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return BridgeMemoryReport(
+      processBytes: dco_decode_u_64(arr[0]),
+      frameCacheBytes: dco_decode_u_64(arr[1]),
+      vramCacheBytes: dco_decode_u_64(arr[2]),
+      decodeCacheBytes: dco_decode_u_64(arr[3]),
+      openDecoders: dco_decode_u_64(arr[4]),
+      parkQueueFrames: dco_decode_u_64(arr[5]),
+      unaccountedBytes: dco_decode_u_64(arr[6]),
     );
   }
 
@@ -9659,6 +9725,27 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         fpsNum: var_fpsNum,
         fpsDen: var_fpsDen,
         duration: var_duration);
+  }
+
+  @protected
+  BridgeMemoryReport sse_decode_bridge_memory_report(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_processBytes = sse_decode_u_64(deserializer);
+    var var_frameCacheBytes = sse_decode_u_64(deserializer);
+    var var_vramCacheBytes = sse_decode_u_64(deserializer);
+    var var_decodeCacheBytes = sse_decode_u_64(deserializer);
+    var var_openDecoders = sse_decode_u_64(deserializer);
+    var var_parkQueueFrames = sse_decode_u_64(deserializer);
+    var var_unaccountedBytes = sse_decode_u_64(deserializer);
+    return BridgeMemoryReport(
+        processBytes: var_processBytes,
+        frameCacheBytes: var_frameCacheBytes,
+        vramCacheBytes: var_vramCacheBytes,
+        decodeCacheBytes: var_decodeCacheBytes,
+        openDecoders: var_openDecoders,
+        parkQueueFrames: var_parkQueueFrames,
+        unaccountedBytes: var_unaccountedBytes);
   }
 
   @protected
@@ -11812,6 +11899,19 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_u_32(self.fpsNum, serializer);
     sse_encode_u_32(self.fpsDen, serializer);
     sse_encode_bridge_rational(self.duration, serializer);
+  }
+
+  @protected
+  void sse_encode_bridge_memory_report(
+      BridgeMemoryReport self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.processBytes, serializer);
+    sse_encode_u_64(self.frameCacheBytes, serializer);
+    sse_encode_u_64(self.vramCacheBytes, serializer);
+    sse_encode_u_64(self.decodeCacheBytes, serializer);
+    sse_encode_u_64(self.openDecoders, serializer);
+    sse_encode_u_64(self.parkQueueFrames, serializer);
+    sse_encode_u_64(self.unaccountedBytes, serializer);
   }
 
   @protected

--- a/flutter_ui/lib/src/rust/frb_generated.io.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.io.dart
@@ -345,6 +345,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeMediaInfo dco_decode_bridge_media_info(dynamic raw);
 
   @protected
+  BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw);
+
+  @protected
   BridgePaintMode dco_decode_bridge_paint_mode(dynamic raw);
 
   @protected
@@ -1010,6 +1013,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeMediaInfo sse_decode_bridge_media_info(SseDeserializer deserializer);
+
+  @protected
+  BridgeMemoryReport sse_decode_bridge_memory_report(
+      SseDeserializer deserializer);
 
   @protected
   BridgePaintMode sse_decode_bridge_paint_mode(SseDeserializer deserializer);
@@ -1748,6 +1755,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_bridge_media_info(
       BridgeMediaInfo self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_bridge_memory_report(
+      BridgeMemoryReport self, SseSerializer serializer);
 
   @protected
   void sse_encode_bridge_paint_mode(

--- a/flutter_ui/lib/src/rust/frb_generated.web.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.web.dart
@@ -347,6 +347,9 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   BridgeMediaInfo dco_decode_bridge_media_info(dynamic raw);
 
   @protected
+  BridgeMemoryReport dco_decode_bridge_memory_report(dynamic raw);
+
+  @protected
   BridgePaintMode dco_decode_bridge_paint_mode(dynamic raw);
 
   @protected
@@ -1012,6 +1015,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
 
   @protected
   BridgeMediaInfo sse_decode_bridge_media_info(SseDeserializer deserializer);
+
+  @protected
+  BridgeMemoryReport sse_decode_bridge_memory_report(
+      SseDeserializer deserializer);
 
   @protected
   BridgePaintMode sse_decode_bridge_paint_mode(SseDeserializer deserializer);
@@ -1750,6 +1757,10 @@ abstract class BridgeLibApiImplPlatform extends BaseApiImpl<BridgeLibWire> {
   @protected
   void sse_encode_bridge_media_info(
       BridgeMediaInfo self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_bridge_memory_report(
+      BridgeMemoryReport self, SseSerializer serializer);
 
   @protected
   void sse_encode_bridge_paint_mode(

--- a/flutter_ui/test/frb/shell_frb_test.dart
+++ b/flutter_ui/test/frb/shell_frb_test.dart
@@ -100,7 +100,7 @@ void main() {
       await tester.pump();
       expect(playbackTier().tier, 1);
 
-      // Where the memory has gone (K-295), at the foot of the page: the rows
+      // Where the memory has gone (K-294), at the foot of the page: the rows
       // above each report one store, and this reports the whole process and
       // what none of them accounts for. Scrolled to, because the page is
       // taller than the window — and a memory report is a thing you go and

--- a/flutter_ui/test/frb/shell_frb_test.dart
+++ b/flutter_ui/test/frb/shell_frb_test.dart
@@ -82,25 +82,6 @@ void main() {
       expect(find.byKey(const ValueKey('settings-tier')), findsOneWidget);
       expect(find.byKey(const ValueKey('settings-cache-used')), findsOneWidget);
 
-      // Where the memory has gone (K-295). The report is the first thing on
-      // the page, and the figure it exists for is the unaccounted one: a user
-      // asked "why is Lumit holding 85 GB" reads this row back to us.
-      expect(find.byKey(const ValueKey('settings-memory-process')),
-          findsOneWidget);
-      final unaccounted =
-          find.byKey(const ValueKey('settings-memory-unaccounted'));
-      expect(unaccounted, findsOneWidget);
-      expect(find.byKey(const ValueKey('settings-memory-decoders')),
-          findsOneWidget);
-      expect(find.byKey(const ValueKey('settings-memory-parks')),
-          findsOneWidget);
-      // A real number, not a placeholder: the platform under the test answers
-      // its own size, so the row must show bytes rather than an em dash.
-      expect(
-        (tester.widget<Text>(unaccounted).data ?? ''),
-        anyOf(contains('MB'), contains('GB')),
-        reason: 'the report is wired to the engine, not a stub',
-      );
 
       // The budget is a typed number now (K-194), not a pick from a list:
       // dragging it changes what the engine holds, not just the label.
@@ -118,6 +99,30 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('settings-tier-reset')));
       await tester.pump();
       expect(playbackTier().tier, 1);
+
+      // Where the memory has gone (K-295), at the foot of the page: the rows
+      // above each report one store, and this reports the whole process and
+      // what none of them accounts for. Scrolled to, because the page is
+      // taller than the window — and a memory report is a thing you go and
+      // look for.
+      final unaccounted =
+          find.byKey(const ValueKey('settings-memory-unaccounted'));
+      await tester.scrollUntilVisible(unaccounted, 200,
+          scrollable: find.byType(Scrollable).first);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('settings-memory-process')),
+          findsOneWidget);
+      expect(unaccounted, findsOneWidget);
+      expect(find.byKey(const ValueKey('settings-memory-gpu')), findsOneWidget);
+      expect(find.byKey(const ValueKey('settings-memory-decoders')),
+          findsOneWidget);
+      // A real number, not a placeholder: the platform under the test answers
+      // its own size, so the row shows bytes rather than an em dash.
+      expect(
+        tester.widget<Text>(unaccounted).data ?? '',
+        anyOf(contains('MB'), contains('GB')),
+        reason: 'the report is wired to the engine, not a stub',
+      );
     });
 
     /// The disk tier's controls: its budget reaches the engine, and where the

--- a/flutter_ui/test/frb/shell_frb_test.dart
+++ b/flutter_ui/test/frb/shell_frb_test.dart
@@ -82,6 +82,26 @@ void main() {
       expect(find.byKey(const ValueKey('settings-tier')), findsOneWidget);
       expect(find.byKey(const ValueKey('settings-cache-used')), findsOneWidget);
 
+      // Where the memory has gone (K-295). The report is the first thing on
+      // the page, and the figure it exists for is the unaccounted one: a user
+      // asked "why is Lumit holding 85 GB" reads this row back to us.
+      expect(find.byKey(const ValueKey('settings-memory-process')),
+          findsOneWidget);
+      final unaccounted =
+          find.byKey(const ValueKey('settings-memory-unaccounted'));
+      expect(unaccounted, findsOneWidget);
+      expect(find.byKey(const ValueKey('settings-memory-decoders')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('settings-memory-parks')),
+          findsOneWidget);
+      // A real number, not a placeholder: the platform under the test answers
+      // its own size, so the row must show bytes rather than an em dash.
+      expect(
+        (tester.widget<Text>(unaccounted).data ?? ''),
+        anyOf(contains('MB'), contains('GB')),
+        reason: 'the report is wired to the engine, not a stub',
+      );
+
       // The budget is a typed number now (K-194), not a pick from a list:
       // dragging it changes what the engine holds, not just the label.
       final before = cacheStats().budgetBytes.toInt();


### PR DESCRIPTION
Closes the second report of Lumit holding tens of gigabytes on a Mac — 85 GB, after the 81 GB K-277 bounded the write-behind queue for.

Rebased onto `main` after the smooth-zoom merge (#62), which took K-293 — this branch's pair renumbered to **K-294** and **K-295**.

## The cause

**Dropping a texture or a buffer does not free it.** wgpu marks it destroyed, and the driver hands the memory back on the device's next *maintain*. A renderer drawing into a window gets those for free, because presenting a frame *is* a maintain. This engine renders into caches, on a worker thread, and spends most of its time idle: the frame cache evicts, read-backs finish, a composite's intermediates go out of scope — and **none of that asks the device for anything**. The memory sat marked-and-not-returned until something else polled for its own reasons.

Every maintain in the engine turned out to be conditional on optional work: the profiler (opt-in), the effects that fence, the read-backs while one is in flight, and the Linux present path. In ordinary idle rendering there is none. The idle fill and idle backup make it worse rather than better — they are precisely what produces dropped objects while nothing presents.

The owner's readings caught it mid-act:

| | process | not held by any cache | pictures | buffers |
|---|---|---|---|---|
| while it had climbed | 6 GB | 5 GB | 1600 | ~5 500 |
| moments later | 2.9 GB | 2 GB | 1600 | **8** |

Nothing was done between those two readings except switching back to the settings page — which happened to make the device do a maintain. Memory that comes back only when the user does something unrelated is a leak in every sense that matters to the person whose machine it is.

## The fix

`GpuContext::reclaim` — a non-blocking `Maintain::Poll` — in `sync_caches`, the first call of **every turn of the worker's loop**: every frame during playback, every 2 ms while idle work remains, every 200 ms when fully idle. It drains what has already finished, costs nothing when there is nothing to drain, and makes reclamation a property of time passing rather than of the user opening a panel.

The rule it writes down (docs/13 §7.0.2): *an engine that renders without presenting MUST maintain its device on a schedule of its own. Anything that frees memory only as a side effect of an unrelated call is not freeing memory.*

## The instrument that found it, and its two mistakes

Settings ▸ Performance gained a **Memory** section: what the OS says the process holds, what each byte-budgeted tier holds, how many textures and buffers the driver still has, how many decoders are open, and **what is left over**. That leftover figure is what cleared every cache in one reading and pointed at the layer underneath.

Two corrections it needed, both worth recording:

- **It first reported GPU bytes**, from `Device::generate_allocator_report` — Vulkan and D3D12 only. On the Mac it was written for it read *"not reported by this driver"*. It now leads with **live object counts**, which every backend keeps, Metal included; the byte row survives where it is real and is not drawn where it would be zero.
- **It counted the card's frames as unaccounted.** On the Apple Silicon Mac doing the reporting, VRAM *is* process memory, so a cache doing exactly its job appeared inside the leftover figure and looked like the fault. The adapter now says which kind of memory it has (`unified_memory`) and the report counts accordingly.

**Debug builds only**, as asked: `kDebugMode` gates both the section and the engine call behind it, so a release build neither draws it nor asks.

## Verification

- **`what_the_engine_drops_the_driver_gets_back`** renders far more frames than the cache can hold, then asks the driver what it still holds: **18 textures and 8 buffers against the 120 frames that went through**. It runs everywhere the suite runs, and the platform that matters is **macOS** — where the reclamation went wrong and where no allocator report exists to see it, which is why the gate counts objects rather than bytes.
- A counter test makes a texture, drops it, and checks the tally follows — without wgpu's `counters` feature these read zero for ever, the one silent failure this row could not afford.
- **A pre-existing flake fixed on the way.** The framecache tests share one process-wide cache and cargo runs them in parallel, so two interleaving is one test clearing another's frames out from under it. It failed once on this branch's own suite and would otherwise block a merge at random. A mutex round each test that touches the global fixes it; stable over eight runs at `--test-threads=16`, where it reproduced before.
- Full Rust suite green (28 binaries), fmt and clippy clean, bridge codegen regenerated (it caught a stale decision number in the generated Dart, which is what that gate is for), `flutter analyze` clean, **Flutter suite 918 passing**.

## What I ruled out on the way, by measurement

- **1200 decodes** through the real decoder against a synthesised H.264 fixture: RSS flat at 34 MB. The decode path does not leak, and macOS uses the same software path (hardware decode is D3D11VA, Windows-only).
- **400 renders through a 64 MB frame-texture cache**, evicting ~50 times over: RSS plateaus.
- Every byte-budgeted tier, the park queue, the read-backs in flight, the ring, the IOSurface pool and the Swift texture registry — each capped, and the IOSurface handle does not change per frame, so Dart is not re-registering.

## Honest limits

This container has no Metal. The fix rests on the mechanism (nothing maintained the device in the idle path; now something does, once a turn), on your two readings, and on a regression test that runs on macOS in CI. The 1600 textures are consistent with the VRAM cache holding small frames at a reduced tier — after this they are counted against the process rather than against the mystery, so the next reading should say so plainly.

## Docs

`13-PERFORMANCE-RULES.md` §7.0.1 (the reporting rule) and §7.0.2 (the reclamation rule), `GUIDE.md` (two plain-English sections), and **K-294** / **K-295** in `02-DECISIONS.md`.
