### PR TITLE
Check for updates is one live menu row, and updates arrive whole (K-294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Run it by hand from the Actions tab. GitHub occasionally does not deliver
+  # the `pull_request` event for a push — a branch sits at "pending" with no run
+  # against its head and nothing to re-run, since re-running needs a run to
+  # exist. This is the way out of that, and the way to re-run a job that failed
+  # on something outside the tree (a runner hiccup, a registry timeout).
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,26 @@ jobs:
           $version = "$env:GITHUB_REF_NAME".TrimStart('v')
           if (-not $version) { $version = '0.0.0' }
           & packaging/windows/build-installer.ps1 -Version $version
+      # The same files the installer lays down, as a plain archive (K-297).
+      # This is what a per-user installation fetches to update itself: no
+      # installer to run, no elevation, no questions already answered once.
+      - name: Package the app for in-place updates
+        shell: pwsh
+        run: |
+          $version = "$env:GITHUB_REF_NAME".TrimStart('v')
+          if (-not $version) { $version = '0.0.0' }
+          $stage = "$env:RUNNER_TEMP\lumit-package"
+          New-Item -ItemType Directory -Force -Path "$stage\icons" | Out-Null
+          Copy-Item -Recurse -Force flutter_ui\build\windows\x64\runner\Release\* $stage
+          Copy-Item assets\brand\lumit-project.ico, assets\brand\lumit-preset.ico "$stage\icons"
+          Compress-Archive -Path "$stage\*" -Force `
+            -DestinationPath "packaging/windows/dist/lumit-$version-windows-x64.zip"
       - uses: actions/upload-artifact@v4
         with:
           name: windows-installer
-          path: packaging/windows/dist/*.exe
+          path: |
+            packaging/windows/dist/*.exe
+            packaging/windows/dist/*.zip
           if-no-files-found: error
 
   linux-bundle:
@@ -188,10 +204,24 @@ jobs:
         run: |
           version="${GITHUB_REF_NAME#v}"
           packaging/macos/make-dmg.sh "${version:-0.0.0}"
+      # The bundle on its own, for in-place updates (K-297). `ditto` rather than
+      # `zip`: an .app carries symbolic links, code signatures and executable
+      # bits, and an archiver that drops those produces a bundle macOS refuses
+      # to open.
+      - name: Package the bundle for in-place updates
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          version="${version:-0.0.0}"
+          app="flutter_ui/build/macos/Build/Products/Release/Lumit.app"
+          mkdir -p packaging/macos/dist
+          ditto -c -k --keepParent "$app" \
+            "packaging/macos/dist/lumit-$version-macos-$(uname -m).zip"
       - uses: actions/upload-artifact@v4
         with:
           name: macos-dmg
-          path: packaging/macos/dist/*.dmg
+          path: |
+            packaging/macos/dist/*.dmg
+            packaging/macos/dist/*.zip
           if-no-files-found: error
 
   publish:

--- a/crates/lumit-bridge/Cargo.toml
+++ b/crates/lumit-bridge/Cargo.toml
@@ -84,6 +84,14 @@ features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
     "Win32_System_SystemInformation",
+    # `GetProcessMemoryInfo`/`PROCESS_MEMORY_COUNTERS` and the pseudo-handle they
+    # are asked with, for the resident-memory readout (K-294). Named here rather
+    # than leant on: the `windows` crate gates every module behind its own
+    # feature, and these two happened to be reachable through another crate's
+    # unification on some builds and not on the Windows CI runner — which is how
+    # main went red with nothing in it having changed.
+    "Win32_System_ProcessStatus",
+    "Win32_System_Threading",
     # `GetCursorPos`/`SetCursorPos`, for the camera tools' pointer lock (K-230).
     "Win32_UI_WindowsAndMessaging",
     # `timeBeginPeriod`, so the worker's present-pacing sleeps are 1 ms-grained

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6365,3 +6365,56 @@ deliberately painter-drawn glyph, and this is one.
 The − / + / Fit buttons are gone: the slider's two ends *are* Fit and full zoom, and a slider
 also says where you are between them, which three buttons never did. `HouseSlider` gained a
 width and a value-hiding option rather than a second slider being written for a toolbar.
+
+**K-294 · DECIDED · Updates are checked from the Help row itself, fetched whole from the
+GitHub Release, and installed on a restart the user chooses.** Help ▸ Check for updates was
+the last row of the bar that was listed and dead. It is now the whole update sequence in one
+row, and nothing else is added to the interface for it.
+
+**The row is the state machine.** Press it and it greys and reads "Checking for updates…";
+a moment later it is either "Click to update - v0.2.0" — the version in the row, where
+somebody deciding whether to update is already looking — or back to "Check for updates",
+with "Lumit is up to date" in the status line. Press it in the offered state and the update
+is fetched; while it comes the row reads "Downloading update… 42%"; once it is on disk and
+verified it reads "Restart to finish updating" until the restart happens. A row that said
+"You are up to date" and stayed that way would be a stale claim by the next morning, which
+is why success goes back to the resting wording rather than boasting about it. This needed
+one small thing of the menu bar: `MenuEntry.live` is a row that rebuilds in place while its
+menu is open and does *not* close the menu when pressed, because the point of pressing it is
+to watch what it does. It is the only live row there is, and rows should have to earn it.
+
+**Full installers, never patches.** Releases already publish the finished installer per
+platform (`release.yml`, a `v*` tag): `setup.exe`, `.dmg`, `.tar.gz`, `.flatpak`. The updater
+downloads whichever suits the machine, entire. A delta scheme means publishing a patch per
+pair of versions, a tool to apply them and a fallback for the pairs that are missing — three
+new failure modes to save bandwidth GitHub serves for nothing (K-279: no bandwidth cap, no
+server of ours). The saving is real and the cost is a few hundred megabytes on a deliberate
+click, a few times a year.
+
+**Nothing is downloaded without being asked, and nothing is run without being checked.**
+Automatic updates are on by default and are offered twice — on the setup screen (K-246) and
+in Settings ▸ General ▸ Updates — but what "on" means is *looking*, once a day at launch, and
+saying so in the menu. The download always waits for a press: this is a video application and
+someone editing on a hotel connection should not find Lumit spending their data. Before the
+downloaded file is executed it must match the length the release published and, where GitHub
+publishes a `digest`, its SHA-256; a file that fails either is deleted rather than run. An
+installer is the most dangerous file Lumit ever touches, so verification is a gate and not a
+diagnostic.
+
+**Finishing means restarting, and the work comes first.** An installer cannot replace files
+that are running, so the last window says so: *Restart to finish updating*. With unsaved work
+open the buttons are **Save and restart** / **Restart without saving** / **Later**; with a
+clean project, **Restart now** / **Later**. Later keeps the verified installer and the row
+that offers it, so the update is not lost by declining it once. Windows starts Inno Setup
+silently (`/SILENT /CLOSEAPPLICATIONS /NORESTART` — the install questions were answered the
+first time and asking them again is ceremony) and quits; macOS opens the disk image and
+quits; **Linux only reveals the download** and does not quit, because a tarball is unpacked
+wherever its owner keeps it and a Flatpak is installed by Flatpak, neither of which Lumit
+should do on somebody's behalf.
+
+**It lives in Dart, not in the engine.** `state/updates.dart` and
+`shell/update_dialog_frb.dart`, with `dart:io`'s own HTTP client and `crypto` for the digest
+— no new Rust dependency, no TLS stack pulled into a crate that renders frames. An updater is
+shell business by every test docs/05 applies: it touches no document, no timeline and no GPU,
+and the engine crates stay free of the network. The version it compares against is the one
+the boot log already reports (K-008), so there is no second source of truth to keep in step.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -6518,3 +6518,54 @@ should do on somebody's behalf.
 shell business by every test docs/05 applies: it touches no document, no timeline and no GPU,
 and the engine crates stay free of the network. The version it compares against is the one
 the boot log already reports (K-008), so there is no second source of truth to keep in step.
+
+**K-297 · DECIDED · Lumit installs per user and replaces itself, the way Chrome and VS
+Code do — except inside a Flatpak, where that is Flatpak's job.** K-296 shipped updating by
+running the installer again. That works and it is a poor experience: a wizard, a UAC prompt,
+and questions the user answered the first time. The reason it had to be that way was the
+install location, not the updater.
+
+**The install moves to the user's own folder.** `packaging/windows/lumit.iss` gains
+`PrivilegesRequired=lowest` and installs to `{localappdata}\Programs\Lumit`
+(`UsePreviousAppDir=yes`, so an existing `Program Files` copy stays where it is and keeps
+being updated by installer). This is what Chrome, VS Code and Discord all do, and it is the
+whole trick: a folder the user owns can be rewritten by a program the user is running, with
+no elevation and nothing to approve. macOS bundles and the Linux tarball already live
+somewhere their owner can write.
+
+**Releases carry the application, not only its installer.** `release.yml` now publishes
+`lumit-<v>-windows-x64.zip` beside the setup, and `lumit-<v>-macos-<arch>.zip` beside the
+disk image; the Linux tarball already was one. macOS uses `ditto` rather than `zip` because
+an `.app` carries symlinks, executable bits and a signature that a naive archiver drops,
+producing a bundle the system will not open. Unpacking uses the platform's own tool for the
+same reason — `ditto` on macOS, `tar` elsewhere, including Windows, which has carried bsdtar
+since Windows 10 1803. No Dart zip library, no new dependency.
+
+**The swap is two renames, not a few hundred file copies.** The new version is unpacked to
+`<install>.new`, verified, and marked complete; then `<install>` becomes `<install>.old` and
+`<install>.new` becomes `<install>`. Renaming is one filesystem operation — it happened or
+it did not — where copying files over a running application is hundreds of chances to be
+interrupted into a Lumit that is neither version and may not start. If the second rename
+fails the first is undone immediately, from code already in memory. The old folder is left
+behind on purpose: Windows will not delete a loaded DLL, so `main()` sweeps it on the next
+launch, and puts it back if it ever finds the install folder missing.
+
+**Three deliveries, chosen by where Lumit actually lives** (`InstallSite.detect`):
+*in place* for a folder or bundle Lumit can write beside — proven by writing a probe file,
+not assumed from the path; *installer* for anywhere it cannot, which covers every existing
+`Program Files` install and the macOS disk image; *Flatpak bundle* inside a Flatpak. The
+release attachment follows the delivery, so a Flatpak is never offered a tarball it cannot
+use, and a per-user install is never offered a setup it does not need.
+
+**A Flatpak is not updated from inside, and pretending otherwise would be a lie.** The
+sandbox is read-only by design and reaching the host to run `flatpak install` would need
+permissions no editor should hold. So Lumit fetches the bundle, says the one command that
+installs it, and stays open. Making that a proper `flatpak update` needs Lumit published to
+an OSTree remote rather than as a single-file bundle — tracked in TODO, and the reason the
+Flatpak wording names a command rather than a button.
+
+**What this costs.** The window between the two renames is not recoverable by Lumit if the
+machine loses power inside it: the install folder would be `Lumit.old` and nothing would
+start. It is two rename calls wide, the start-up sweep puts it back for every failure short
+of that, and the fallback is the installer, which is still published. Judged worth it
+against a UAC prompt on every update for ever.

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -228,6 +228,12 @@ panel layout is.
 - **Effect** MUST offer one submenu per effect category, each item applying to *every* selected
   layer (K-217), and the whole menu MUST be disabled with nothing selected.
 - **File ▸ Open recent** lists the ten most recent project paths, newest first.
+- **Help ▸ Check for updates** MUST carry the whole update sequence in the one row (K-294):
+  disabled and reading "Checking for updates…" while a check runs, then either
+  "Click to update - v*X.Y.Z*" or back to "Check for updates" with *Lumit is up to date* in
+  the status line. Pressing it MUST NOT close the menu, and the row MUST redraw in place as
+  the state changes. Downloading MUST show progress in the same row, and a downloaded update
+  MUST read "Restart to finish updating" until it is applied.
 
 ---
 
@@ -1622,7 +1628,10 @@ no-wizard rule below.
 
 The **v1 build** (K-246) ships the minimal form of this screen: two plain choices,
 **AE-style** and **Vegas-style**, where Vegas ticks the two K-246 settings (Retime opens to
-speed; video arrives as a Sequence layer) and AE ticks neither. The four cards above, with a
+speed; video arrives as a Sequence layer) and AE ticks neither. Along the bottom sits one
+tick, **on by default**, for automatic update checks (K-294) — the same setting as
+Settings ▸ General ▸ Updates, asked here because it is a decision about how Lumit behaves
+from now on. Skipping the screen leaves it on. The four cards above, with a
 small image over each choice, remain the destination (polish tracked in TODO).
 
 ### 13.2 Empty states
@@ -1793,6 +1802,10 @@ travel in the `.lum` and are marked below:
   preference order, filename template.
 - **Rendering** — *not here at all*: it is the project's, not this machine's, so it lives in
   the **Project settings** window instead (§13.5, K-286).
+- **Updates** (K-294), under General: *Automatic updates* — look for a new version at
+  launch, at most once a day — on by default, plus a readout of the installed version and a
+  button driving the same check the Help row does. Checking is all "on" means; the download
+  always waits to be asked for.
 - **Keymap**, **Interface** (UI scale, tooltips, reduced motion follows OS or override),
   **Autosave** (interval, copies kept), **Plugins** (search paths, disabled list,
   per-plugin overrides).

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -234,6 +234,11 @@ panel layout is.
   the status line. Pressing it MUST NOT close the menu, and the row MUST redraw in place as
   the state changes. Downloading MUST show progress in the same row, and a downloaded update
   MUST read "Restart to finish updating" until it is applied.
+- **How an update is applied** follows where Lumit is installed (K-297), and the restart
+  window MUST say which it is: swapped in place and restarted (a per-user installation, the
+  normal case), handed to the installer (anywhere Lumit cannot write to its own files), or
+  handed to Flatpak with the install command, in which case Lumit MUST NOT offer to restart
+  because it is not replacing anything.
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3951,3 +3951,68 @@ Every point where the updater touches the outside world — asking GitHub,
 downloading, running an installer, quitting — is a swappable seam, which is how
 the tests exercise the entire sequence without ever going near a network or
 actually running anything.
+
+### Updating without an installer (K-297)
+
+The section above describes updating by downloading the installer and running
+it. That still happens in some cases, but it is no longer the normal one — and
+the reason is not clever code, it is *where Lumit lives*.
+
+**Why Chrome never shows you an installer.** Programs on Windows traditionally
+go in `Program Files`, a folder only an administrator may write to. That is why
+updating one always involves a prompt: the program cannot change its own files,
+so it has to ask an installer, and the installer has to ask Windows for
+permission. Chrome, VS Code and Discord sidestep the whole ceremony by
+installing somewhere *you* own — a folder inside your own user profile. A
+program running as you can rewrite a folder belonging to you without asking
+anybody. Lumit now installs there too (`%LOCALAPPDATA%\Programs\Lumit`).
+
+**What a release now carries.** As well as the installer for each platform,
+every release publishes the application *by itself* as a plain archive: a zip of
+the Windows files, a zip of the macOS `Lumit.app`, and the Linux tarball that
+already existed. That archive is what Lumit downloads to update itself. Nothing
+in it is an installer — it is simply the new version of the same files.
+
+**How the swap works, and why it is done that way.** The obvious approach is to
+copy the new files over the old ones. Do not: that is several hundred separate
+operations, and if anything interrupts it half way — a crash, a flat battery —
+you are left with a Lumit that is half one version and half another, which may
+not start at all. Instead Lumit unpacks the whole new version *beside* the old
+one, then does two renames:
+
+1. `Lumit` becomes `Lumit.old`
+2. `Lumit.new` becomes `Lumit`
+
+A rename is a single filesystem operation: it either happened or it did not,
+with nothing in between. So at every moment there is a complete, working Lumit
+on disk — the old one, or the new one. If the second rename fails, the first is
+undone on the spot, and the code doing the undoing is already loaded in memory,
+so it does not need the files it is moving.
+
+The old folder is deliberately left lying there. Windows will not let anyone
+delete a `.dll` that is currently loaded, and at that moment Lumit is still
+running from those very files. So it is swept up on the *next* launch, by the
+new version, when nothing is holding it — that is the first thing `main()` does.
+The same sweep also puts the old version back if it ever finds the install
+folder missing, which is what a machine dying between those two renames would
+leave behind.
+
+**Three ways an update can be applied**, and Lumit works out which by looking at
+where it is actually installed:
+
+- **In place** — the swap above. Requires a folder Lumit can write beside, which
+  it checks by genuinely writing a small file there rather than guessing from
+  the path.
+- **By installer** — for an older installation still in `Program Files`, or a
+  macOS disk image. Exactly the K-296 behaviour, kept as the fallback so nobody
+  is stranded.
+- **Handed to Flatpak** — see below.
+
+**Flatpak is the exception, and honestly so.** A Flatpak runs in a sandbox whose
+files are read-only on purpose: that is the security model, not an oversight. An
+application inside one genuinely cannot replace its own files, and the ways to
+reach out to the host and do it anyway require permissions no video editor
+should be asking for. So on Flatpak, Lumit downloads the new bundle, shows you
+the one command that installs it, and stays open. Making this a real
+`flatpak update` needs Lumit published to a Flatpak *remote* rather than as a
+single downloadable bundle — that is written down in TODO as the next step.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3808,3 +3808,78 @@ libraries are folded into the app itself (so it runs without Homebrew), but
 it carries no paid Apple signature yet, so macOS warns before first launch —
 the proper signing lands with the macOS pass in the TODO, and a release still
 publishes even if this job fails.
+
+## 11. Keeping Lumit up to date, in plain terms
+
+Every release already ends up in the same place: a GitHub Release, tagged `v0.1.0`
+or whatever the version is, with the finished installers hanging off it — a
+`setup.exe` for Windows, a disk image for macOS, a bundle and a Flatpak for
+Linux. That is the whole raw material the updater needs, and it means Lumit has
+no update server to run and nothing to pay for.
+
+**What "check for updates" actually does.** GitHub will answer a small,
+public question — *what is the newest release of this repository, and what is
+attached to it?* — over the same sort of web request a browser makes. Lumit asks
+it, reads the tag (`v0.2.0`), strips the `v`, and compares that with the version
+this build reports on start-up: the very first line of the boot log, the one the
+About window shows. Comparing versions is fiddlier than it looks — `0.10.0` is
+newer than `0.9.0` even though it sorts earlier as text, and `0.2.0-rc.1` is
+*older* than `0.2.0` because a release candidate comes before the release. There
+is a small function for exactly that, and a test for each of those traps.
+
+**One menu row does everything.** Help ▸ Check for updates is not a button that
+opens an update window; it is the update, in a row. Press it and it goes grey and
+says *Checking for updates…*. A second later it either says *Click to update -
+v0.2.0* or goes back to *Check for updates*, with "Lumit is up to date" in the
+status line at the bottom. Press the offered version and Lumit asks whether to
+fetch it, tells you how big it is, and shows a bar while it comes; the row
+counts along too, in case you closed the window and went back to editing. When it
+has arrived the row says *Restart to finish updating* until you do.
+
+Making a menu row behave like that needed one new trick: menus in Lumit are
+normally a list of labels decided the moment the menu opens, and pressing any row
+closes the menu. This one row is a `MenuEntry.live` — it redraws itself while the
+menu is open and it stays open when pressed, because the whole point of pressing
+it is to watch what happens. It is the only row like that, deliberately.
+
+**Automatic updates.** There is a tick on the setup screen, and the same tick in
+Settings ▸ General ▸ Updates. It is on to begin with, and it means one specific
+thing: when Lumit starts, and no more than once a day, it *looks*. It never
+downloads anything on its own. If there is something newer, all that happens is
+that the Help row is already saying so the next time you open the menu. Someone
+editing on a hotel connection should never discover Lumit quietly spending their
+data allowance.
+
+**Why the whole installer, rather than a patch.** Patches are smaller, and that
+is genuinely nice; the price is publishing a separate patch for every pair of
+versions people might be coming from, writing the tool that applies them, and
+then writing the fallback for when somebody's particular pair does not exist.
+That is three new things that can be broken in order to save bandwidth GitHub
+gives us for free. So: the whole installer, every time, on a click you made.
+
+**What stops a bad download from being run.** The release says how many bytes the
+installer is and — where GitHub provides one — its SHA-256, which is a
+fingerprint of the file's contents: change one byte and the fingerprint changes
+completely. Lumit checks both before it will run anything, and deletes the file
+if either disagrees. An installer is the most dangerous file Lumit ever touches;
+a truncated download or a swapped file is caught here or not at all.
+
+**Why you have to restart.** An installer cannot overwrite a program that is
+running, which is a rule of the operating system rather than a choice of ours. So
+the last window says *Restart to finish updating*. If you have unsaved work open,
+it offers **Save and restart** as well as **Restart without saving** — losing an
+evening's work to a version number would be an absurd way to lose it — and
+**Later**, which keeps the downloaded installer so you can finish whenever you
+like. On Windows the installer runs itself quietly and Lumit closes; on macOS the
+disk image opens and Lumit closes; on Linux Lumit only shows you the downloaded
+file, because unpacking a bundle or installing a Flatpak is something you do
+where you want it, not something an editor should do behind you.
+
+**Where the code is.** `flutter_ui/lib/state/updates.dart` knows about versions,
+downloads and files; `flutter_ui/lib/shell/update_dialog_frb.dart` is the windows
+you see. None of it is in Rust: the engine has no business knowing about the
+internet, and this way nothing that renders frames grows a network dependency.
+Every point where the updater touches the outside world — asking GitHub,
+downloading, running an installer, quitting — is a swappable seam, which is how
+the tests exercise the entire sequence without ever going near a network or
+actually running anything.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,6 +17,18 @@ this file is the concrete backlog underneath it.
 
 These sit above everything else: they are what the editor feels like in the hand.
 
+- **The reclamation gate does not hold on D3D12 — CI is red on Windows (K-295).**
+    `what_the_engine_drops_the_driver_gets_back` renders 120 frames against a
+    32 MB budget and asserts fewer than 64 live textures afterwards. The
+    software rasteriser leaves 18; the Windows runner leaves ~575, three runs
+    running (`crates/lumit-render/src/headless.rs`). Either the hand-back does
+    not reach D3D12's deferred destruction — in which case the leak K-295 was
+    written to catch is still there on the platform Lumit ships first — or the
+    live count means something different per backend. Needs a machine with a
+    real graphics card: the test skips where there is no adapter, so it cannot
+    be judged from CI logs alone. Until it is settled, every Windows CI run
+    fails and the gate guards nothing.
+
 - **Take the lens flare's bake off the render thread.** Choosing a lens blocks
     the picture for about half a second of pure CPU optics (measured, K-263) -
     the single longest stall the effect has - and the bake is still a closure the

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -494,9 +494,9 @@ entry above.
     command with a place waiting for it: Close project, History, Cut/Copy/Paste,
     layer settings and the mask/transform/blending/matte/style families, the
     whole Animation menu, the View menu's zoom/resolution/grid/ruler rows,
-    Trim and Crop comp to work area, Add to export queue, Check for updates and
-    the help links. Delete each mark as the command lands. Suggested chords for
-    the AE-shaped ones are in K-244.
+    Trim and Crop comp to work area, Add to export queue and the help links
+    (Check for updates is built — K-294). Delete each mark as the command
+    lands. Suggested chords for the AE-shaped ones are in K-244.
 
 ## Later - roadmap features not yet built
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -498,6 +498,13 @@ entry above.
     (Check for updates is built — K-296). Delete each mark as the command
     lands. Suggested chords for the AE-shaped ones are in K-244.
 
+- **A Flatpak remote, so `flatpak update` has something to update from (K-297).**
+    Releases ship a single-file `.flatpak` bundle, which installs perfectly well
+    and then never updates: `flatpak update` needs a remote. Export an OSTree
+    repo in `release.yml`, publish it (Cloudflare Pages beside the site, K-279)
+    and ship a `.flatpakref`, or submit to Flathub and let it host. Until then
+    Lumit tells Flatpak users the install command rather than offering a button.
+
 ## Later - roadmap features not yet built
 
 Grouped by the phase they belong to in [16-ROADMAP.md](16-ROADMAP.md). A pointer

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show File;
+import 'dart:io' show File, Platform;
 import 'dart:ui' show AppExitResponse;
 
 import 'package:flutter/material.dart';
@@ -16,6 +16,7 @@ import 'package:lumit_flutter/panels/viewer_texture_controller.dart';
 import 'package:lumit_flutter/shell/comp_settings_frb.dart';
 import 'package:lumit_flutter/shell/precompose_dialog_frb.dart';
 import 'package:lumit_flutter/shell/dock_widget.dart';
+import 'package:lumit_flutter/shell/about_window_frb.dart';
 import 'package:lumit_flutter/shell/first_run_frb.dart';
 import 'package:lumit_flutter/shell/menu_bar_frb.dart';
 import 'package:lumit_flutter/shell/project_settings_frb.dart';
@@ -42,6 +43,7 @@ import 'package:lumit_flutter/state/preview_progress.dart';
 import 'package:lumit_flutter/state/render_timings.dart';
 import 'package:lumit_flutter/state/settings.dart';
 import 'package:lumit_flutter/state/tools.dart';
+import 'package:lumit_flutter/state/updates.dart';
 import 'package:lumit_flutter/state/workspace.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/widgets/controls.dart';
@@ -430,6 +432,15 @@ class LumitUiState extends ChangeNotifier {
   /// The keyboard map every shortcut is looked up in (docs/07 §15, K-199).
   late final KeymapState keymap;
 
+  /// Whether there is a newer Lumit, and fetching it (K-294).
+  ///
+  /// One for the session, here, because the Help menu and Settings ▸ General
+  /// are two views of the same check and neither owns it. The version is passed
+  /// as a function, not a string: it comes over the bridge, and a widget test
+  /// that builds this state must not call the engine merely by existing.
+  late final UpdateService updates =
+      UpdateService(currentVersion: () => versionFromBootLine(lumitVersion()));
+
   /// How big each layer's content is, for the Viewer's boxes and hit-testing
   /// (K-217). Held here because the answer is the document's, not a panel's,
   /// and probing a clip is disk work that must happen once rather than per
@@ -478,6 +489,23 @@ class LumitUiState extends ChangeNotifier {
   final ValueNotifier<int> togglePlayRequest = ValueNotifier(0);
 
   void requestTogglePlay() => togglePlayRequest.value++;
+
+  /// Look for a newer Lumit on launch, if that is switched on and it has been
+  /// a day since the last look (K-294).
+  ///
+  /// Only ever a *look*: what it finds ends up as the wording of the Help menu
+  /// row, and downloading anything still waits for a click. Failure is silent —
+  /// a machine with no network has not done anything wrong, and an editor that
+  /// opened with a complaint about the internet would be insufferable.
+  Future<void> maybeCheckForUpdates() async {
+    if (!workspace.autoUpdate) return;
+    // Never under `flutter test`: a suite that mounts the shell would otherwise
+    // reach the network, which is slow, flaky, and none of a test's business.
+    if (Platform.environment.containsKey('FLUTTER_TEST')) return;
+    if (!updates.dueForCheck(workspace.lastUpdateCheckMs)) return;
+    await updates.check();
+    workspace.rememberUpdateCheck(DateTime.now().millisecondsSinceEpoch);
+  }
 
   /// Bumped when `Ctrl+Shift+P` asks for the command palette.
   ///
@@ -1412,7 +1440,11 @@ class _LumitAppViewState extends State<LumitAppView> {
     // Overlay to put it in. It asks nothing on any later launch.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      maybeShowFirstRunFrb(context, context.read<LumitUiState>().workspace);
+      final ui = context.read<LumitUiState>();
+      // The update check follows the question rather than racing it: the
+      // setup screen is where somebody may have just switched it off (K-294).
+      maybeShowFirstRunFrb(context, ui.workspace)
+          .then((_) => ui.maybeCheckForUpdates());
     });
   }
 

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -42,6 +42,7 @@ import 'package:lumit_flutter/state/layer_bounds.dart';
 import 'package:lumit_flutter/state/preview_progress.dart';
 import 'package:lumit_flutter/state/render_timings.dart';
 import 'package:lumit_flutter/state/settings.dart';
+import 'package:lumit_flutter/state/install_site.dart';
 import 'package:lumit_flutter/state/tools.dart';
 import 'package:lumit_flutter/state/updates.dart';
 import 'package:lumit_flutter/state/workspace.dart';
@@ -193,6 +194,12 @@ String? projectPathFromArgs(List<String> args) {
 
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Sweep up after an update before anything else happens (K-297): delete the
+  // version we have just replaced, now that nothing is holding its files, and
+  // put it back if a swap was cut in half. Never throws and never blocks — a
+  // tidying problem is not a reason for an editor not to open.
+  tidyAfterUpdate(InstallSite.detect());
 
   await BridgeLib.init(handler: CustomHandler());
 

--- a/flutter_ui/lib/shell/first_run_frb.dart
+++ b/flutter_ui/lib/shell/first_run_frb.dart
@@ -2,9 +2,11 @@
 //
 // On the very first launch — a machine with no settings file — Lumit asks how
 // the user edits, and sets the two preferences of K-246 from the answer. That
-// is the whole screen: a preference primer, not a tour, and not a wizard. Every
-// setting it writes is an ordinary row in Settings ▸ Interface ▸ Editing
-// afterwards, so nothing here is a decision anybody is stuck with.
+// is the whole screen, plus the update tick along the bottom (K-294): a
+// preference primer, not a tour, and not a wizard. Every setting it writes is
+// an ordinary row in Settings afterwards — the editing pair under Interface ▸
+// Editing, the tick under General ▸ Updates — so nothing here is a decision
+// anybody is stuck with.
 //
 // It is deliberately plain for now. The four cards of docs/07 §13.1, each with
 // a small image showing what the choice does, are the destination; the owner
@@ -15,21 +17,29 @@ import 'package:flutter/widgets.dart';
 import '../state/workspace.dart';
 import '../widgets/controls.dart';
 
+/// What the screen comes back with: which editor, and whether Lumit should
+/// keep an eye out for new versions (K-294). The tick is on the screen rather
+/// than only in Settings because it is a decision about how Lumit behaves from
+/// now on, which is exactly what this screen is for.
+typedef FirstRunAnswer = ({bool? vegas, bool autoUpdate});
+
 /// Show the screen if this machine has never answered it, and record the
 /// answer. Does nothing at all on any later launch, so callers can call it
 /// unconditionally at start-up.
 Future<void> maybeShowFirstRunFrb(
     BuildContext context, Workspace workspace) async {
   if (workspace.firstRunDone) return;
-  final vegas = await showLumitModal<bool>(
+  final answer = await showLumitModal<FirstRunAnswer>(
     context: context,
-    initialSize: const Size(560, 340),
-    minSize: const Size(460, 300),
+    initialSize: const Size(560, 380),
+    minSize: const Size(460, 320),
     builder: (close) => _FirstRun(onChoose: close),
   );
-  // Null is the skip — the button, or a click on the scrim. Either way the
-  // question has been put, so it is not put again; skipping keeps the defaults,
-  // which is the After Effects shape.
+  // A null answer is a click on the scrim, which is the same as Skip: the
+  // question has been put, so it is not put again, and the defaults stand —
+  // the After Effects shape, with update checks on.
+  workspace.setAutoUpdate(answer?.autoUpdate ?? true);
+  final vegas = answer?.vegas;
   if (vegas == null) {
     workspace.skipFirstRun();
   } else {
@@ -37,9 +47,23 @@ Future<void> maybeShowFirstRunFrb(
   }
 }
 
-class _FirstRun extends StatelessWidget {
-  final ValueChanged<bool?> onChoose;
+class _FirstRun extends StatefulWidget {
+  final ValueChanged<FirstRunAnswer?> onChoose;
   const _FirstRun({required this.onChoose});
+
+  @override
+  State<_FirstRun> createState() => _FirstRunState();
+}
+
+class _FirstRunState extends State<_FirstRun> {
+  /// Ticked to begin with (K-294). Nothing is downloaded either way — this is
+  /// permission to look, not permission to fetch.
+  bool _autoUpdate = true;
+
+  /// Answer with both halves at once: the editor, and the update tick as it
+  /// stands when the choice is made.
+  void _answer(bool? vegas) =>
+      widget.onChoose((vegas: vegas, autoUpdate: _autoUpdate));
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +98,7 @@ class _FirstRun extends StatelessWidget {
                         blurb: 'Footage arrives as a layer, and the Retime '
                             'graph shows which moment of the source is on '
                             'screen.',
-                        onTap: () => onChoose(false),
+                        onTap: () => _answer(false),
                       ),
                     ),
                     const SizedBox(width: 10),
@@ -86,7 +110,7 @@ class _FirstRun extends StatelessWidget {
                             'into clips, and the Retime graph shows playback '
                             'speed you drag up to ramp and below zero to '
                             'reverse.',
-                        onTap: () => onChoose(true),
+                        onTap: () => _answer(true),
                       ),
                     ),
                   ],
@@ -96,13 +120,29 @@ class _FirstRun extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
+                  // The update tick sits beside Skip rather than in a section
+                  // of its own: it is a second, much smaller question, and
+                  // giving it a heading would suggest the two are equals.
+                  HouseCheckbox(
+                    key: const ValueKey('first-run-auto-update'),
+                    value: _autoUpdate,
+                    onChanged: (on) => setState(() => _autoUpdate = on),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Check for new versions of Lumit. Nothing is downloaded '
+                      'until you ask for it.',
+                      style: t.small.copyWith(color: t.textMuted),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
                   HouseButton(
                     key: const ValueKey('first-run-skip'),
                     small: true,
                     frameless: true,
-                    onPressed: () => onChoose(null),
+                    onPressed: () => _answer(null),
                     child: Text('Skip', style: t.small),
                   ),
                 ],

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -46,6 +46,7 @@ import 'export_dialog_frb.dart';
 import 'recovery_dialog_frb.dart';
 import 'project_settings_frb.dart';
 import 'settings_window_frb.dart';
+import 'update_dialog_frb.dart';
 
 /// One row of a menu: a label with an action, a submenu, or a divider.
 ///
@@ -62,6 +63,13 @@ class MenuEntry {
   final bool todo;
   final bool? checked;
 
+  /// What this row watches, for the few rows whose wording changes while the
+  /// menu is open. Null for every ordinary row — see [MenuEntry.live].
+  final Listenable? live;
+
+  /// How to rebuild this row when [live] fires. Null unless [live] is set.
+  final MenuEntry Function()? rebuild;
+
   const MenuEntry(
     this.label,
     this.onPressed, {
@@ -69,7 +77,9 @@ class MenuEntry {
     this.checked,
   })  : isDivider = false,
         children = null,
-        todo = false;
+        todo = false,
+        live = null,
+        rebuild = null;
 
   const MenuEntry.divider()
       : label = null,
@@ -78,14 +88,18 @@ class MenuEntry {
         isDivider = true,
         action = null,
         todo = false,
-        checked = null;
+        checked = null,
+        live = null,
+        rebuild = null;
 
   const MenuEntry.submenu(this.label, this.children)
       : onPressed = null,
         isDivider = false,
         action = null,
         todo = false,
-        checked = null;
+        checked = null,
+        live = null,
+        rebuild = null;
 
   /// A command the specification has and the build has not.
   const MenuEntry.todo(this.label, {this.action})
@@ -93,7 +107,32 @@ class MenuEntry {
         children = null,
         isDivider = false,
         todo = true,
+        checked = null,
+        live = null,
+        rebuild = null;
+
+  /// A row that redraws itself while its menu is open, from [rebuild], every
+  /// time [live] fires — and which does *not* close the menu when pressed.
+  ///
+  /// Only for rows where the press has visible consequences in the row itself:
+  /// Check for updates is the one, and it is the whole reason this exists
+  /// (K-294). Pressing it starts a check, the row greys and says so, and the
+  /// answer arrives in the same row a second or two later. A row that closed
+  /// the menu would leave the user pressing Help again to find out what
+  /// happened, and one that did not redraw would still say "Check for updates"
+  /// while it was checking.
+  const MenuEntry.live(Listenable this.live, MenuEntry Function() this.rebuild)
+      : label = null,
+        onPressed = null,
+        children = null,
+        isDivider = false,
+        action = null,
+        todo = false,
         checked = null;
+
+  /// This row as it currently reads. The same row for everything except a
+  /// [MenuEntry.live] one, which asks its builder.
+  MenuEntry get current => rebuild == null ? this : rebuild!();
 
   /// What the row reads as, suffix and all.
   String get text => todo ? '$label (Not implemented)' : (label ?? '');
@@ -130,9 +169,15 @@ class LumitMenuBarFrb extends StatelessWidget {
     // ValueNotifier that does not notify the shell state. Without this the bar
     // would keep whatever selection it was last built with, and every one of
     // those rows would be greyed out with a layer plainly selected.
+    // The updater is the second thing outside the shell state that a menu row
+    // reads (K-294): the Help row says what it is doing, and on macOS the whole
+    // tree is handed to the system, where there is no rebuilding a single row.
     return ValueListenableBuilder<List<LayerReference>>(
       valueListenable: context.read<LumitUiState>().selectedLayers,
-      builder: (context, _, __) => _bar(context),
+      builder: (context, _, __) => ListenableBuilder(
+        listenable: context.read<LumitUiState>().updates,
+        builder: (context, _) => _bar(context),
+      ),
     );
   }
 
@@ -619,7 +664,10 @@ List<MenuSection> lumitMenus(
     ]),
     (title: 'Help', items: [
       MenuEntry('About Lumit', () => showAboutWindowFrb(context)),
-      const MenuEntry.todo('Check for updates'),
+      MenuEntry.live(
+        ui.updates,
+        () => updateMenuEntry(context, app, ui, savePicker: savePicker),
+      ),
       const MenuEntry.divider(),
       const MenuEntry.todo('Lumit help'),
       const MenuEntry.todo('Lumit online guides'),
@@ -885,6 +933,34 @@ Future<void> saveProjectFrb(
   app.notifyDocumentChanged();
 }
 
+/// The Help ▸ Check for updates row, reading whatever the updater is doing
+/// (K-294).
+///
+/// Built fresh every time the service notifies, which is what makes one row
+/// carry the whole sequence: check, offer, download, restart. Disabled while
+/// something is in flight — a second press during a check would start a second
+/// one, and there is nothing useful for it to do.
+MenuEntry updateMenuEntry(
+  BuildContext context,
+  LumitState app,
+  LumitUiState ui, {
+  Future<String?> Function()? savePicker,
+}) {
+  final updates = ui.updates;
+  return MenuEntry(
+    updates.menuLabel,
+    updates.busy
+        ? null
+        : () => pressUpdateRow(
+              context,
+              updates: updates,
+              notice: app.postNotice,
+              projectIsDirty: () => app.project?.isDirty() ?? false,
+              saveProject: () => saveProjectFrb(app, ui, picker: savePicker),
+            ),
+  );
+}
+
 // --- The macOS renderer ---------------------------------------------------
 
 /// The same tree as native macOS menus.
@@ -910,11 +986,16 @@ List<PlatformMenuItem> platformMenusFor(
       group = [];
     }
 
-    for (final item in items) {
-      if (item.isDivider) {
+    for (final raw in items) {
+      if (raw.isDivider) {
         flush();
         continue;
       }
+      // A live row resolves to whatever it currently reads. The Mac menu is
+      // rebuilt whenever the bar is, and the bar watches the same object the
+      // row does, so this stays in step without the in-app renderer's
+      // rebuild-in-place machinery.
+      final item = raw.current;
       final label = switch (item.checked) {
         true => '✓ ${item.text}',
         false => '  ${item.text}',
@@ -1155,6 +1236,19 @@ class _MenuList extends StatelessWidget {
                     submenu: (dismiss) =>
                         _MenuList(items: children, close: dismiss),
                     child: _label(t, item, ticks: ticks, shortcut: null),
+                  )
+                else if (item.live case final listenable?)
+                  // Stays open and redraws in place: the point of a live row is
+                  // to watch what pressing it did (K-294).
+                  ListenableBuilder(
+                    listenable: listenable,
+                    builder: (context, _) {
+                      final row = item.current;
+                      return MenuRow(
+                        onPressed: row.onPressed ?? () {},
+                        child: _label(t, row, ticks: ticks, shortcut: null),
+                      );
+                    },
                   )
                 else
                   MenuRow(

--- a/flutter_ui/lib/shell/settings_window_frb.dart
+++ b/flutter_ui/lib/shell/settings_window_frb.dart
@@ -40,12 +40,16 @@ import 'package:provider/provider.dart';
 import '../state/file_dialogs.dart';
 import '../state/keymap.dart';
 import '../state/settings.dart';
+import '../state/updates.dart';
 import '../state/workspace.dart';
 import '../theme/theme.dart';
 import '../widgets/controls.dart';
+import 'about_window_frb.dart';
 import 'cache_confirm_frb.dart';
+import 'menu_bar_frb.dart';
 import 'settings_rows.dart';
 import 'theme_editor_frb.dart';
+import 'update_dialog_frb.dart';
 
 /// The smallest budget worth setting, in MiB. Below this the cache holds a
 /// frame or two and costs more in bookkeeping than it saves.
@@ -209,9 +213,71 @@ class _SettingsWindowState extends State<_SettingsWindow> {
             ),
           ),
         ]),
+        // The same updater the Help menu drives, seen from the other side
+        // (K-294): one service, two views, so they can never disagree about
+        // whether a check is running or an update is waiting.
+        settingsSection(t, 'Updates', [
+          settingsRow(
+            t,
+            'Automatic updates',
+            'Look for a new version of Lumit when it starts, at most once a '
+                'day. Nothing is downloaded until you ask for it.',
+            HouseCheckbox(
+              key: const ValueKey('settings-auto-update'),
+              value: ui.workspace.autoUpdate,
+              onChanged: (on) =>
+                  setState(() => ui.workspace.setAutoUpdate(on)),
+            ),
+          ),
+          // The whole row watches the service, not just its button: the line
+          // under the title is the part that says what was found, and a stale
+          // sentence beside a live button would be worse than either alone.
+          ListenableBuilder(
+            listenable: ui.updates,
+            builder: (context, _) => settingsRow(
+              t,
+              'This version',
+              _updateStatusLine(ui),
+              HouseButton(
+                key: const ValueKey('settings-check-updates'),
+                small: true,
+                onPressed: ui.updates.busy
+                    ? null
+                    : () => pressUpdateRow(
+                          context,
+                          updates: ui.updates,
+                          notice: context.read<LumitState>().postNotice,
+                          projectIsDirty: () =>
+                              context.read<LumitState>().project?.isDirty() ??
+                              false,
+                          saveProject: () =>
+                              saveProjectFrb(context.read<LumitState>(), ui),
+                        ),
+                child: Text(ui.updates.menuLabel, style: t.small),
+              ),
+            ),
+          ),
+        ]),
         // About used to sit here. It is Help ▸ About Lumit now (K-244):
         // Settings is for what you change, and a version number is not that.
       ];
+
+  /// The line under "This version": what is installed, and what the last check
+  /// made of it. Rebuilt with the row, so it follows the service too.
+  String _updateStatusLine(LumitUiState ui) {
+    final installed = 'Lumit ${versionFromBootLine(lumitVersion()) ?? '?'}';
+    return switch (ui.updates.stage) {
+      UpdateStage.upToDate => '$installed — the newest there is.',
+      UpdateStage.available =>
+        '$installed. Lumit ${ui.updates.release?.version} is available.',
+      UpdateStage.ready =>
+        '$installed. Lumit ${ui.updates.release?.version} is downloaded and '
+            'installs when Lumit restarts.',
+      UpdateStage.failed =>
+        '$installed. ${ui.updates.failure ?? 'The last check did not finish.'}',
+      _ => installed,
+    };
+  }
 
   List<Widget> _appearance(LumitTheme t, LumitUiState ui) => [
         settingsSection(t, 'Theme', [

--- a/flutter_ui/lib/shell/update_dialog_frb.dart
+++ b/flutter_ui/lib/shell/update_dialog_frb.dart
@@ -355,7 +355,7 @@ class _RestartToFinish extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = ThemeScope.of(context).theme;
     return FloatSurface(
-      width: 420,
+      width: 460,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -385,8 +385,15 @@ class _RestartToFinish extends StatelessWidget {
           const SizedBox(height: 14),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
+            // A Wrap rather than a Row: with unsaved work there are three
+            // buttons and one of them is a whole sentence, which overflowed the
+            // window and pushed Save and restart off the right edge. Wrapping
+            // holds however wide the UI scale makes these labels, rather than
+            // depending on a width that happens to fit at 100%.
+            child: Wrap(
+              alignment: WrapAlignment.end,
+              spacing: 8,
+              runSpacing: 8,
               children: [
                 HouseButton(
                   key: const ValueKey('update-restart-later'),
@@ -395,7 +402,6 @@ class _RestartToFinish extends StatelessWidget {
                   onPressed: () => onChoose(_RestartAnswer.later),
                   child: Text('Later', style: t.small),
                 ),
-                const SizedBox(width: 8),
                 if (quits && dirty) ...[
                   HouseButton(
                     key: const ValueKey('update-restart-now'),
@@ -404,7 +410,6 @@ class _RestartToFinish extends StatelessWidget {
                     onPressed: () => onChoose(_RestartAnswer.restart),
                     child: Text('Restart without saving', style: t.small),
                   ),
-                  const SizedBox(width: 8),
                   HouseButton(
                     key: const ValueKey('update-save-restart'),
                     small: true,

--- a/flutter_ui/lib/shell/update_dialog_frb.dart
+++ b/flutter_ui/lib/shell/update_dialog_frb.dart
@@ -1,0 +1,430 @@
+// The windows an update puts up, and the order they come in (K-294).
+//
+// # In plain terms
+//
+// `state/updates.dart` knows how to find a newer Lumit and fetch it. This file
+// is the part the user sees: the one question before a few hundred megabytes
+// are downloaded, the progress while it comes, and the restart at the end —
+// with the offer to save first, because the update cannot finish while Lumit is
+// running and nobody should lose an evening's work to a version number.
+//
+// Nothing here decides anything about updating. It asks, it shows, and it calls
+// back into the service, so the two can be read separately: what an update *is*
+// over there, what it *looks like* here.
+
+import 'package:flutter/widgets.dart';
+
+import '../state/updates.dart';
+import '../widgets/controls.dart';
+
+/// Act on the Help ▸ Check for updates row, whatever it currently says.
+///
+/// One entry point for the menu row and the Settings button both, so the two
+/// cannot come to mean different things. [saveProject] is passed in rather than
+/// reached for: saving belongs to the shell's File menu, and a dialogue that
+/// imported it would tie this file to the menu bar that calls it.
+Future<void> pressUpdateRow(
+  BuildContext context, {
+  required UpdateService updates,
+  required void Function(String message, {bool error}) notice,
+  required bool Function() projectIsDirty,
+  required Future<void> Function() saveProject,
+}) async {
+  // In flight: the row is disabled anyway, and a second press should not start
+  // a second check.
+  if (updates.busy) return;
+
+  if (updates.stage == UpdateStage.available) {
+    await _offerAndFetch(
+      context,
+      updates: updates,
+      notice: notice,
+      projectIsDirty: projectIsDirty,
+      saveProject: saveProject,
+    );
+    return;
+  }
+
+  if (updates.stage == UpdateStage.ready) {
+    await _askAboutRestart(
+      context,
+      updates: updates,
+      projectIsDirty: projectIsDirty,
+      saveProject: saveProject,
+    );
+    return;
+  }
+
+  // Idle, up to date, or a check that did not finish: all three are "ask
+  // again", and what comes back is said in the status line as well as in the
+  // row, because the row is a menu somebody has probably just closed.
+  await updates.check();
+  switch (updates.stage) {
+    case UpdateStage.upToDate:
+      notice('Lumit is up to date');
+    case UpdateStage.failed:
+      notice(updates.failure ?? 'Could not check for updates', error: true);
+    case UpdateStage.available:
+      notice('Lumit ${updates.release?.version} is available');
+    default:
+      break;
+  }
+}
+
+/// Ask, download, then move on to the restart question.
+Future<void> _offerAndFetch(
+  BuildContext context, {
+  required UpdateService updates,
+  required void Function(String message, {bool error}) notice,
+  required bool Function() projectIsDirty,
+  required Future<void> Function() saveProject,
+}) async {
+  final release = updates.release;
+  if (release == null) return;
+
+  final go = await showLumitModal<bool>(
+    context: context,
+    builder: (close) => _OfferUpdate(release: release, onChoose: close),
+  );
+  if (go != true || !context.mounted) return;
+
+  // Started first, shown second: the dialogue watches the service, and the
+  // service is what is doing the work.
+  final downloading = updates.downloadUpdate();
+  // Dismissing this window (the scrim, or Cancel arriving late) does not stop
+  // the download — the service owns that, and only the Cancel button asks it
+  // to stop. So the flow waits for the download itself below, whichever way the
+  // window went.
+  await showLumitModal<void>(
+    context: context,
+    builder: (close) => _DownloadProgress(
+      updates: updates,
+      release: release,
+      onDone: () => close(null),
+      onCancel: updates.cancelDownload,
+    ),
+  );
+  await downloading;
+
+  if (updates.stage == UpdateStage.failed) {
+    notice(updates.failure ?? 'Could not download the update', error: true);
+    return;
+  }
+  if (updates.stage != UpdateStage.ready || !context.mounted) return;
+  await _askAboutRestart(
+    context,
+    updates: updates,
+    projectIsDirty: projectIsDirty,
+    saveProject: saveProject,
+  );
+}
+
+/// The last window: restart now, or later, and save first if there is work
+/// open.
+Future<void> _askAboutRestart(
+  BuildContext context, {
+  required UpdateService updates,
+  required bool Function() projectIsDirty,
+  required Future<void> Function() saveProject,
+}) async {
+  final answer = await showLumitModal<_RestartAnswer>(
+    context: context,
+    builder: (close) => _RestartToFinish(
+      version: updates.release?.version ?? '',
+      dirty: projectIsDirty(),
+      quits: updates.installQuits,
+      onChoose: close,
+    ),
+  );
+  // Later keeps the downloaded installer and the row that offers it: the
+  // update is still ready, and the next press of it comes straight back here.
+  if (answer == null || answer == _RestartAnswer.later) return;
+  if (answer == _RestartAnswer.saveAndRestart) await saveProject();
+  await updates.install();
+}
+
+/// What the restart window can be answered with.
+enum _RestartAnswer { restart, saveAndRestart, later }
+
+/// "There is a newer Lumit — shall I fetch it?", with what that costs.
+class _OfferUpdate extends StatelessWidget {
+  final UpdateRelease release;
+  final ValueChanged<bool?> onChoose;
+
+  const _OfferUpdate({required this.release, required this.onChoose});
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    return FloatSurface(
+      width: 400,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Text('Update to Lumit ${release.version}?',
+                style: t.bodyPrimary),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Text(
+              '${release.assetName} is ${release.sizeLabel}. Lumit downloads '
+              'it now and installs it when you restart, so you can carry on '
+              'working in the meantime.',
+              style: t.small.copyWith(color: t.textMuted),
+            ),
+          ),
+          const SizedBox(height: 14),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HouseButton(
+                  key: const ValueKey('update-offer-no'),
+                  small: true,
+                  frameless: true,
+                  onPressed: () => onChoose(false),
+                  child: Text('Not now', style: t.small),
+                ),
+                const SizedBox(width: 8),
+                HouseButton(
+                  key: const ValueKey('update-offer-yes'),
+                  small: true,
+                  onPressed: () => onChoose(true),
+                  child: Text('Download', style: t.small),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+        ],
+      ),
+    );
+  }
+}
+
+/// The download, while it happens. Closes itself the moment the service leaves
+/// the downloading stage, however it left — finished, cancelled or failed.
+class _DownloadProgress extends StatefulWidget {
+  final UpdateService updates;
+  final UpdateRelease release;
+  final VoidCallback onDone;
+  final VoidCallback onCancel;
+
+  const _DownloadProgress({
+    required this.updates,
+    required this.release,
+    required this.onDone,
+    required this.onCancel,
+  });
+
+  @override
+  State<_DownloadProgress> createState() => _DownloadProgressState();
+}
+
+class _DownloadProgressState extends State<_DownloadProgress> {
+  @override
+  void initState() {
+    super.initState();
+    widget.updates.addListener(_onChange);
+    // A download can be over before this window is on screen — a small file, a
+    // fast connection, a failure at the first byte. Without this the window
+    // would sit there waiting for a notification that has already been sent.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.updates.stage != UpdateStage.downloading) {
+        widget.onDone();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.updates.removeListener(_onChange);
+    super.dispose();
+  }
+
+  void _onChange() {
+    if (!mounted) return;
+    if (widget.updates.stage == UpdateStage.downloading) {
+      setState(() {});
+      return;
+    }
+    // Closing from inside a notification would be a window disposing itself
+    // mid-build; the next frame is soon enough and always safe.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) widget.onDone();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    final fraction = widget.updates.progress;
+    final done = (widget.release.assetBytes * fraction / (1 << 20)).round();
+    return FloatSurface(
+      width: 400,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Text('Downloading Lumit ${widget.release.version}',
+                style: t.bodyPrimary),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // A plain bar in the theme's own colours: the shell has no
+                // progress control of its own, and this is one rectangle.
+                Container(
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: t.surface3,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: FractionallySizedBox(
+                    alignment: Alignment.centerLeft,
+                    widthFactor: fraction.clamp(0.0, 1.0).toDouble(),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: t.accent,
+                        borderRadius: BorderRadius.circular(3),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  '$done MB of ${widget.release.sizeLabel}',
+                  style: t.small.copyWith(color: t.textMuted),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HouseButton(
+                  key: const ValueKey('update-download-cancel'),
+                  small: true,
+                  frameless: true,
+                  onPressed: widget.onCancel,
+                  child: Text('Cancel', style: t.small),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+        ],
+      ),
+    );
+  }
+}
+
+/// The end of the update: it is on disk, and applying it means closing Lumit.
+class _RestartToFinish extends StatelessWidget {
+  final String version;
+
+  /// Whether the open project has unsaved work, which is what puts the save
+  /// button on this window rather than leaving the choice to be regretted.
+  final bool dirty;
+
+  /// Whether finishing means quitting at all — on Linux the download is only
+  /// revealed, so this window says that instead.
+  final bool quits;
+
+  final ValueChanged<_RestartAnswer?> onChoose;
+
+  const _RestartToFinish({
+    required this.version,
+    required this.dirty,
+    required this.quits,
+    required this.onChoose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    return FloatSurface(
+      width: 420,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Text(
+              quits
+                  ? 'Restart to finish updating'
+                  : 'Lumit $version is downloaded',
+              style: t.bodyPrimary,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Text(
+              quits
+                  ? 'Lumit $version is downloaded. It installs while Lumit is '
+                      'closed, so the update finishes the next time you open '
+                      'it.${dirty ? ' This project has unsaved changes.' : ''}'
+                  : 'Open the downloaded file to install it. Lumit does not '
+                      'unpack it for you, because where it goes is yours to '
+                      'choose.',
+              style: t.small.copyWith(color: t.textMuted),
+            ),
+          ),
+          const SizedBox(height: 14),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HouseButton(
+                  key: const ValueKey('update-restart-later'),
+                  small: true,
+                  frameless: true,
+                  onPressed: () => onChoose(_RestartAnswer.later),
+                  child: Text('Later', style: t.small),
+                ),
+                const SizedBox(width: 8),
+                if (quits && dirty) ...[
+                  HouseButton(
+                    key: const ValueKey('update-restart-now'),
+                    small: true,
+                    frameless: true,
+                    onPressed: () => onChoose(_RestartAnswer.restart),
+                    child: Text('Restart without saving', style: t.small),
+                  ),
+                  const SizedBox(width: 8),
+                  HouseButton(
+                    key: const ValueKey('update-save-restart'),
+                    small: true,
+                    onPressed: () => onChoose(_RestartAnswer.saveAndRestart),
+                    child: Text('Save and restart', style: t.small),
+                  ),
+                ] else
+                  HouseButton(
+                    key: const ValueKey('update-restart-now'),
+                    small: true,
+                    onPressed: () => onChoose(_RestartAnswer.restart),
+                    child: Text(quits ? 'Restart now' : 'Show the file',
+                        style: t.small),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_ui/lib/shell/update_dialog_frb.dart
+++ b/flutter_ui/lib/shell/update_dialog_frb.dart
@@ -132,7 +132,7 @@ Future<void> _askAboutRestart(
     builder: (close) => _RestartToFinish(
       version: updates.release?.version ?? '',
       dirty: projectIsDirty(),
-      quits: updates.installQuits,
+      delivery: updates.delivery,
       onChoose: close,
     ),
   );
@@ -338,18 +338,22 @@ class _RestartToFinish extends StatelessWidget {
   /// button on this window rather than leaving the choice to be regretted.
   final bool dirty;
 
-  /// Whether finishing means quitting at all — on Linux the download is only
-  /// revealed, so this window says that instead.
-  final bool quits;
+  /// How the update will be applied (K-297), which is what this window is
+  /// really about: a swap and a restart, an installer and a restart, or a file
+  /// handed to Flatpak while Lumit stays open.
+  final UpdateDelivery delivery;
 
   final ValueChanged<_RestartAnswer?> onChoose;
 
   const _RestartToFinish({
     required this.version,
     required this.dirty,
-    required this.quits,
+    required this.delivery,
     required this.onChoose,
   });
+
+  /// Whether finishing means leaving. False only for the Flatpak hand-off.
+  bool get quits => delivery != UpdateDelivery.flatpakBundle;
 
   @override
   Widget build(BuildContext context) {
@@ -372,13 +376,26 @@ class _RestartToFinish extends StatelessWidget {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 10),
             child: Text(
-              quits
-                  ? 'Lumit $version is downloaded. It installs while Lumit is '
+              switch (delivery) {
+                // The Chrome-shaped one: no installer, no questions, a restart
+                // that lands in the new version a second later.
+                UpdateDelivery.inPlace =>
+                  'Lumit $version is ready. Restarting puts it in place and '
+                      'opens it — no installer, and nothing to answer.'
+                      '${dirty ? ' This project has unsaved changes.' : ''}',
+                UpdateDelivery.installer =>
+                  'Lumit $version is downloaded. It installs while Lumit is '
                       'closed, so the update finishes the next time you open '
-                      'it.${dirty ? ' This project has unsaved changes.' : ''}'
-                  : 'Open the downloaded file to install it. Lumit does not '
-                      'unpack it for you, because where it goes is yours to '
-                      'choose.',
+                      'it.${dirty ? ' This project has unsaved changes.' : ''}',
+                // Inside the sandbox the files are not ours to replace, so the
+                // bundle is handed over and Flatpak does the rest.
+                UpdateDelivery.flatpakBundle =>
+                  'Lumit installs its own updates everywhere except here: a '
+                      'Flatpak is updated by Flatpak. The bundle is '
+                      'downloaded — install it with\n\n'
+                      '    flatpak install --user lumit-$version-linux-x64'
+                      '.flatpak',
+              },
               style: t.small.copyWith(color: t.textMuted),
             ),
           ),

--- a/flutter_ui/lib/state/install_site.dart
+++ b/flutter_ui/lib/state/install_site.dart
@@ -120,7 +120,12 @@ class InstallSite {
   /// Work out where we are from the running executable.
   ///
   /// [executablePath] and the two probes are injected so a test can describe an
-  /// installation that does not exist on the machine running the test.
+  /// installation that does not exist on the machine running the test — which
+  /// is why the path is taken apart *here* rather than with `File.parent`: that
+  /// splits on whatever separator the machine running the code uses, so a
+  /// Windows path handed to it on any other platform comes back as `.`, and the
+  /// whole install site is then nonsense. The operating system is a parameter,
+  /// so the separator has to be one too.
   static InstallSite detect({
     String? executablePath,
     String? operatingSystem,
@@ -129,6 +134,21 @@ class InstallSite {
     final exe = executablePath ?? Platform.resolvedExecutable;
     final os = operatingSystem ?? Platform.operatingSystem;
     final flatpak = isFlatpak ?? (path) => File(path).existsSync();
+    // Windows accepts both separators; everywhere else a backslash is an
+    // ordinary character in a name and must not split anything.
+    // Escaped rather than raw: a raw string cannot end in a backslash.
+    final sep = os == 'windows' ? '\\' : '/';
+    final split = os == 'windows' ? RegExp(r'[/\\]') : RegExp(r'/');
+
+    String parentOf(String path) {
+      final parts = path.split(split);
+      if (parts.length <= 1) return path;
+      parts.removeLast();
+      // A leading empty part is the root slash, and joining keeps it.
+      return parts.join(sep);
+    }
+
+    String join(String dir, String name) => '$dir$sep$name';
 
     // A Flatpak announces itself with a file the sandbox always carries. Asked
     // first, because inside the sandbox the paths below look perfectly ordinary
@@ -136,38 +156,39 @@ class InstallSite {
     if (os == 'linux' && flatpak('/.flatpak-info')) {
       return InstallSite(
         kind: InstallKind.flatpak,
-        root: File(exe).parent,
+        root: Directory(parentOf(exe)),
         launcher: File(exe),
       );
     }
 
     if (os == 'macos') {
-      // …/Lumit.app/Contents/MacOS/lumit_flutter — the bundle is three levels
-      // up, and only if the layout really is a bundle.
-      final macos = File(exe).parent;
-      final contents = macos.parent;
-      final app = contents.parent;
-      if (macos.path.endsWith('MacOS') &&
-          contents.path.endsWith('Contents') &&
-          app.path.endsWith('.app')) {
+      // …/Lumit.app/Contents/MacOS/Lumit — the bundle is three levels up, and
+      // only if the layout really is a bundle.
+      final macos = parentOf(exe);
+      final contents = parentOf(macos);
+      final app = parentOf(contents);
+      if (macos.endsWith('MacOS') &&
+          contents.endsWith('Contents') &&
+          app.endsWith('.app')) {
         return InstallSite(
           kind: InstallKind.bundle,
-          root: Directory(app.path),
-          launcher: File('${app.path}/Contents/MacOS/${_name(exe)}'),
+          root: Directory(app),
+          launcher: File(join(join(join(app, 'Contents'), 'MacOS'),
+              _name(exe))),
         );
       }
       return InstallSite(
         kind: InstallKind.unknown,
-        root: File(exe).parent,
+        root: Directory(parentOf(exe)),
         launcher: File(exe),
       );
     }
 
-    final folder = File(exe).parent;
+    final folder = parentOf(exe);
     return InstallSite(
       kind: InstallKind.folder,
-      root: Directory(folder.path),
-      launcher: File('${folder.path}${Platform.pathSeparator}${_name(exe)}'),
+      root: Directory(folder),
+      launcher: File(join(folder, _name(exe))),
     );
   }
 

--- a/flutter_ui/lib/state/install_site.dart
+++ b/flutter_ui/lib/state/install_site.dart
@@ -1,0 +1,274 @@
+// Where this copy of Lumit lives, and whether it is allowed to replace itself
+// (K-297).
+//
+// # In plain terms
+//
+// Chrome, VS Code and Discord update without ever showing you an installer.
+// The trick is not clever patching — it is *where they live*. They install into
+// your own user folder, which you can write to without an administrator, so the
+// application can simply put the new files down beside the old ones and swap
+// them over. An application in `Program Files` cannot: replacing anything there
+// needs elevation, which is why it has to hand the job to an installer that
+// asks for it.
+//
+// So Lumit installs per user now (K-297), and this file is the part that knows:
+//
+//   1. **Where the application is** — the folder on Windows and Linux, the
+//      `Lumit.app` bundle on macOS.
+//   2. **Whether it can be replaced from inside** — a Flatpak cannot, by design:
+//      the sandbox is read-only and updating is Flatpak's job, not ours.
+//   3. **How the swap is done** — the whole new version is unpacked *beside* the
+//      old one and then two renames put it in place.
+//
+// **Why two renames rather than copying files over the top.** Renaming a folder
+// is one filesystem operation: either it happened or it did not. Copying a few
+// hundred files over a running application is a few hundred chances to be
+// interrupted half way, leaving a Lumit that is neither the old version nor the
+// new one and may not start at all. So: `Lumit` becomes `Lumit.old`, `Lumit.new`
+// becomes `Lumit`, and the only moment of danger is the hair's breadth between
+// the two — and if the second rename fails, the first is undone immediately,
+// because the code doing it is already in memory and does not need the files on
+// disk any more.
+//
+// The old folder is left behind deliberately: its files are still open in the
+// running process, and Windows will not delete a loaded DLL. It is swept up on
+// the next launch, from the new copy, when nothing is holding it.
+
+import 'dart:io';
+
+/// What kind of installation this is, which is what decides whether Lumit can
+/// update itself and what a release attachment has to contain.
+enum InstallKind {
+  /// A folder of files, the usual Windows and Linux shape. The folder's
+  /// *contents* are the application, and the folder keeps its path so Start
+  /// Menu entries and file associations still point at it.
+  folder,
+
+  /// A macOS `.app` bundle, which is a folder the system treats as one thing.
+  /// The bundle itself is what gets swapped.
+  bundle,
+
+  /// A Flatpak. The application cannot write to its own files — that is the
+  /// point of the sandbox — so updating belongs to Flatpak (K-297).
+  flatpak,
+
+  /// Somewhere Lumit cannot reason about: a build tree, a test harness, an
+  /// unusual layout. Never updated in place; the installer is the answer.
+  unknown,
+}
+
+/// The marker written into a staged tree once every byte of it is there.
+///
+/// Without it an interrupted download or a half-finished unpack would look
+/// exactly like a complete update waiting to be applied, and the swap would put
+/// a partial Lumit in place of a working one.
+const String stagedUpdateMarker = '.lumit-staged';
+
+/// This installation: where it is, what shape it is, and what to start again
+/// when the swap is done.
+class InstallSite {
+  final InstallKind kind;
+
+  /// The thing that gets replaced: the install folder, or the `.app` bundle.
+  final Directory root;
+
+  /// What to run to start Lumit again, *after* the swap — so it is expressed
+  /// against [root] rather than being the path this process was started from,
+  /// which by then names a folder called `Lumit.old`.
+  final File launcher;
+
+  const InstallSite({
+    required this.kind,
+    required this.root,
+    required this.launcher,
+  });
+
+  /// Where the new version is unpacked: beside the old one, so the swap is a
+  /// rename rather than a copy across filesystems.
+  Directory get staging => Directory('${root.path}.new');
+
+  /// Where the old version waits to be swept up, after the swap.
+  Directory get previous => Directory('${root.path}.old');
+
+  /// Where a download is unpacked before it is known to be whole. Also a
+  /// sibling, for the same reason.
+  Directory get unpacking => Directory('${root.path}.unpacking');
+
+  /// Whether Lumit may replace itself here.
+  ///
+  /// Two questions, both of which have to be yes: is this a shape we know how
+  /// to swap, and can we actually write beside it? The second is asked of the
+  /// filesystem rather than assumed from the path — an installation copied to a
+  /// read-only volume or left in `Program Files` by an older installer answers
+  /// no, and gets the installer route instead of a confusing failure.
+  bool get replaceable {
+    if (kind != InstallKind.folder && kind != InstallKind.bundle) return false;
+    return _parentIsWritable;
+  }
+
+  bool get _parentIsWritable {
+    try {
+      final probe = File('${root.path}.write-probe');
+      probe.writeAsStringSync('');
+      probe.deleteSync();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Work out where we are from the running executable.
+  ///
+  /// [executablePath] and the two probes are injected so a test can describe an
+  /// installation that does not exist on the machine running the test.
+  static InstallSite detect({
+    String? executablePath,
+    String? operatingSystem,
+    bool Function(String path)? isFlatpak,
+  }) {
+    final exe = executablePath ?? Platform.resolvedExecutable;
+    final os = operatingSystem ?? Platform.operatingSystem;
+    final flatpak = isFlatpak ?? (path) => File(path).existsSync();
+
+    // A Flatpak announces itself with a file the sandbox always carries. Asked
+    // first, because inside the sandbox the paths below look perfectly ordinary
+    // and would suggest a swap that cannot work.
+    if (os == 'linux' && flatpak('/.flatpak-info')) {
+      return InstallSite(
+        kind: InstallKind.flatpak,
+        root: File(exe).parent,
+        launcher: File(exe),
+      );
+    }
+
+    if (os == 'macos') {
+      // …/Lumit.app/Contents/MacOS/lumit_flutter — the bundle is three levels
+      // up, and only if the layout really is a bundle.
+      final macos = File(exe).parent;
+      final contents = macos.parent;
+      final app = contents.parent;
+      if (macos.path.endsWith('MacOS') &&
+          contents.path.endsWith('Contents') &&
+          app.path.endsWith('.app')) {
+        return InstallSite(
+          kind: InstallKind.bundle,
+          root: Directory(app.path),
+          launcher: File('${app.path}/Contents/MacOS/${_name(exe)}'),
+        );
+      }
+      return InstallSite(
+        kind: InstallKind.unknown,
+        root: File(exe).parent,
+        launcher: File(exe),
+      );
+    }
+
+    final folder = File(exe).parent;
+    return InstallSite(
+      kind: InstallKind.folder,
+      root: Directory(folder.path),
+      launcher: File('${folder.path}${Platform.pathSeparator}${_name(exe)}'),
+    );
+  }
+
+  static String _name(String path) =>
+      path.split(RegExp(r'[/\\]')).where((p) => p.isNotEmpty).last;
+}
+
+/// Whether a complete new version is sitting in [site]'s staging folder,
+/// waiting for the swap.
+bool stagedUpdateReady(InstallSite site) =>
+    File('${site.staging.path}${Platform.pathSeparator}$stagedUpdateMarker')
+        .existsSync();
+
+/// Mark a staged tree complete. Called once the unpack has finished and every
+/// file has been checked, and never before.
+void markStagedUpdateReady(InstallSite site) =>
+    File('${site.staging.path}${Platform.pathSeparator}$stagedUpdateMarker')
+        .writeAsStringSync('ready\n');
+
+/// Put the staged version in place: two renames, and an undo if the second one
+/// does not happen.
+///
+/// Throws when it could not be done *and* the old version is back where it was,
+/// which is the only failure a caller can carry on from. Returns normally when
+/// Lumit's files on disk are now the new version — at which point the running
+/// process is the old one and has to be replaced by starting [InstallSite
+/// .launcher] again.
+void swapInStagedUpdate(InstallSite site) {
+  if (!stagedUpdateReady(site)) {
+    throw StateError('no complete update is staged');
+  }
+  // A leftover from a previous update would make the first rename fail. It is
+  // only ever the version before last, and nothing is holding it now.
+  _removeQuietly(site.previous);
+
+  site.root.renameSync(site.previous.path);
+  try {
+    site.staging.renameSync(site.root.path);
+  } catch (error) {
+    // The dangerous half-second. Undo it now, while this code is in memory and
+    // does not need anything on disk: leaving the application with no folder at
+    // all is the one outcome worth going to lengths to avoid.
+    try {
+      site.previous.renameSync(site.root.path);
+    } catch (_) {
+      // Both renames failed, which means the filesystem is refusing us
+      // entirely. Nothing here can fix that; the error below says so.
+    }
+    rethrow;
+  }
+}
+
+/// Tidy up at start-up: finish what an interrupted update left behind.
+///
+/// Three states worth acting on, in the order they are checked:
+///
+///  * **The application folder is missing and the old one is there.** The swap
+///    was cut in half — put the old version back. (Only reachable if the
+///    machine stopped between the two renames, since the swap itself undoes a
+///    failure; belt as well as braces.)
+///  * **An old version is lying about.** The update worked and we are running
+///    from the new copy, so nothing holds those files any more: delete them.
+///  * **A staged tree that was never marked complete.** An abandoned download.
+///    Delete it, or it will be mistaken for an update that is ready.
+///
+/// Never throws: this runs before the window opens, and no cleanup problem is a
+/// reason for Lumit not to start.
+void tidyAfterUpdate(InstallSite site) {
+  try {
+    if (!site.root.existsSync() && site.previous.existsSync()) {
+      site.previous.renameSync(site.root.path);
+      return;
+    }
+    if (site.previous.existsSync()) _removeQuietly(site.previous);
+    if (site.staging.existsSync() && !stagedUpdateReady(site)) {
+      _removeQuietly(site.staging);
+    }
+    _removeQuietly(site.unpacking);
+  } catch (_) {
+    // Best effort by design — see the doc comment.
+  }
+}
+
+/// The tree an archive unpacked to, with a single wrapping folder taken off.
+///
+/// The Linux tarball holds `lumit-0.2.0-linux-x64/…` and the macOS archive
+/// holds `Lumit.app/…`, while the Windows archive is the files themselves. One
+/// rule covers all three: if the unpacked folder holds exactly one directory
+/// and nothing else, that directory *is* the application.
+Directory unwrapSingleFolder(Directory unpacked) {
+  final entries = unpacked.listSync();
+  if (entries.length == 1 && entries.single is Directory) {
+    return Directory(entries.single.path);
+  }
+  return unpacked;
+}
+
+void _removeQuietly(Directory dir) {
+  try {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  } catch (_) {
+    // A folder we cannot delete costs disk space and nothing else.
+  }
+}

--- a/flutter_ui/lib/state/updates.dart
+++ b/flutter_ui/lib/state/updates.dart
@@ -1,0 +1,618 @@
+// Looking for a newer Lumit, and fetching it (K-294).
+//
+// # In plain terms
+//
+// Releases are published as GitHub Releases on a `v*` tag, and every one of
+// them carries the finished installers as attachments: a `setup.exe` for
+// Windows, a `.dmg` for macOS, a `.tar.gz` and a `.flatpak` for Linux. So
+// "is there a newer Lumit?" is one small web request — GitHub will say what the
+// latest release is called and what is attached to it — and "get it" is an
+// ordinary download of the attachment that suits this machine.
+//
+// This file is that, and nothing else: it knows the versions, the download and
+// the file on disk. It draws no windows and it never quits the application; the
+// shell does both (`shell/update_dialog_frb.dart`), because *when* to ask the
+// user something is a question about the interface, not about updating.
+//
+// **Full installers, never patches (K-294).** The download is the whole
+// installer every time. A patch system means publishing a patch per pair of
+// versions, a tool to apply them, and a fallback for when the pair is missing —
+// three new things that can go wrong to save bandwidth GitHub gives us for
+// nothing. A few hundred megabytes, once in a while, on a deliberate click.
+//
+// **Nothing is downloaded behind the user's back.** With automatic updates on,
+// Lumit *looks* on launch, at most once a day, and says what it found in the
+// menu. Fetching the installer always waits for a click — this is a video
+// application, and someone who is mid-edit on a hotel connection should not
+// discover Lumit spending their data.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+
+/// The repository releases are published from (K-279: the website reads the
+/// same one).
+const String updatesRepository = 'luminalmvm/lumit';
+
+/// Where the newest release is described.
+Uri get latestReleaseUrl =>
+    Uri.parse('https://api.github.com/repos/$updatesRepository/releases/latest');
+
+/// How long a check is good for. A day: long enough that launching Lumit six
+/// times in a morning asks GitHub once, short enough that a release is noticed
+/// the day after it lands.
+const Duration updateCheckInterval = Duration(hours: 24);
+
+/// Where the state machine has got to.
+///
+/// The order is the order a successful update walks through them; [upToDate]
+/// and [failed] are both endings that go back to being able to check again.
+enum UpdateStage {
+  /// Nothing has been asked yet this session.
+  idle,
+
+  /// A check is in flight.
+  checking,
+
+  /// Checked, and this is the newest Lumit there is.
+  upToDate,
+
+  /// A newer release exists and has an installer for this machine.
+  available,
+
+  /// That installer is coming down now.
+  downloading,
+
+  /// It is on disk, verified, and waiting for a restart.
+  ready,
+
+  /// The check or the download did not finish. Recoverable: the menu goes back
+  /// to offering a check.
+  failed,
+}
+
+/// A release that is newer than this build, and the file to fetch for it.
+@immutable
+class UpdateRelease {
+  /// The version without its leading `v` — `0.2.0`.
+  final String version;
+
+  /// The tag as GitHub has it — `v0.2.0`.
+  final String tag;
+
+  /// The release's page, for the notes.
+  final String pageUrl;
+
+  /// The attachment that suits this machine.
+  final String assetName;
+  final Uri assetUrl;
+
+  /// What GitHub says the attachment weighs. Checked after the download, so a
+  /// truncated file is caught before anything is run.
+  final int assetBytes;
+
+  /// The attachment's SHA-256 as `sha256:…`, when the API gives one. Newer
+  /// GitHub responses carry a `digest` field; older ones do not, and a release
+  /// without it is verified by size alone.
+  final String? sha256;
+
+  const UpdateRelease({
+    required this.version,
+    required this.tag,
+    required this.pageUrl,
+    required this.assetName,
+    required this.assetUrl,
+    required this.assetBytes,
+    this.sha256,
+  });
+
+  /// How big the download is, for a sentence a human reads. Whole MB: the
+  /// difference between 412 and 412.4 MB is not a decision anybody makes.
+  String get sizeLabel => '${(assetBytes / (1 << 20)).round()} MB';
+
+  /// Read a release out of the GitHub API's answer, picking the attachment for
+  /// [platform]. Null when the release has nothing this machine can install —
+  /// a release whose Windows job failed, say, seen from Windows. Null rather
+  /// than an error: there is genuinely no update *for this machine*, and
+  /// offering one that cannot be installed is worse than offering none.
+  static UpdateRelease? parse(
+    Map<String, dynamic> json, {
+    required String platform,
+  }) {
+    final tag = json['tag_name'];
+    if (tag is! String || tag.isEmpty) return null;
+    // Draft releases are not published and pre-releases are not what `latest`
+    // returns, but both are cheap to refuse and expensive to ship by accident.
+    if (json['draft'] == true || json['prerelease'] == true) return null;
+
+    final assets = json['assets'];
+    if (assets is! List) return null;
+
+    Map<String, dynamic>? chosen;
+    for (final suffix in assetSuffixesFor(platform)) {
+      for (final raw in assets) {
+        if (raw is! Map) continue;
+        final asset = raw.cast<String, dynamic>();
+        final name = asset['name'];
+        if (name is String && name.toLowerCase().endsWith(suffix)) {
+          chosen = asset;
+          break;
+        }
+      }
+      if (chosen != null) break;
+    }
+    if (chosen == null) return null;
+
+    final url = chosen['browser_download_url'];
+    if (url is! String) return null;
+    final size = chosen['size'];
+
+    return UpdateRelease(
+      version: versionFromTag(tag),
+      tag: tag,
+      pageUrl: json['html_url'] is String ? json['html_url'] as String : '',
+      assetName: chosen['name'] as String,
+      assetUrl: Uri.parse(url),
+      assetBytes: size is int ? size : 0,
+      sha256: chosen['digest'] is String ? chosen['digest'] as String : null,
+    );
+  }
+}
+
+/// Which attachments this platform can install, best first.
+///
+/// Windows and macOS have one answer each. Linux has two, and the tarball wins:
+/// a `.flatpak` needs `flatpak install` and the Flatpak tooling present, where
+/// the bundle is a folder anybody can unpack — and on Linux the download is
+/// revealed rather than run in any case (see [UpdateService.install]).
+List<String> assetSuffixesFor(String platform) => switch (platform) {
+      'windows' => const ['.exe'],
+      'macos' => const ['.dmg'],
+      _ => const ['.tar.gz', '.flatpak'],
+    };
+
+/// `v0.2.0` → `0.2.0`. Anything else is handed back unchanged, so an oddly
+/// named tag is compared rather than silently treated as version zero.
+String versionFromTag(String tag) =>
+    tag.startsWith('v') ? tag.substring(1) : tag;
+
+/// The version out of a boot-log line — `lumit-bridge 0.1.0` → `0.1.0`.
+///
+/// The boot log is where this build's version already lives (K-008), so there
+/// is no second source of truth to keep in step. Null when the line is not
+/// shaped like that, which is what a test harness with no engine sees.
+String? versionFromBootLine(String line) {
+  final match = RegExp(r'(\d+\.\d+\.\d+[^\s]*)').firstMatch(line);
+  return match?.group(1);
+}
+
+/// Compare two versions: negative when [a] is older, zero when they are the
+/// same release, positive when [a] is newer.
+///
+/// Semantic versioning, as much of it as tags actually use: the three numbers
+/// compared as numbers, then the pre-release suffix, where *having* one makes a
+/// version older than the same numbers without one (`0.2.0-rc.1` < `0.2.0`).
+/// Build metadata after `+` is not part of the ordering, so it is dropped.
+int compareVersions(String a, String b) {
+  (List<int>, String) split(String raw) {
+    final noBuild = raw.split('+').first.trim();
+    final dash = noBuild.indexOf('-');
+    final core = dash < 0 ? noBuild : noBuild.substring(0, dash);
+    final pre = dash < 0 ? '' : noBuild.substring(dash + 1);
+    final numbers = [
+      for (final part in core.split('.')) int.tryParse(part) ?? 0,
+    ];
+    // Missing places are zero: `1.2` is `1.2.0`.
+    while (numbers.length < 3) {
+      numbers.add(0);
+    }
+    return (numbers, pre);
+  }
+
+  final (leftNumbers, leftPre) = split(a);
+  final (rightNumbers, rightPre) = split(b);
+  for (var i = 0; i < 3; i++) {
+    final diff = leftNumbers[i].compareTo(rightNumbers[i]);
+    if (diff != 0) return diff;
+  }
+  if (leftPre == rightPre) return 0;
+  // A release beats its own pre-releases.
+  if (leftPre.isEmpty) return 1;
+  if (rightPre.isEmpty) return -1;
+  return leftPre.compareTo(rightPre);
+}
+
+/// Asking GitHub what the latest release is. Injected so a test can answer
+/// without a network.
+typedef ReleaseFetcher = Future<Map<String, dynamic>> Function(Uri url);
+
+/// Fetching the installer. [onProgress] is called with bytes received and the
+/// total expected; [cancelled] is asked as it goes and a true answer abandons
+/// the download. Injected for the same reason.
+typedef AssetDownloader = Future<void> Function(
+  Uri url,
+  File into, {
+  required void Function(int received, int total) onProgress,
+  required bool Function() cancelled,
+});
+
+/// Handing the downloaded file to the system. Injected so a test never runs an
+/// installer, which is the one thing in this file that cannot be undone.
+typedef InstallerLauncher = Future<void> Function(File file, String platform);
+
+/// Ending the process so the installer can replace the files underneath it.
+typedef Quitter = void Function();
+
+/// The whole update state machine, shared by the Help menu and Settings.
+///
+/// One instance for the session, on [LumitUiState], so the menu and the
+/// Settings page cannot disagree about what is happening — they are two views
+/// of this object, and both redraw from its notifications.
+class UpdateService extends ChangeNotifier {
+  /// What this build is, asked lazily. A function rather than a string because
+  /// the answer comes over the bridge, and a service constructed in a widget
+  /// test must not call the engine merely by existing.
+  final String? Function() currentVersion;
+
+  /// Which platform's attachment to look for. `Platform.operatingSystem` in
+  /// the shipped application; set outright in tests.
+  final String platform;
+
+  final ReleaseFetcher _fetch;
+  final AssetDownloader _download;
+  final InstallerLauncher _launch;
+  final Quitter _quit;
+
+  /// Now, in milliseconds since the epoch. Injected so the once-a-day rule can
+  /// be tested without waiting a day.
+  final int Function() _now;
+
+  /// Where the installer is put. The system temporary folder in the shipped
+  /// application: it is a file the operating system may clean up, and once the
+  /// update is installed there is no reason to keep it.
+  final Directory Function() _downloadFolder;
+
+  UpdateService({
+    required this.currentVersion,
+    String? platform,
+    ReleaseFetcher? fetch,
+    AssetDownloader? download,
+    InstallerLauncher? launch,
+    Quitter? quit,
+    int Function()? now,
+    Directory Function()? downloadFolder,
+  })  : platform = platform ?? Platform.operatingSystem,
+        _fetch = fetch ?? _fetchReleaseJson,
+        _download = download ?? _downloadAsset,
+        _launch = launch ?? _launchInstaller,
+        _quit = quit ?? _exitProcess,
+        _now = now ?? _epochMillis,
+        _downloadFolder = downloadFolder ?? _defaultDownloadFolder;
+
+  UpdateStage _stage = UpdateStage.idle;
+  UpdateRelease? _release;
+  File? _downloaded;
+  double _progress = 0;
+  String? _failure;
+  bool _cancelRequested = false;
+
+  UpdateStage get stage => _stage;
+
+  /// The release that is waiting, once one has been found.
+  UpdateRelease? get release => _release;
+
+  /// How far the download has got, 0 to 1. Zero at every other stage.
+  double get progress => _progress;
+
+  /// Why the last attempt did not finish, in a sentence fit for the status
+  /// line. Null unless [stage] is [UpdateStage.failed].
+  String? get failure => _failure;
+
+  /// The installer on disk, once [UpdateStage.ready].
+  File? get downloadedInstaller => _downloaded;
+
+  /// Whether something is in flight, and so neither the menu row nor the
+  /// Settings button should be pressable.
+  bool get busy =>
+      _stage == UpdateStage.checking || _stage == UpdateStage.downloading;
+
+  /// What the Help menu's row reads (K-294).
+  ///
+  /// The wording is the state: an update that has been found says so with its
+  /// version in the row itself, which is the one place somebody is already
+  /// looking when they wonder whether to update. "Check for updates" is both
+  /// the resting state and where a finished check with nothing to report goes
+  /// back to — a row that stayed on "You are up to date" would be a stale
+  /// claim by the next morning.
+  String get menuLabel => switch (_stage) {
+        UpdateStage.checking => 'Checking for updates…',
+        UpdateStage.available =>
+          'Click to update - v${_release?.version ?? ''}',
+        UpdateStage.downloading =>
+          'Downloading update… ${(_progress * 100).round()}%',
+        UpdateStage.ready => 'Restart to finish updating',
+        _ => 'Check for updates',
+      };
+
+  /// Whether enough time has passed to look again.
+  bool dueForCheck(int lastCheckedMillis) =>
+      _now() - lastCheckedMillis >= updateCheckInterval.inMilliseconds;
+
+  /// Ask GitHub what the newest release is.
+  ///
+  /// Never throws: a machine with no network, a rate-limited API and a
+  /// malformed answer all land in [UpdateStage.failed] with a sentence, because
+  /// none of them is a reason for an editor to stop working.
+  Future<void> check() async {
+    if (busy) return;
+    _stage = UpdateStage.checking;
+    _failure = null;
+    notifyListeners();
+
+    try {
+      final current = currentVersion();
+      if (current == null) {
+        // No version to compare against — every release would look newer.
+        _fail('Could not tell which version of Lumit this is');
+        return;
+      }
+      final json = await _fetch(latestReleaseUrl);
+      final found = UpdateRelease.parse(json, platform: platform);
+      if (found == null || compareVersions(found.version, current) <= 0) {
+        _stage = UpdateStage.upToDate;
+        _release = null;
+      } else {
+        _stage = UpdateStage.available;
+        _release = found;
+      }
+    } catch (_) {
+      _fail('Could not check for updates');
+      return;
+    }
+    notifyListeners();
+  }
+
+  /// Fetch the waiting release's installer and verify it.
+  ///
+  /// Ends at [UpdateStage.ready] with [downloadedInstaller] set, or back at
+  /// [UpdateStage.available] when cancelled — a cancelled download leaves the
+  /// offer standing, since nothing about the release has changed.
+  Future<void> downloadUpdate() async {
+    final release = _release;
+    if (release == null || busy) return;
+    _cancelRequested = false;
+    _progress = 0;
+    _stage = UpdateStage.downloading;
+    _failure = null;
+    notifyListeners();
+
+    File? file;
+    try {
+      final folder = _downloadFolder();
+      folder.createSync(recursive: true);
+      file = File('${folder.path}${Platform.pathSeparator}${release.assetName}');
+      // A leftover from an abandoned attempt would otherwise be appended to or
+      // mistaken for a finished download.
+      if (file.existsSync()) file.deleteSync();
+
+      await _download(
+        release.assetUrl,
+        file,
+        onProgress: (received, total) {
+          // `contentLength` is -1 when the server does not say, in which case
+          // the size the release published is the best answer there is.
+          final expected = total > 0 ? total : release.assetBytes;
+          final fraction = expected > 0 ? received / expected : 0.0;
+          _progress = fraction.clamp(0.0, 1.0).toDouble();
+          notifyListeners();
+        },
+        cancelled: () => _cancelRequested,
+      );
+
+      if (_cancelRequested) {
+        _discard(file);
+        _stage = UpdateStage.available;
+        _progress = 0;
+        notifyListeners();
+        return;
+      }
+
+      final problem = await _verify(file, release);
+      if (problem != null) {
+        _discard(file);
+        _fail(problem);
+        return;
+      }
+
+      _downloaded = file;
+      _progress = 1;
+      _stage = UpdateStage.ready;
+    } catch (_) {
+      if (file != null) _discard(file);
+      _fail(_cancelRequested
+          ? 'Update download cancelled'
+          : 'Could not download the update');
+      return;
+    }
+    notifyListeners();
+  }
+
+  /// Abandon a download in progress. Safe at any other stage, where it does
+  /// nothing.
+  void cancelDownload() {
+    if (_stage != UpdateStage.downloading) return;
+    _cancelRequested = true;
+  }
+
+  /// Check the file against what the release said it would be.
+  ///
+  /// Returns null when it is sound, or the sentence to show when it is not.
+  /// This is the gate before anything is executed: an installer is the most
+  /// dangerous file Lumit ever touches, so it is run only when its length and
+  /// — where GitHub publishes one — its digest are exactly what the release
+  /// described.
+  ///
+  /// The length is read synchronously on purpose: it keeps the whole sequence
+  /// — offer, download, verify, restart — free of real asynchronous IO except
+  /// where a digest genuinely needs streaming, which is what lets a widget test
+  /// drive the windows from end to end (`flutter_test` does not run real IO
+  /// outside `runAsync`).
+  Future<String?> _verify(File file, UpdateRelease release) async {
+    final length = file.lengthSync();
+    if (release.assetBytes > 0 && length != release.assetBytes) {
+      return 'The downloaded update was incomplete';
+    }
+    final expected = release.sha256;
+    if (expected == null) return null;
+    final wanted = expected.startsWith('sha256:')
+        ? expected.substring('sha256:'.length)
+        : expected;
+    final digest = await sha256.bind(file.openRead()).first;
+    if (digest.toString().toLowerCase() != wanted.toLowerCase()) {
+      return 'The downloaded update did not match its checksum';
+    }
+    return null;
+  }
+
+  /// Hand the verified installer to the system, and — where that means
+  /// replacing files Lumit is running from — leave.
+  ///
+  /// On Windows the installer is started and Lumit quits, because Inno Setup
+  /// cannot overwrite an executable that is running. On macOS the disk image is
+  /// opened and Lumit quits, since the application is dragged over itself. On
+  /// Linux the download is only revealed: the bundle is unpacked wherever the
+  /// user keeps it and the Flatpak is installed by Flatpak, neither of which
+  /// Lumit should be doing on someone's behalf — so there is nothing to quit
+  /// for.
+  Future<void> install() async {
+    final file = _downloaded;
+    if (file == null || _stage != UpdateStage.ready) return;
+    try {
+      await _launch(file, platform);
+    } catch (_) {
+      _fail('Could not start the installer');
+      return;
+    }
+    if (platform == 'windows' || platform == 'macos') _quit();
+  }
+
+  /// Whether finishing the update means leaving the application. Linux reveals
+  /// the file instead, so the restart question is not put there.
+  bool get installQuits => platform == 'windows' || platform == 'macos';
+
+  void _discard(File file) {
+    try {
+      if (file.existsSync()) file.deleteSync();
+    } catch (_) {
+      // A file we cannot delete is litter in a temporary folder, not a fault
+      // worth showing anybody.
+    }
+  }
+
+  void _fail(String message) {
+    _stage = UpdateStage.failed;
+    _failure = message;
+    _progress = 0;
+    notifyListeners();
+  }
+}
+
+// --- The real implementations ---------------------------------------------
+
+int _epochMillis() => DateTime.now().millisecondsSinceEpoch;
+
+void _exitProcess() => exit(0);
+
+Directory _defaultDownloadFolder() =>
+    Directory('${Directory.systemTemp.path}${Platform.pathSeparator}'
+        'lumit-update');
+
+/// GitHub wants a user agent and answers JSON. Nothing is authenticated: the
+/// releases of a public repository are public, and asking anonymously means
+/// Lumit never holds a token.
+Future<Map<String, dynamic>> _fetchReleaseJson(Uri url) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 10);
+  try {
+    final request = await client.getUrl(url);
+    request.headers.set(HttpHeaders.userAgentHeader, 'Lumit');
+    request.headers.set(HttpHeaders.acceptHeader, 'application/vnd.github+json');
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      // Drained rather than dropped: an undrained response holds the socket.
+      await response.drain<void>();
+      throw HttpException('GitHub answered ${response.statusCode}', uri: url);
+    }
+    final body = await response.transform(utf8.decoder).join();
+    final json = jsonDecode(body);
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('The releases API answered something else');
+    }
+    return json;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+/// Stream the attachment to disk. GitHub redirects asset URLs at its CDN, which
+/// `HttpClient` follows; the file is written as it arrives rather than held in
+/// memory, because these are hundreds of megabytes.
+Future<void> _downloadAsset(
+  Uri url,
+  File into, {
+  required void Function(int received, int total) onProgress,
+  required bool Function() cancelled,
+}) async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 10);
+  IOSink? sink;
+  try {
+    final request = await client.getUrl(url);
+    request.headers.set(HttpHeaders.userAgentHeader, 'Lumit');
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      await response.drain<void>();
+      throw HttpException('The download answered ${response.statusCode}',
+          uri: url);
+    }
+    final total = response.contentLength;
+    var received = 0;
+    sink = into.openWrite();
+    await for (final chunk in response) {
+      if (cancelled()) break;
+      sink.add(chunk);
+      received += chunk.length;
+      onProgress(received, total);
+    }
+  } finally {
+    await sink?.flush();
+    await sink?.close();
+    client.close(force: true);
+  }
+}
+
+/// Start the installer, detached, so it outlives the process that started it —
+/// which it has to, since that process is about to end.
+Future<void> _launchInstaller(File file, String platform) async {
+  switch (platform) {
+    case 'windows':
+      // Inno Setup's own switches (packaging/windows/lumit.iss). `/SILENT`
+      // shows progress and no questions — the questions were all answered when
+      // Lumit was first installed, and asking them again to apply an update the
+      // user has already agreed to would be ceremony. `/CLOSEAPPLICATIONS`
+      // lets it deal with anything of ours still holding a file, and
+      // `/NORESTART` means it never reboots the machine on its own.
+      await Process.start(
+        file.path,
+        const ['/SILENT', '/CLOSEAPPLICATIONS', '/NORESTART'],
+        mode: ProcessStartMode.detached,
+      );
+    case 'macos':
+      await Process.start('open', [file.path],
+          mode: ProcessStartMode.detached);
+    default:
+      // Reveal, do not run: see `UpdateService.install`.
+      await Process.start('xdg-open', [file.parent.path],
+          mode: ProcessStartMode.detached);
+  }
+}

--- a/flutter_ui/lib/state/updates.dart
+++ b/flutter_ui/lib/state/updates.dart
@@ -32,6 +32,8 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 
+import 'install_site.dart';
+
 /// The repository releases are published from (K-279: the website reads the
 /// same one).
 const String updatesRepository = 'luminalmvm/lumit';
@@ -73,6 +75,22 @@ enum UpdateStage {
   failed,
 }
 
+/// How a downloaded release gets applied (K-297).
+enum UpdateDelivery {
+  /// Unpacked beside the installation and swapped in on restart — no installer,
+  /// no elevation, the way Chrome and VS Code do it. What a per-user
+  /// installation gets.
+  inPlace,
+
+  /// Handed to the installer that built it: an older installation in
+  /// `Program Files`, a macOS disk image, anywhere Lumit cannot write to its
+  /// own files.
+  installer,
+
+  /// Handed to Flatpak, which owns updating inside its own sandbox.
+  flatpakBundle,
+}
+
 /// A release that is newer than this build, and the file to fetch for it.
 @immutable
 class UpdateRelease {
@@ -93,6 +111,9 @@ class UpdateRelease {
   /// truncated file is caught before anything is run.
   final int assetBytes;
 
+  /// What will be done with the attachment once it is here.
+  final UpdateDelivery delivery;
+
   /// The attachment's SHA-256 as `sha256:…`, when the API gives one. Newer
   /// GitHub responses carry a `digest` field; older ones do not, and a release
   /// without it is verified by size alone.
@@ -105,6 +126,7 @@ class UpdateRelease {
     required this.assetName,
     required this.assetUrl,
     required this.assetBytes,
+    required this.delivery,
     this.sha256,
   });
 
@@ -120,6 +142,8 @@ class UpdateRelease {
   static UpdateRelease? parse(
     Map<String, dynamic> json, {
     required String platform,
+    InstallKind kind = InstallKind.unknown,
+    bool replaceable = false,
   }) {
     final tag = json['tag_name'];
     if (tag is! String || tag.isEmpty) return null;
@@ -131,7 +155,7 @@ class UpdateRelease {
     if (assets is! List) return null;
 
     Map<String, dynamic>? chosen;
-    for (final suffix in assetSuffixesFor(platform)) {
+    for (final suffix in assetSuffixesFor(platform, kind: kind)) {
       for (final raw in assets) {
         if (raw is! Map) continue;
         final asset = raw.cast<String, dynamic>();
@@ -149,29 +173,63 @@ class UpdateRelease {
     if (url is! String) return null;
     final size = chosen['size'];
 
+    final name = chosen['name'] as String;
     return UpdateRelease(
       version: versionFromTag(tag),
       tag: tag,
       pageUrl: json['html_url'] is String ? json['html_url'] as String : '',
-      assetName: chosen['name'] as String,
+      assetName: name,
       assetUrl: Uri.parse(url),
       assetBytes: size is int ? size : 0,
+      delivery: deliveryFor(name, kind: kind, replaceable: replaceable),
       sha256: chosen['digest'] is String ? chosen['digest'] as String : null,
     );
   }
 }
 
-/// Which attachments this platform can install, best first.
+/// Which attachments suit this machine, best first (K-297).
 ///
-/// Windows and macOS have one answer each. Linux has two, and the tarball wins:
-/// a `.flatpak` needs `flatpak install` and the Flatpak tooling present, where
-/// the bundle is a folder anybody can unpack — and on Linux the download is
-/// revealed rather than run in any case (see [UpdateService.install]).
-List<String> assetSuffixesFor(String platform) => switch (platform) {
-      'windows' => const ['.exe'],
-      'macos' => const ['.dmg'],
-      _ => const ['.tar.gz', '.flatpak'],
-    };
+/// A per-user installation prefers the *package* — the plain archive of the
+/// application's own files — because that can be swapped in without an
+/// installer or an administrator. The installer stays second on the list, for
+/// an older installation sitting somewhere only an installer can write to.
+///
+/// A Flatpak is offered the Flatpak bundle and nothing else: the sandbox cannot
+/// be updated from inside, so the other attachments would be useless there.
+List<String> assetSuffixesFor(String platform,
+    {InstallKind kind = InstallKind.unknown}) {
+  if (kind == InstallKind.flatpak) return const ['.flatpak'];
+  switch (platform) {
+    case 'windows':
+      return kind == InstallKind.folder
+          ? const ['windows-x64.zip', '.exe']
+          : const ['.exe'];
+    case 'macos':
+      return kind == InstallKind.bundle
+          ? const ['macos-arm64.zip', 'macos-x64.zip', 'macos.zip', '.dmg']
+          : const ['.dmg'];
+    default:
+      return const ['linux-x64.tar.gz', '.tar.gz', '.flatpak'];
+  }
+}
+
+/// What will happen to an attachment once it has been fetched.
+///
+/// The archive is only applied in place when this installation can genuinely
+/// be written to — otherwise the archive is no use and the file we have is an
+/// installer, whatever its extension.
+UpdateDelivery deliveryFor(
+  String assetName, {
+  required InstallKind kind,
+  required bool replaceable,
+}) {
+  if (kind == InstallKind.flatpak) return UpdateDelivery.flatpakBundle;
+  final name = assetName.toLowerCase();
+  final isArchive = name.endsWith('.zip') || name.endsWith('.tar.gz');
+  return isArchive && replaceable
+      ? UpdateDelivery.inPlace
+      : UpdateDelivery.installer;
+}
 
 /// `v0.2.0` → `0.2.0`. Anything else is handed back unchanged, so an oddly
 /// named tag is compared rather than silently treated as version zero.
@@ -242,6 +300,14 @@ typedef AssetDownloader = Future<void> Function(
 /// installer, which is the one thing in this file that cannot be undone.
 typedef InstallerLauncher = Future<void> Function(File file, String platform);
 
+/// Unpacking a downloaded archive into a folder. The platform's own tool does
+/// this in the shipped application (see `_extractArchive`); a test hands over a
+/// tree it made itself.
+typedef ArchiveExtractor = Future<void> Function(File archive, Directory into);
+
+/// Starting the freshly swapped-in Lumit, once the old one is about to go.
+typedef Relauncher = Future<void> Function(File launcher);
+
 /// Ending the process so the installer can replace the files underneath it.
 typedef Quitter = void Function();
 
@@ -260,9 +326,14 @@ class UpdateService extends ChangeNotifier {
   /// the shipped application; set outright in tests.
   final String platform;
 
+  /// Where this copy of Lumit lives and whether it may replace itself (K-297).
+  final InstallSite site;
+
   final ReleaseFetcher _fetch;
   final AssetDownloader _download;
   final InstallerLauncher _launch;
+  final ArchiveExtractor _extract;
+  final Relauncher _relaunch;
   final Quitter _quit;
 
   /// Now, in milliseconds since the epoch. Injected so the once-a-day rule can
@@ -277,16 +348,22 @@ class UpdateService extends ChangeNotifier {
   UpdateService({
     required this.currentVersion,
     String? platform,
+    InstallSite? site,
     ReleaseFetcher? fetch,
     AssetDownloader? download,
     InstallerLauncher? launch,
+    ArchiveExtractor? extract,
+    Relauncher? relaunch,
     Quitter? quit,
     int Function()? now,
     Directory Function()? downloadFolder,
   })  : platform = platform ?? Platform.operatingSystem,
+        site = site ?? InstallSite.detect(),
         _fetch = fetch ?? _fetchReleaseJson,
         _download = download ?? _downloadAsset,
         _launch = launch ?? _launchInstaller,
+        _extract = extract ?? _extractArchive,
+        _relaunch = relaunch ?? _relaunchLumit,
         _quit = quit ?? _exitProcess,
         _now = now ?? _epochMillis,
         _downloadFolder = downloadFolder ?? _defaultDownloadFolder;
@@ -359,7 +436,12 @@ class UpdateService extends ChangeNotifier {
         return;
       }
       final json = await _fetch(latestReleaseUrl);
-      final found = UpdateRelease.parse(json, platform: platform);
+      final found = UpdateRelease.parse(
+        json,
+        platform: platform,
+        kind: site.kind,
+        replaceable: site.replaceable,
+      );
       if (found == null || compareVersions(found.version, current) <= 0) {
         _stage = UpdateStage.upToDate;
         _release = null;
@@ -476,31 +558,96 @@ class UpdateService extends ChangeNotifier {
     return null;
   }
 
-  /// Hand the verified installer to the system, and — where that means
-  /// replacing files Lumit is running from — leave.
+  /// What will happen when the waiting update is applied. [UpdateDelivery
+  /// .installer] until a release has been found, since that is the cautious
+  /// answer.
+  UpdateDelivery get delivery => _release?.delivery ?? UpdateDelivery.installer;
+
+  /// Whether finishing the update means leaving the application.
   ///
-  /// On Windows the installer is started and Lumit quits, because Inno Setup
-  /// cannot overwrite an executable that is running. On macOS the disk image is
-  /// opened and Lumit quits, since the application is dragged over itself. On
-  /// Linux the download is only revealed: the bundle is unpacked wherever the
-  /// user keeps it and the Flatpak is installed by Flatpak, neither of which
-  /// Lumit should be doing on someone's behalf — so there is nothing to quit
-  /// for.
+  /// True for the two that replace what is running — the in-place swap and the
+  /// installer. False for a Flatpak, where Lumit only hands the file over and
+  /// carries on.
+  bool get installQuits => delivery != UpdateDelivery.flatpakBundle;
+
+  /// Apply the update that is waiting, whichever of the three ways this
+  /// installation calls for (K-297).
+  ///
+  /// In place: unpack beside the installation, swap the two folders, start the
+  /// new Lumit and leave. By installer: start it and leave, because it needs to
+  /// write where we cannot. Flatpak: reveal the bundle and stay open, because
+  /// the sandbox is not ours to rewrite.
   Future<void> install() async {
     final file = _downloaded;
     if (file == null || _stage != UpdateStage.ready) return;
+
+    if (delivery == UpdateDelivery.inPlace) {
+      await _applyInPlace(file);
+      return;
+    }
     try {
       await _launch(file, platform);
     } catch (_) {
       _fail('Could not start the installer');
       return;
     }
-    if (platform == 'windows' || platform == 'macos') _quit();
+    if (delivery == UpdateDelivery.installer) _quit();
   }
 
-  /// Whether finishing the update means leaving the application. Linux reveals
-  /// the file instead, so the restart question is not put there.
-  bool get installQuits => platform == 'windows' || platform == 'macos';
+  /// The installer-free path: unpack, stage, swap, restart (K-297).
+  ///
+  /// Every step before the swap is undoable by deleting a folder, and the swap
+  /// itself puts the old version back if it cannot finish — so a failure here
+  /// leaves the working Lumit exactly where it was, and says so.
+  Future<void> _applyInPlace(File archive) async {
+    try {
+      // Anything left from a previous attempt would be mistaken for this one.
+      _sweep(site.unpacking);
+      _sweep(site.staging);
+      site.unpacking.createSync(recursive: true);
+
+      await _extract(archive, site.unpacking);
+      final tree = unwrapSingleFolder(site.unpacking);
+      // An archive that unpacked to nothing is not something to swap a working
+      // application for. The checksum already proved the *file*; this proves
+      // there is an application inside it.
+      if (tree.listSync().isEmpty) {
+        _sweep(site.unpacking);
+        _fail('The downloaded update was empty');
+        return;
+      }
+      // Onto the final name, on the same filesystem, so the swap that follows
+      // is a rename and not a copy.
+      tree.renameSync(site.staging.path);
+      _sweep(site.unpacking);
+      markStagedUpdateReady(site);
+
+      swapInStagedUpdate(site);
+    } catch (_) {
+      _sweep(site.unpacking);
+      _sweep(site.staging);
+      _fail('Could not put the update in place');
+      return;
+    }
+
+    try {
+      await _relaunch(site.launcher);
+    } catch (_) {
+      // The files are already the new version, so there is nothing to undo —
+      // starting Lumit again by hand gets the update either way.
+      _fail('Lumit is updated, but could not start itself again');
+      return;
+    }
+    _quit();
+  }
+
+  void _sweep(Directory dir) {
+    try {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    } catch (_) {
+      // Litter beside the installation, not a reason to stop.
+    }
+  }
 
   void _discard(File file) {
     try {
@@ -593,6 +740,9 @@ Future<void> _downloadAsset(
 
 /// Start the installer, detached, so it outlives the process that started it —
 /// which it has to, since that process is about to end.
+///
+/// Only reached where the update could *not* be applied in place (K-297): an
+/// installation somewhere Lumit cannot write, or a macOS disk image.
 Future<void> _launchInstaller(File file, String platform) async {
   switch (platform) {
     case 'windows':
@@ -611,8 +761,50 @@ Future<void> _launchInstaller(File file, String platform) async {
       await Process.start('open', [file.path],
           mode: ProcessStartMode.detached);
     default:
-      // Reveal, do not run: see `UpdateService.install`.
+      // A Flatpak bundle: revealed, never run. `flatpak install` is the user's
+      // to run, and a sandboxed Lumit has no business reaching the host to do
+      // it for them (K-297).
       await Process.start('xdg-open', [file.parent.path],
           mode: ProcessStartMode.detached);
   }
+}
+
+/// Unpack a downloaded archive with the tool the platform already has.
+///
+/// Not a Dart zip library, deliberately: a macOS `.app` and a Linux bundle carry
+/// symbolic links and executable permissions, and an unpacker that quietly drops
+/// those produces a Lumit that will not start. `ditto` and `tar` keep them.
+/// Windows has carried bsdtar (`tar.exe`) since Windows 10 1803, and it reads
+/// zip files as happily as tarballs.
+Future<void> _extractArchive(File archive, Directory into) async {
+  final result = switch (Platform.operatingSystem) {
+    'macos' => await Process.run(
+        'ditto', ['-x', '-k', archive.path, into.path]),
+    _ => await Process.run(
+        'tar', ['-xf', archive.path, '-C', into.path]),
+  };
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      'unpack',
+      [archive.path],
+      result.stderr.toString().trim(),
+      result.exitCode,
+    );
+  }
+}
+
+/// Start the swapped-in Lumit, detached, so it survives this process ending a
+/// moment later.
+Future<void> _relaunchLumit(File launcher) async {
+  if (Platform.isMacOS) {
+    // `open` starts the *bundle*, which is what makes it a proper application
+    // launch — Dock icon, activation, the lot — rather than a bare process.
+    final bundle = launcher.parent.parent.parent.path;
+    await Process.start('open', ['-n', bundle],
+        mode: ProcessStartMode.detached);
+    return;
+  }
+  await Process.start(launcher.path, const [],
+      mode: ProcessStartMode.detached,
+      workingDirectory: launcher.parent.path);
 }

--- a/flutter_ui/lib/state/workspace.dart
+++ b/flutter_ui/lib/state/workspace.dart
@@ -190,6 +190,19 @@ class Workspace extends ChangeNotifier {
   PerformanceSettings performance = PerformanceSettings();
   InterfaceSettings interface = InterfaceSettings();
 
+  /// Whether Lumit looks for a newer version on launch (K-294).
+  ///
+  /// On by default, and offered on the setup screen as well as in Settings: an
+  /// editor that quietly falls years behind is how people end up reporting bugs
+  /// that were fixed long ago. It is a *look*, not a download — the installer
+  /// is only fetched when the user asks for it, so leaving this on never costs
+  /// anybody a surprise few hundred megabytes.
+  bool autoUpdate = true;
+
+  /// When the last update check finished, in milliseconds since the epoch.
+  /// Zero means never. Kept so six launches in a morning ask GitHub once.
+  int lastUpdateCheckMs = 0;
+
   /// Whether the first-run screen has had its answer (K-246, docs/07 §13.1).
   ///
   /// **True unless [load] finds no settings file.** Only loading can tell a
@@ -383,6 +396,22 @@ class Workspace extends ChangeNotifier {
     save();
   }
 
+  /// Turn automatic update checks on or off (K-294). Written straight out: it
+  /// is one boolean, and a setting that did not survive the restart it is about
+  /// would be a poor joke.
+  void setAutoUpdate(bool on) {
+    autoUpdate = on;
+    notifyListeners();
+    save();
+  }
+
+  /// Record that a check has just happened, so the next launch does not repeat
+  /// it. Saved without notifying — nothing on screen reads this.
+  void rememberUpdateCheck(int atMillis) {
+    lastUpdateCheckMs = atMillis;
+    save();
+  }
+
   void setThemedScopes(bool on) {
     themedScopes = on;
     notifyListeners();
@@ -568,6 +597,8 @@ class Workspace extends ChangeNotifier {
         'performance': performance.toJson(),
         'interface': interface.toJson(),
         'first_run_done': firstRunDone,
+        'auto_update': autoUpdate,
+        'last_update_check_ms': lastUpdateCheckMs,
         'keymap': keymapJson,
         'custom_themes': [for (final t in customThemes) t.toJson()],
         'custom_theme': customThemeName,
@@ -611,6 +642,11 @@ class Workspace extends ChangeNotifier {
     }
     // Absent means an existing user, not a new one — see the field.
     firstRunDone = j['first_run_done'] as bool? ?? true;
+    // Absent means a settings file written before there were updates to check
+    // for; the default is on, and an existing user gets the same offer a new
+    // one does.
+    autoUpdate = j['auto_update'] as bool? ?? true;
+    lastUpdateCheckMs = j['last_update_check_ms'] as int? ?? 0;
     keymapJson = j['keymap'] is String ? j['keymap'] as String : null;
     customThemes = [];
     final rawThemes = j['custom_themes'];

--- a/flutter_ui/pubspec.lock
+++ b/flutter_ui/pubspec.lock
@@ -146,7 +146,7 @@ packages:
     source: hosted
     version: "0.3.5+4"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/flutter_ui/pubspec.yaml
+++ b/flutter_ui/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  crypto: ^3.0.7
   ffi: ^2.1.0
   iconoir_flutter: ^7.11.1
   file_selector: ^1.1.0

--- a/flutter_ui/test/first_run_test.dart
+++ b/flutter_ui/test/first_run_test.dart
@@ -87,6 +87,39 @@ void main() {
     expect(workspace.firstRunDone, isTrue);
   });
 
+  testWidgets('the update tick is on, and the answer carries it', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+
+    // Ticked before anything is touched (K-294): the default is that Lumit
+    // looks for new versions.
+    await tester.tap(find.byKey(const ValueKey('first-run-ae')));
+    await tester.pumpAndSettle();
+    expect(workspace.autoUpdate, isTrue);
+  });
+
+  testWidgets('unticking the update box is remembered', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('first-run-auto-update')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('first-run-vegas')));
+    await tester.pumpAndSettle();
+
+    expect(workspace.autoUpdate, isFalse);
+    // The editing answer is unaffected: two questions, one screen.
+    expect(workspace.interface.videoAsSequenceLayer, isTrue);
+  });
+
+  testWidgets('skipping leaves update checks on', (tester) async {
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('first-run-skip')));
+    await tester.pumpAndSettle();
+    expect(workspace.autoUpdate, isTrue);
+  });
+
   testWidgets('a machine that has answered is never asked again',
       (tester) async {
     workspace.firstRunDone = true;

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -728,6 +728,19 @@ void main() {
           reason: 'File is the first heading, at the left');
     });
 
+    /// The update row is live rather than listed-and-dead (K-294). It is not
+    /// *pressed* here: pressing it asks GitHub, and a test suite has no
+    /// business on the network — what the press does is `updates_test.dart`,
+    /// against a service whose seams are stopped up.
+    testWidgets('Help ▸ Check for updates is a built command', (tester) async {
+      await mount(tester);
+      await tester.tap(find.byKey(const ValueKey<String>('menu-Help')));
+      await tester.pump();
+      expect(find.text('Check for updates'), findsOneWidget);
+      expect(find.text('Check for updates (Not implemented)'), findsNothing);
+      await dismiss(tester);
+    });
+
     testWidgets('Help ▸ About Lumit opens the About window', (tester) async {
       await mount(tester);
       await choose(tester, 'Help', 'About Lumit');

--- a/flutter_ui/test/install_site_test.dart
+++ b/flutter_ui/test/install_site_test.dart
@@ -1,0 +1,230 @@
+// Replacing Lumit with a newer Lumit, from inside Lumit (K-297).
+//
+// This is the part of updating that can destroy an installation if it is wrong,
+// so it is tested against real folders on disk rather than a pretend
+// filesystem: the swap is two renames, and whether a rename does what this code
+// assumes is a question only a real filesystem can answer.
+//
+// Every test builds a little installation in a temporary folder — a launcher, a
+// library, an assets folder — and checks what is standing afterwards.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/state/install_site.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() => tmp = Directory.systemTemp.createTempSync('lumit-install'));
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  /// An installation at `<tmp>/Lumit`, with [version] written into every file
+  /// so a test can say which one is standing.
+  InstallSite install(String version) {
+    final root = Directory('${tmp.path}/Lumit')..createSync(recursive: true);
+    File('${root.path}/lumit_flutter').writeAsStringSync(version);
+    File('${root.path}/liblumit_bridge.so').writeAsStringSync(version);
+    Directory('${root.path}/data').createSync();
+    File('${root.path}/data/icudtl.dat').writeAsStringSync(version);
+    return InstallSite(
+      kind: InstallKind.folder,
+      root: root,
+      launcher: File('${root.path}/lumit_flutter'),
+    );
+  }
+
+  /// A complete staged update at `<tmp>/Lumit.new`.
+  void stage(InstallSite site, String version, {bool complete = true}) {
+    final staging = site.staging..createSync(recursive: true);
+    File('${staging.path}/lumit_flutter').writeAsStringSync(version);
+    File('${staging.path}/liblumit_bridge.so').writeAsStringSync(version);
+    if (complete) markStagedUpdateReady(site);
+  }
+
+  String versionAt(InstallSite site) =>
+      File('${site.root.path}/lumit_flutter').readAsStringSync();
+
+  group('working out where we are', () {
+    test('Windows and Linux are a folder of files', () {
+      final site = InstallSite.detect(
+        executablePath: r'C:\Users\me\AppData\Local\Programs\Lumit\lumit.exe',
+        operatingSystem: 'windows',
+      );
+      expect(site.kind, InstallKind.folder);
+      expect(site.root.path, endsWith('Lumit'));
+      expect(site.launcher.path, endsWith('lumit.exe'));
+    });
+
+    test('macOS is the bundle, not the folder the binary sits in', () {
+      final site = InstallSite.detect(
+        executablePath: '/Applications/Lumit.app/Contents/MacOS/Lumit',
+        operatingSystem: 'macos',
+      );
+      expect(site.kind, InstallKind.bundle);
+      expect(site.root.path, '/Applications/Lumit.app',
+          reason: 'the whole bundle is what gets swapped');
+      expect(site.launcher.path, '/Applications/Lumit.app/Contents/MacOS/Lumit');
+    });
+
+    test('a macOS binary outside a bundle is not something to swap', () {
+      final site = InstallSite.detect(
+        executablePath: '/Users/me/build/lumit_flutter',
+        operatingSystem: 'macos',
+      );
+      expect(site.kind, InstallKind.unknown);
+      expect(site.replaceable, isFalse);
+    });
+
+    test('a Flatpak says so, and is never replaced from inside', () {
+      final site = InstallSite.detect(
+        executablePath: '/app/bin/lumit_flutter',
+        operatingSystem: 'linux',
+        isFlatpak: (path) => path == '/.flatpak-info',
+      );
+      expect(site.kind, InstallKind.flatpak);
+      expect(site.replaceable, isFalse,
+          reason: 'the sandbox is read-only by design');
+    });
+
+    test('a folder Lumit can write beside is replaceable, one it cannot is not',
+        () {
+      expect(install('0.1.0').replaceable, isTrue);
+      final nowhere = InstallSite(
+        kind: InstallKind.folder,
+        root: Directory('/definitely/not/a/place/Lumit'),
+        launcher: File('/definitely/not/a/place/Lumit/lumit'),
+      );
+      expect(nowhere.replaceable, isFalse);
+    });
+  });
+
+  group('staging', () {
+    test('a tree is only ready once it has been marked', () {
+      final site = install('0.1.0');
+      stage(site, '0.2.0', complete: false);
+      expect(stagedUpdateReady(site), isFalse,
+          reason: 'a half-unpacked download must never be swapped in');
+      markStagedUpdateReady(site);
+      expect(stagedUpdateReady(site), isTrue);
+    });
+
+    test('swapping refuses a tree that was never marked complete', () {
+      final site = install('0.1.0');
+      stage(site, '0.2.0', complete: false);
+      expect(() => swapInStagedUpdate(site), throwsStateError);
+      expect(versionAt(site), '0.1.0', reason: 'the old version is untouched');
+    });
+  });
+
+  group('the swap', () {
+    test('the new version takes the old one\'s place, at the same path', () {
+      final site = install('0.1.0');
+      final where = site.root.path;
+      stage(site, '0.2.0');
+
+      swapInStagedUpdate(site);
+
+      expect(site.root.path, where,
+          reason: 'shortcuts and file associations point at this path');
+      expect(versionAt(site), '0.2.0');
+      expect(site.staging.existsSync(), isFalse);
+    });
+
+    test('the old version is kept, because its files are still open', () {
+      final site = install('0.1.0');
+      stage(site, '0.2.0');
+      swapInStagedUpdate(site);
+
+      expect(site.previous.existsSync(), isTrue);
+      expect(File('${site.previous.path}/lumit_flutter').readAsStringSync(),
+          '0.1.0');
+    });
+
+    test('a version before last is cleared out of the way first', () {
+      final site = install('0.1.0');
+      site.previous.createSync();
+      File('${site.previous.path}/lumit_flutter').writeAsStringSync('0.0.9');
+      stage(site, '0.2.0');
+
+      swapInStagedUpdate(site);
+
+      expect(versionAt(site), '0.2.0');
+      expect(File('${site.previous.path}/lumit_flutter').readAsStringSync(),
+          '0.1.0', reason: 'the one just replaced, not the ancient one');
+    });
+  });
+
+  group('tidying up at start-up', () {
+    test('the replaced version is deleted once nothing holds it', () {
+      final site = install('0.2.0');
+      site.previous.createSync();
+      File('${site.previous.path}/lumit_flutter').writeAsStringSync('0.1.0');
+
+      tidyAfterUpdate(site);
+
+      expect(site.previous.existsSync(), isFalse);
+      expect(versionAt(site), '0.2.0', reason: 'the running version stands');
+    });
+
+    test('a swap cut in half is put back', () {
+      final site = install('0.1.0');
+      // What a power cut between the two renames leaves: the old version under
+      // its safety name, and nothing at all where Lumit should be.
+      site.root.renameSync(site.previous.path);
+      expect(site.root.existsSync(), isFalse);
+
+      tidyAfterUpdate(site);
+
+      expect(site.root.existsSync(), isTrue);
+      expect(versionAt(site), '0.1.0',
+          reason: 'better the version they had than no Lumit at all');
+      expect(site.previous.existsSync(), isFalse);
+    });
+
+    test('an abandoned download is swept, a complete one is left alone', () {
+      final site = install('0.1.0');
+      stage(site, '0.2.0', complete: false);
+      tidyAfterUpdate(site);
+      expect(site.staging.existsSync(), isFalse);
+
+      stage(site, '0.2.0');
+      tidyAfterUpdate(site);
+      expect(site.staging.existsSync(), isTrue,
+          reason: 'an update that is ready survives a restart that did not '
+              'apply it');
+    });
+
+    test('leftover unpacking is swept', () {
+      final site = install('0.1.0');
+      site.unpacking.createSync();
+      File('${site.unpacking.path}/half-a-file').writeAsStringSync('...');
+      tidyAfterUpdate(site);
+      expect(site.unpacking.existsSync(), isFalse);
+    });
+  });
+
+  group('unwrapping an archive', () {
+    test('an archive with one folder in it is that folder', () {
+      final unpacked = Directory('${tmp.path}/unpacked')..createSync();
+      Directory('${unpacked.path}/lumit-0.2.0-linux-x64').createSync();
+      expect(unwrapSingleFolder(unpacked).path, endsWith('linux-x64'));
+    });
+
+    test('an archive of loose files is itself', () {
+      final unpacked = Directory('${tmp.path}/unpacked')..createSync();
+      File('${unpacked.path}/lumit.exe').writeAsStringSync('x');
+      File('${unpacked.path}/lumit_bridge.dll').writeAsStringSync('x');
+      expect(unwrapSingleFolder(unpacked).path, unpacked.path);
+    });
+
+    test('one folder beside a loose file is not a wrapper', () {
+      final unpacked = Directory('${tmp.path}/unpacked')..createSync();
+      Directory('${unpacked.path}/data').createSync();
+      File('${unpacked.path}/lumit.exe').writeAsStringSync('x');
+      expect(unwrapSingleFolder(unpacked).path, unpacked.path);
+    });
+  });
+}

--- a/flutter_ui/test/settings_test.dart
+++ b/flutter_ui/test/settings_test.dart
@@ -130,6 +130,37 @@ void main() {
     Workspace.storeOverride = null;
   });
 
+  // Automatic update checks (K-294): on by default, for a fresh install and
+  // for a settings file written before the setting existed alike.
+  test('update checks default to on and survive a restart', () {
+    expect(Workspace().autoUpdate, isTrue);
+    expect(
+        (Workspace()..applyJson(<String, dynamic>{'ui_scale': 1.0})).autoUpdate,
+        isTrue,
+        reason: 'a file that predates the setting still gets the default');
+
+    final path = _scratchStore('auto-update');
+    File(path).parent.createSync(recursive: true);
+    if (File(path).existsSync()) File(path).deleteSync();
+    Workspace.storeOverride = path;
+
+    (Workspace()..load()).setAutoUpdate(false);
+    expect((Workspace()..load()).autoUpdate, isFalse);
+    Workspace.storeOverride = null;
+  });
+
+  test('when the last update check happened is remembered', () {
+    final path = _scratchStore('update-check');
+    File(path).parent.createSync(recursive: true);
+    if (File(path).existsSync()) File(path).deleteSync();
+    Workspace.storeOverride = path;
+
+    expect((Workspace()..load()).lastUpdateCheckMs, 0);
+    (Workspace()..load()).rememberUpdateCheck(1234567);
+    expect((Workspace()..load()).lastUpdateCheckMs, 1234567);
+    Workspace.storeOverride = null;
+  });
+
   test('an unknown playback name falls back to adaptive', () {
     final p = PerformanceSettings.fromJson(const {'playback': 'warp-speed'});
     expect(p.playback, PlaybackMode.adaptive);

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -169,12 +169,20 @@ void main() {
     });
 
     test('a check is good for a day', () {
-      var now = 1000000;
+      // An ordinary moment, not a small number: "a day since never" is only
+      // true if now is itself more than a day past the epoch.
+      const morning = 1770000000000;
+      var now = morning;
       final service = _service(now: () => now);
-      expect(service.dueForCheck(0), isTrue);
-      expect(service.dueForCheck(now), isFalse);
+      expect(service.dueForCheck(0), isTrue, reason: 'never looked');
+      expect(service.dueForCheck(now), isFalse, reason: 'just looked');
+      expect(
+        service.dueForCheck(now - updateCheckInterval.inMilliseconds + 1),
+        isFalse,
+        reason: 'a minute short of a day is still too soon',
+      );
       now += updateCheckInterval.inMilliseconds;
-      expect(service.dueForCheck(1000000), isTrue);
+      expect(service.dueForCheck(morning), isTrue, reason: 'a day later');
     });
   });
 

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -1,0 +1,590 @@
+// Finding, fetching and applying a newer Lumit (K-294).
+//
+// Every seam the updater has with the outside world is injected, so this suite
+// never reaches the network, never writes an installer anywhere but a scratch
+// folder, and — the one that matters — never runs one and never quits the
+// process. What it does exercise is the whole sequence: the version arithmetic
+// that decides whether there *is* an update, the state machine the Help menu
+// row reads its wording from, the checks that stand between a download and
+// something being executed, and the two windows at the end of it.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/shell/update_dialog_frb.dart';
+import 'package:lumit_flutter/state/updates.dart';
+import 'package:lumit_flutter/theme/theme.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
+
+void main() {
+  group('version arithmetic', () {
+    test('a tag is a version without its v', () {
+      expect(versionFromTag('v0.2.0'), '0.2.0');
+      expect(versionFromTag('0.2.0'), '0.2.0');
+    });
+
+    test('the boot log is where this build says what it is', () {
+      expect(versionFromBootLine('lumit-bridge 0.1.0'), '0.1.0');
+      expect(versionFromBootLine('lumit-bridge 1.2.3-rc.1'), '1.2.3-rc.1');
+      // A harness with no engine sees a line with no version in it.
+      expect(versionFromBootLine('unknown'), isNull);
+    });
+
+    test('newer, older and the same', () {
+      expect(compareVersions('0.2.0', '0.1.0'), greaterThan(0));
+      expect(compareVersions('0.1.0', '0.2.0'), lessThan(0));
+      expect(compareVersions('0.1.0', '0.1.0'), 0);
+      // Ten is not one: the numbers are compared as numbers, which a string
+      // comparison would get backwards.
+      expect(compareVersions('0.10.0', '0.9.0'), greaterThan(0));
+      // A missing place is zero.
+      expect(compareVersions('1.2', '1.2.0'), 0);
+    });
+
+    test('a release beats its own pre-releases', () {
+      expect(compareVersions('0.2.0', '0.2.0-rc.1'), greaterThan(0));
+      expect(compareVersions('0.2.0-rc.1', '0.2.0'), lessThan(0));
+      expect(compareVersions('0.2.0-rc.2', '0.2.0-rc.1'), greaterThan(0));
+    });
+
+    test('build metadata is not part of the ordering', () {
+      expect(compareVersions('0.2.0+3', '0.2.0'), 0);
+    });
+  });
+
+  group('reading a release', () {
+    test('each platform is offered the attachment it can install', () {
+      for (final (platform, expected) in const [
+        ('windows', 'lumit-0.2.0-windows-x64-setup.exe'),
+        ('macos', 'lumit-0.2.0.dmg'),
+        ('linux', 'lumit-0.2.0-linux-x64.tar.gz'),
+      ]) {
+        final release = UpdateRelease.parse(_releaseJson(), platform: platform);
+        expect(release?.assetName, expected, reason: platform);
+        expect(release?.version, '0.2.0');
+      }
+    });
+
+    test('a release with nothing for this machine is no release at all', () {
+      final json = _releaseJson(assets: [
+        _asset('lumit-0.2.0-linux-x64.tar.gz'),
+      ]);
+      expect(UpdateRelease.parse(json, platform: 'windows'), isNull);
+    });
+
+    test('drafts and pre-releases are refused', () {
+      expect(
+        UpdateRelease.parse(_releaseJson(draft: true), platform: 'windows'),
+        isNull,
+      );
+      expect(
+        UpdateRelease.parse(_releaseJson(prerelease: true),
+            platform: 'windows'),
+        isNull,
+      );
+    });
+
+    test('the digest comes through when GitHub publishes one', () {
+      final release = UpdateRelease.parse(
+        _releaseJson(assets: [
+          _asset('lumit-0.2.0-windows-x64-setup.exe', digest: 'sha256:abc'),
+        ]),
+        platform: 'windows',
+      );
+      expect(release?.sha256, 'sha256:abc');
+    });
+  });
+
+  group('checking', () {
+    test('a newer release is offered by version, in the row itself', () async {
+      final service = _service(fetch: (_) async => _releaseJson());
+      await service.check();
+      expect(service.stage, UpdateStage.available);
+      // The exact wording the owner asked for. A test rather than a comment,
+      // because this string is the whole feature as far as anyone using Lumit
+      // is concerned.
+      expect(service.menuLabel, 'Click to update - v0.2.0');
+      expect(service.busy, isFalse);
+    });
+
+    test('the same version is up to date, and the row goes back to offering '
+        'a check', () async {
+      final service = _service(
+        version: '0.2.0',
+        fetch: (_) async => _releaseJson(),
+      );
+      await service.check();
+      expect(service.stage, UpdateStage.upToDate);
+      expect(service.menuLabel, 'Check for updates');
+    });
+
+    test('an older release on GitHub is not an update', () async {
+      final service = _service(
+        version: '0.3.0',
+        fetch: (_) async => _releaseJson(),
+      );
+      await service.check();
+      expect(service.stage, UpdateStage.upToDate);
+    });
+
+    test('the row says what it is doing while it does it', () async {
+      final gate = Completer<Map<String, dynamic>>();
+      final service = _service(fetch: (_) => gate.future);
+      final checking = service.check();
+      expect(service.stage, UpdateStage.checking);
+      expect(service.menuLabel, 'Checking for updates…');
+      // Disabled while in flight: pressing again would start a second check.
+      expect(service.busy, isTrue);
+      gate.complete(_releaseJson());
+      await checking;
+      expect(service.busy, isFalse);
+    });
+
+    test('no network is a sentence, not a crash', () async {
+      final service = _service(
+          fetch: (_) async => throw const SocketException('no route'));
+      await service.check();
+      expect(service.stage, UpdateStage.failed);
+      expect(service.failure, 'Could not check for updates');
+      // Recoverable: the row offers the check again.
+      expect(service.menuLabel, 'Check for updates');
+    });
+
+    test('a build that cannot say what version it is checks nothing', () async {
+      var asked = false;
+      final service = _service(
+        version: null,
+        fetch: (_) async {
+          asked = true;
+          return _releaseJson();
+        },
+      );
+      await service.check();
+      expect(asked, isFalse);
+      expect(service.stage, UpdateStage.failed);
+    });
+
+    test('a check is good for a day', () {
+      var now = 1000000;
+      final service = _service(now: () => now);
+      expect(service.dueForCheck(0), isTrue);
+      expect(service.dueForCheck(now), isFalse);
+      now += updateCheckInterval.inMilliseconds;
+      expect(service.dueForCheck(1000000), isTrue);
+    });
+  });
+
+  group('downloading', () {
+    late Directory scratch;
+
+    setUp(() => scratch = Directory.systemTemp.createTempSync('lumit-update'));
+    tearDown(() {
+      if (scratch.existsSync()) scratch.deleteSync(recursive: true);
+    });
+
+    /// A service whose download writes [body] to the file it is given.
+    UpdateService serviceFor(List<int> body, {String? digest}) => _service(
+          fetch: (_) async => _releaseJson(assets: [
+            _asset('lumit-0.2.0-windows-x64-setup.exe',
+                size: body.length, digest: digest),
+          ]),
+          folder: () => scratch,
+          download: (url, into, {required onProgress, required cancelled}) async {
+            into.writeAsBytesSync(body);
+            onProgress(body.length, body.length);
+          },
+        );
+
+    test('a sound download ends ready, on disk, with the restart wording',
+        () async {
+      final body = utf8.encode('an installer, for the sake of argument');
+      final service =
+          serviceFor(body, digest: 'sha256:${sha256.convert(body)}');
+      await service.check();
+      await service.downloadUpdate();
+
+      expect(service.stage, UpdateStage.ready);
+      expect(service.menuLabel, 'Restart to finish updating');
+      expect(service.downloadedInstaller?.existsSync(), isTrue);
+      expect(service.progress, 1);
+    });
+
+    test('a short file is not run, and does not stay on disk', () async {
+      final service = _service(
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-windows-x64-setup.exe', size: 999),
+        ]),
+        folder: () => scratch,
+        download: (url, into, {required onProgress, required cancelled}) async {
+          into.writeAsBytesSync(utf8.encode('truncated'));
+        },
+      );
+      await service.check();
+      await service.downloadUpdate();
+
+      expect(service.stage, UpdateStage.failed);
+      expect(service.failure, 'The downloaded update was incomplete');
+      expect(scratch.listSync(), isEmpty);
+    });
+
+    test('a file that does not match its checksum is not run', () async {
+      final body = utf8.encode('an installer, or is it');
+      final service = serviceFor(body, digest: 'sha256:${'0' * 64}');
+      await service.check();
+      await service.downloadUpdate();
+
+      expect(service.stage, UpdateStage.failed);
+      expect(service.failure, 'The downloaded update did not match its '
+          'checksum');
+      expect(scratch.listSync(), isEmpty);
+    });
+
+    test('cancelling leaves the offer standing', () async {
+      final service = _service(
+        fetch: (_) async => _releaseJson(),
+        folder: () => scratch,
+        download: (url, into, {required onProgress, required cancelled}) async {
+          // A turn of the loop, so the Cancel below lands mid-download the way
+          // a real one does — the service asks as each chunk arrives.
+          await Future<void>.delayed(Duration.zero);
+          expect(cancelled(), isTrue);
+          into.writeAsBytesSync(utf8.encode('half of one'));
+        },
+      );
+      await service.check();
+      final fetching = service.downloadUpdate();
+      service.cancelDownload();
+      await fetching;
+
+      expect(service.stage, UpdateStage.available);
+      expect(service.menuLabel, 'Click to update - v0.2.0');
+      expect(scratch.listSync(), isEmpty);
+    });
+
+    test('progress is reported as a fraction of the whole', () async {
+      // Declared first: the fake download looks at the service that owns it.
+      late final UpdateService service;
+      service = _service(
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-windows-x64-setup.exe', size: 100),
+        ]),
+        folder: () => scratch,
+        download: (url, into, {required onProgress, required cancelled}) async {
+          onProgress(25, 100);
+          expect(service.progress, 0.25);
+          expect(service.menuLabel, 'Downloading update… 25%');
+          into.writeAsBytesSync(List<int>.filled(100, 0));
+          onProgress(100, 100);
+        },
+      );
+      await service.check();
+      await service.downloadUpdate();
+      expect(service.stage, UpdateStage.ready);
+    });
+  });
+
+  group('installing', () {
+    late Directory scratch;
+    setUp(() => scratch = Directory.systemTemp.createTempSync('lumit-update'));
+    tearDown(() {
+      if (scratch.existsSync()) scratch.deleteSync(recursive: true);
+    });
+
+    Future<UpdateService> ready(
+      String platform, {
+      required List<File> launched,
+      required List<int> quits,
+    }) async {
+      final body = utf8.encode('installer');
+      final service = _service(
+        platform: platform,
+        folder: () => scratch,
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-windows-x64-setup.exe', size: body.length),
+          _asset('lumit-0.2.0.dmg', size: body.length),
+          _asset('lumit-0.2.0-linux-x64.tar.gz', size: body.length),
+        ]),
+        download: (url, into, {required onProgress, required cancelled}) async =>
+            into.writeAsBytesSync(body),
+        launch: (file, _) async => launched.add(file),
+        quit: () => quits.add(1),
+      );
+      await service.check();
+      await service.downloadUpdate();
+      return service;
+    }
+
+    test('Windows starts the installer and leaves', () async {
+      final launched = <File>[];
+      final quits = <int>[];
+      final service =
+          await ready('windows', launched: launched, quits: quits);
+      await service.install();
+      expect(launched.single.path, endsWith('setup.exe'));
+      expect(quits, hasLength(1));
+      expect(service.installQuits, isTrue);
+    });
+
+    test('Linux reveals the download and stays open', () async {
+      final launched = <File>[];
+      final quits = <int>[];
+      final service = await ready('linux', launched: launched, quits: quits);
+      await service.install();
+      expect(launched, hasLength(1));
+      expect(quits, isEmpty, reason: 'nothing is being replaced underneath us');
+      expect(service.installQuits, isFalse);
+    });
+
+    test('nothing is run before a download has finished', () async {
+      final launched = <File>[];
+      final service = _service(
+        fetch: (_) async => _releaseJson(),
+        launch: (file, _) async => launched.add(file),
+      );
+      await service.check();
+      await service.install();
+      expect(launched, isEmpty);
+    });
+  });
+
+  group('the windows', () {
+    late Directory scratch;
+    setUp(() => scratch = Directory.systemTemp.createTempSync('lumit-update'));
+    tearDown(() {
+      if (scratch.existsSync()) scratch.deleteSync(recursive: true);
+    });
+
+    /// Everything the flow needs, with the answers a test can look at
+    /// afterwards.
+    ({Widget host, List<String> notices, List<int> saves}) harness(
+      UpdateService service, {
+      required bool dirty,
+    }) {
+      final notices = <String>[];
+      final saves = <int>[];
+      return (
+        host: _Host(
+          onPressed: (context) => pressUpdateRow(
+            context,
+            updates: service,
+            notice: (message, {bool error = false}) => notices.add(message),
+            projectIsDirty: () => dirty,
+            saveProject: () async => saves.add(1),
+          ),
+        ),
+        notices: notices,
+        saves: saves,
+      );
+    }
+
+    testWidgets('nothing to report says so in the status line', (tester) async {
+      final service = _service(
+        version: '0.2.0',
+        fetch: (_) async => _releaseJson(),
+      );
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+      expect(h.notices, ['Lumit is up to date']);
+    });
+
+    testWidgets('the whole sequence: offer, download, save and restart',
+        (tester) async {
+      final body = utf8.encode('installer');
+      final launched = <File>[];
+      final quits = <int>[];
+      final service = _service(
+        platform: 'windows',
+        folder: () => scratch,
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-windows-x64-setup.exe', size: body.length),
+        ]),
+        download: (url, into, {required onProgress, required cancelled}) async {
+          onProgress(body.length, body.length);
+          into.writeAsBytesSync(body);
+        },
+        launch: (file, _) async => launched.add(file),
+        quit: () => quits.add(1),
+      );
+      await service.check();
+      expect(service.stage, UpdateStage.available);
+
+      final h = harness(service, dirty: true);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+
+      // The offer names the version and what it costs.
+      expect(find.text('Update to Lumit 0.2.0?'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('update-offer-yes')));
+      await tester.pumpAndSettle();
+
+      // Straight through the download to the restart question, which offers
+      // to save because this project has unsaved work.
+      expect(find.byKey(const ValueKey('update-save-restart')), findsOneWidget);
+      expect(find.byKey(const ValueKey('update-restart-now')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('update-save-restart')));
+      await tester.pumpAndSettle();
+
+      expect(h.saves, hasLength(1), reason: 'saved before quitting');
+      expect(launched, hasLength(1));
+      expect(quits, hasLength(1));
+    });
+
+    testWidgets('a clean project is not offered a save it does not need',
+        (tester) async {
+      final service = await _readyService(scratch);
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('update-save-restart')), findsNothing);
+      expect(find.text('Restart now'), findsOneWidget);
+    });
+
+    testWidgets('Later keeps the update waiting rather than losing it',
+        (tester) async {
+      final service = await _readyService(scratch);
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('update-restart-later')));
+      await tester.pumpAndSettle();
+
+      expect(service.stage, UpdateStage.ready);
+      expect(service.menuLabel, 'Restart to finish updating');
+      expect(service.downloadedInstaller?.existsSync(), isTrue);
+    });
+
+    testWidgets('turning the offer down downloads nothing', (tester) async {
+      var downloads = 0;
+      final service = _service(
+        fetch: (_) async => _releaseJson(),
+        folder: () => scratch,
+        download: (url, into, {required onProgress, required cancelled}) async {
+          downloads++;
+        },
+      );
+      await service.check();
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('update-offer-no')));
+      await tester.pumpAndSettle();
+
+      expect(downloads, 0);
+      expect(service.stage, UpdateStage.available);
+    });
+  });
+}
+
+/// A service already holding a verified download, for the windows that come
+/// after one.
+Future<UpdateService> _readyService(Directory scratch) async {
+  final body = utf8.encode('installer');
+  final service = _service(
+    platform: 'windows',
+    folder: () => scratch,
+    fetch: (_) async => _releaseJson(assets: [
+      _asset('lumit-0.2.0-windows-x64-setup.exe', size: body.length),
+    ]),
+    download: (url, into, {required onProgress, required cancelled}) async =>
+        into.writeAsBytesSync(body),
+    launch: (file, _) async {},
+    quit: () {},
+  );
+  await service.check();
+  await service.downloadUpdate();
+  return service;
+}
+
+/// A service with every seam stopped up. The default version is 0.1.0, which
+/// is older than the 0.2.0 the sample release describes.
+UpdateService _service({
+  String? version = '0.1.0',
+  String platform = 'windows',
+  ReleaseFetcher? fetch,
+  AssetDownloader? download,
+  InstallerLauncher? launch,
+  Quitter? quit,
+  int Function()? now,
+  Directory Function()? folder,
+}) =>
+    UpdateService(
+      currentVersion: () => version,
+      platform: platform,
+      fetch: fetch ?? (_) async => _releaseJson(),
+      download: download ??
+          (url, into, {required onProgress, required cancelled}) async {},
+      launch: launch ?? (file, _) async {},
+      quit: quit ?? () {},
+      now: now,
+      downloadFolder: folder ?? Directory.systemTemp.createTempSync,
+    );
+
+/// The shape of GitHub's answer, with only the fields the updater reads.
+Map<String, dynamic> _releaseJson({
+  String tag = 'v0.2.0',
+  bool draft = false,
+  bool prerelease = false,
+  List<Map<String, dynamic>>? assets,
+}) =>
+    {
+      'tag_name': tag,
+      'draft': draft,
+      'prerelease': prerelease,
+      'html_url': 'https://github.com/luminalmvm/lumit/releases/tag/$tag',
+      'assets': assets ??
+          [
+            _asset('lumit-0.2.0-windows-x64-setup.exe'),
+            _asset('lumit-0.2.0.dmg'),
+            _asset('lumit-0.2.0-linux-x64.tar.gz'),
+            _asset('lumit-0.2.0-linux-x64.flatpak'),
+          ],
+    };
+
+Map<String, dynamic> _asset(String name, {int size = 0, String? digest}) => {
+      'name': name,
+      'size': size,
+      'browser_download_url':
+          'https://github.com/luminalmvm/lumit/releases/download/v0.2.0/$name',
+      if (digest != null) 'digest': digest,
+    };
+
+/// A window with an Overlay and one button, which is what the update windows
+/// need to be shown into.
+class _Host extends StatelessWidget {
+  final Future<void> Function(BuildContext context) onPressed;
+  const _Host({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThemeScope(
+          theme: LumitTheme.dark(),
+          animationLevel: AnimationLevel.none,
+          showTooltips: false,
+          child: Overlay(
+            initialEntries: [
+              OverlayEntry(
+                builder: (context) => Center(
+                  child: HouseButton(
+                    key: const ValueKey('host-press'),
+                    onPressed: () => onPressed(context),
+                    child: const Text('Press'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+}

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -16,6 +16,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/shell/update_dialog_frb.dart';
+import 'package:lumit_flutter/state/install_site.dart';
 import 'package:lumit_flutter/state/updates.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/widgets/controls.dart';
@@ -337,13 +338,37 @@ void main() {
       expect(service.installQuits, isTrue);
     });
 
-    test('Linux reveals the download and stays open', () async {
+    test('a Flatpak is handed its bundle and Lumit stays open', () async {
       final launched = <File>[];
       final quits = <int>[];
-      final service = await ready('linux', launched: launched, quits: quits);
+      final body = utf8.encode('bundle');
+      final service = _service(
+        platform: 'linux',
+        site: InstallSite(
+          kind: InstallKind.flatpak,
+          root: Directory('/app'),
+          launcher: File('/app/bin/lumit_flutter'),
+        ),
+        folder: () => scratch,
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-linux-x64.tar.gz', size: body.length),
+          _asset('lumit-0.2.0-linux-x64.flatpak', size: body.length),
+        ]),
+        download: (url, into, {required onProgress, required cancelled}) async =>
+            into.writeAsBytesSync(body),
+        launch: (file, _) async => launched.add(file),
+        quit: () => quits.add(1),
+      );
+      await service.check();
+      // The sandbox gets the bundle, never the tarball it cannot use.
+      expect(service.release?.assetName, endsWith('.flatpak'));
+      expect(service.delivery, UpdateDelivery.flatpakBundle);
+
+      await service.downloadUpdate();
       await service.install();
-      expect(launched, hasLength(1));
-      expect(quits, isEmpty, reason: 'nothing is being replaced underneath us');
+
+      expect(launched, hasLength(1), reason: 'revealed, not run');
+      expect(quits, isEmpty, reason: 'nothing of ours is being replaced');
       expect(service.installQuits, isFalse);
     });
 
@@ -356,6 +381,144 @@ void main() {
       await service.check();
       await service.install();
       expect(launched, isEmpty);
+    });
+  });
+
+  group('choosing how to update (K-297)', () {
+    test('a per-user installation is offered the package, not the installer',
+        () {
+      final release = UpdateRelease.parse(
+        _releaseJson(),
+        platform: 'windows',
+        kind: InstallKind.folder,
+        replaceable: true,
+      );
+      expect(release?.assetName, 'lumit-0.2.0-windows-x64.zip');
+      expect(release?.delivery, UpdateDelivery.inPlace);
+    });
+
+    test('an installation Lumit cannot write to falls back to the installer',
+        () {
+      final release = UpdateRelease.parse(
+        _releaseJson(),
+        platform: 'windows',
+        kind: InstallKind.folder,
+        replaceable: false,
+      );
+      // The archive is still the preferred *asset* — it is the delivery that
+      // changes, because an archive is no use where we cannot write.
+      expect(release?.delivery, UpdateDelivery.installer);
+    });
+
+    test('a macOS bundle takes the zip, and a loose binary takes the image',
+        () {
+      expect(
+        UpdateRelease.parse(_releaseJson(),
+                platform: 'macos',
+                kind: InstallKind.bundle,
+                replaceable: true)
+            ?.assetName,
+        'lumit-0.2.0-macos-arm64.zip',
+      );
+      expect(
+        UpdateRelease.parse(_releaseJson(),
+                platform: 'macos', kind: InstallKind.unknown)
+            ?.assetName,
+        endsWith('.dmg'),
+      );
+    });
+
+    test('a Flatpak is offered the bundle and nothing else', () {
+      expect(assetSuffixesFor('linux', kind: InstallKind.flatpak),
+          const ['.flatpak']);
+      final release = UpdateRelease.parse(_releaseJson(),
+          platform: 'linux', kind: InstallKind.flatpak);
+      expect(release?.assetName, endsWith('.flatpak'));
+      expect(release?.delivery, UpdateDelivery.flatpakBundle);
+    });
+
+    test('a release with no package still updates, by installer', () {
+      final release = UpdateRelease.parse(
+        _releaseJson(assets: [_asset('lumit-0.2.0-windows-x64-setup.exe')]),
+        platform: 'windows',
+        kind: InstallKind.folder,
+        replaceable: true,
+      );
+      expect(release?.delivery, UpdateDelivery.installer);
+    });
+  });
+
+  group('replacing Lumit in place (K-297)', () {
+    late Directory tmp;
+    setUp(() => tmp = Directory.systemTemp.createTempSync('lumit-inplace'));
+    tearDown(() {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    /// A real little installation, and a service pointed at it whose "unpack"
+    /// writes the new version out by hand.
+    ({UpdateService service, InstallSite site, List<File> relaunched})
+        installed({bool emptyArchive = false}) {
+      final root = Directory('${tmp.path}/Lumit')..createSync(recursive: true);
+      File('${root.path}/lumit_flutter').writeAsStringSync('0.1.0');
+      final site = InstallSite(
+        kind: InstallKind.folder,
+        root: root,
+        launcher: File('${root.path}/lumit_flutter'),
+      );
+      final relaunched = <File>[];
+      final body = utf8.encode('a package');
+      final service = _service(
+        platform: 'linux',
+        site: site,
+        folder: () => Directory('${tmp.path}/downloads')
+          ..createSync(recursive: true),
+        fetch: (_) async => _releaseJson(assets: [
+          _asset('lumit-0.2.0-linux-x64.tar.gz', size: body.length),
+        ]),
+        download: (url, into, {required onProgress, required cancelled}) async =>
+            into.writeAsBytesSync(body),
+        extract: (archive, into) async {
+          if (emptyArchive) return;
+          // What `tar` would leave: the tree inside its own wrapping folder.
+          final tree = Directory('${into.path}/lumit-0.2.0-linux-x64')
+            ..createSync(recursive: true);
+          File('${tree.path}/lumit_flutter').writeAsStringSync('0.2.0');
+        },
+        relaunch: (launcher) async => relaunched.add(launcher),
+      );
+      return (service: service, site: site, relaunched: relaunched);
+    }
+
+    test('the new version replaces the old at the same path, and restarts',
+        () async {
+      final h = installed();
+      await h.service.check();
+      expect(h.service.delivery, UpdateDelivery.inPlace);
+      await h.service.downloadUpdate();
+      await h.service.install();
+
+      expect(File('${h.site.root.path}/lumit_flutter').readAsStringSync(),
+          '0.2.0');
+      expect(h.relaunched, hasLength(1),
+          reason: 'no installer — Lumit starts itself again');
+      expect(h.site.previous.existsSync(), isTrue,
+          reason: 'the old files are still open; the next launch sweeps them');
+      expect(h.site.staging.existsSync(), isFalse);
+    });
+
+    test('an archive that unpacks to nothing leaves the old version standing',
+        () async {
+      final h = installed(emptyArchive: true);
+      await h.service.check();
+      await h.service.downloadUpdate();
+      await h.service.install();
+
+      expect(File('${h.site.root.path}/lumit_flutter').readAsStringSync(),
+          '0.1.0', reason: 'the working Lumit is untouched');
+      expect(h.service.stage, UpdateStage.failed);
+      expect(h.relaunched, isEmpty);
+      expect(h.site.unpacking.existsSync(), isFalse);
     });
   });
 
@@ -519,9 +682,12 @@ Future<UpdateService> _readyService(Directory scratch) async {
 UpdateService _service({
   String? version = '0.1.0',
   String platform = 'windows',
+  InstallSite? site,
   ReleaseFetcher? fetch,
   AssetDownloader? download,
   InstallerLauncher? launch,
+  ArchiveExtractor? extract,
+  Relauncher? relaunch,
   Quitter? quit,
   int Function()? now,
   Directory Function()? folder,
@@ -529,14 +695,29 @@ UpdateService _service({
     UpdateService(
       currentVersion: () => version,
       platform: platform,
+      // Unknown by default, which means "use the installer": a test has to
+      // ask for a replaceable installation before anything here will
+      // contemplate swapping folders about, so the suite can never reach the
+      // installation it is itself running from.
+      site: site ?? _unknownSite,
       fetch: fetch ?? (_) async => _releaseJson(),
       download: download ??
           (url, into, {required onProgress, required cancelled}) async {},
       launch: launch ?? (file, _) async {},
+      extract: extract ?? (archive, into) async {},
+      relaunch: relaunch ?? (launcher) async {},
       quit: quit ?? () {},
       now: now,
       downloadFolder: folder ?? Directory.systemTemp.createTempSync,
     );
+
+/// An installation Lumit cannot replace from inside — the safe default for
+/// every test that is not about replacing one.
+final InstallSite _unknownSite = InstallSite(
+  kind: InstallKind.unknown,
+  root: Directory('${Directory.systemTemp.path}/lumit-nowhere'),
+  launcher: File('${Directory.systemTemp.path}/lumit-nowhere/lumit'),
+);
 
 /// The shape of GitHub's answer, with only the fields the updater reads.
 Map<String, dynamic> _releaseJson({
@@ -550,10 +731,14 @@ Map<String, dynamic> _releaseJson({
       'draft': draft,
       'prerelease': prerelease,
       'html_url': 'https://github.com/luminalmvm/lumit/releases/tag/$tag',
+      // What a release actually carries (K-297): an installer and a package
+      // per platform, plus the Flatpak bundle.
       'assets': assets ??
           [
             _asset('lumit-0.2.0-windows-x64-setup.exe'),
+            _asset('lumit-0.2.0-windows-x64.zip'),
             _asset('lumit-0.2.0.dmg'),
+            _asset('lumit-0.2.0-macos-arm64.zip'),
             _asset('lumit-0.2.0-linux-x64.tar.gz'),
             _asset('lumit-0.2.0-linux-x64.flatpak'),
           ],

--- a/packaging/windows/lumit.iss
+++ b/packaging/windows/lumit.iss
@@ -20,7 +20,17 @@ AppName=Lumit
 AppVersion={#MyAppVersion}
 AppPublisher=Lumit
 AppPublisherURL=https://github.com/luminalmvm/Lumit
-DefaultDirName={autopf}\Lumit
+; Per user, not per machine (K-297). This is what lets Lumit update itself the
+; way Chrome and VS Code do: {localappdata} belongs to the person running it, so
+; the application can put a new version down beside the old one and swap them
+; over without an administrator and without running this installer again.
+; `PrivilegesRequired=lowest` means no UAC prompt to install in the first place.
+PrivilegesRequired=lowest
+DefaultDirName={localappdata}\Programs\Lumit
+; An existing installation keeps its folder, wherever a previous version put it
+; — including the old {autopf} one, which simply carries on being updated by
+; this installer rather than in place.
+UsePreviousAppDir=yes
 DefaultGroupName=Lumit
 LicenseFile=..\..\LICENSE
 OutputDir=dist


### PR DESCRIPTION
Help ▸ Check for updates was the last row of the bar that was listed and dead. It now carries the whole update sequence in the row itself — and updates no longer run an installer at all.

Two decisions: **K-296** (the updater) and **K-297** (per-user install, replacing itself). Numbered around #66, which took K-294/K-295 while this was in review.

## What it does

Press the row and it greys and reads *Checking for updates…*, then either `Click to update - v0.2.0` — the version in the row, where somebody deciding whether to update is already looking — or back to *Check for updates*, with "Lumit is up to date" in the status line. Press the offered version and Lumit fetches it, showing progress in the same row, and the last window asks about the restart, offering to save first when there is unsaved work.

Automatic checks are on by default, ticked on the setup screen and in Settings ▸ General ▸ Updates. "On" means *looking*, once a day at launch. The download always waits for a press.

## No installer (K-297)

The reason updates used to need an installer was the install location, not the updater: `Program Files` needs an administrator. So Lumit installs per user now — `{localappdata}\Programs\Lumit`, `PrivilegesRequired=lowest` — which is exactly what Chrome, VS Code and Discord do, and it is the whole trick.

Releases now publish the application as well as its installer: a Windows zip, a macOS bundle zip (via `ditto`, because a naive archiver drops the symlinks, permissions and signature that make an `.app` openable), and the Linux tarball that already existed. Unpacking uses the platform's own `tar`/`ditto`, so no new Dart dependency.

**The swap is two renames, not a file copy.** The new version unpacks to `<install>.new`, is verified and marked complete, then `Lumit` → `Lumit.old` → `Lumit.new` → `Lumit`. A rename either happened or it did not, so a complete working Lumit is on disk at every instant; copying hundreds of files over a running application is hundreds of chances to end up with neither version. A failed second rename undoes the first from memory, and `main()` sweeps the old folder on the next launch — or puts it back if it ever finds none.

**Three deliveries, chosen from where Lumit actually lives:** in place for a folder or bundle it can write beside (proven with a probe file, not assumed from the path); the installer wherever it cannot, which covers every existing `Program Files` install and the macOS disk image; and inside a Flatpak, the bundle plus the install command — a sandbox is read-only by design, and reaching the host to run `flatpak install` needs permissions an editor should not hold. A Flatpak remote, so `flatpak update` has something to update from, is written up in TODO.

## Other pieces

- `MenuEntry.live` — a menu row that redraws in place and does not close the menu when pressed. The only one, deliberately.
- Verification is a gate: the downloaded file must match the published length and, where GitHub gives one, its SHA-256, or it is deleted rather than run.
- `ci.yml` gained `workflow_dispatch`, after GitHub twice failed to deliver the `pull_request` event for a push on this branch and left the head with no run and nothing to re-run.
- `crates/lumit-bridge/Cargo.toml` names the `windows` features K-294's memory readout uses — `main` does not compile on Windows without it (see the thread).

## Tests

`updates_test.dart` and `install_site_test.dart` drive the whole sequence with every outside-world seam injected: no network, no installer ever run, no process ever quit. The swap is tested against real folders on disk — a rename is exactly the thing a mock filesystem would prove nothing about — including the half-finished swap, the abandoned download and the start-up sweep.

## CI

Green everywhere except `tests (Windows)`, which fails on #66's `what_the_engine_drops_the_driver_gets_back` — see the thread. Nothing here touches `lumit-render`.

The release-workflow packaging steps cannot be proven by a PR run: that workflow only fires on a `v*` tag.