### PR TITLE
Timeline: a layer is decided once, and both halves read that decision

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -215,15 +215,30 @@ imported theme travels with the user rather than the machine's settings.
     in [04-RETIMING.md](04-RETIMING.md).
 - **The Flow column is reserved, not wired** - per-layer optical flow has no
     engine backing. Build the engine model first, then the fold-out's Flow group.
-- **The Timeline's two halves are built twice and kept in step by hand.**
-    `_Outline` and `_LayerArea` are separate widget trees walking the same layer
-    list, aligned only because both read the same numbers, with vertical scroll
-    mirrored behind a reentrancy flag. Building a layer **once** as a row holding
-    both halves inside one vertical scrollable (the lane side keeping its own
-    horizontal controller) gives alignment by construction. It deletes
-    `blockHeights`, both controllers' sync and the guard flag rather than adding
-    anything. A session's refactor, no behaviour change, alignment tests as the
-    net.
+- **The Timeline's two halves are still two widget trees, and one vertical
+    scrollable cannot hold both.** This was once written down here as a session's
+    refactor — build each layer as a row holding both halves inside a single
+    vertical scrollable, and alignment holds by construction. It does not work,
+    and the reason is worth keeping so it is not re-derived. The ruler and the
+    cache bar scroll sideways with the lanes but must not scroll with the rows,
+    which means the lanes' horizontal scroll view has to sit *above* the vertical
+    one; a single `Scrollable` has a single subtree, so everything inside that
+    vertical scroll view then scrolls sideways with the lanes — including the
+    outline, which must not move (`timeline_alignment_test.dart` says so, and the
+    outline has a horizontal scroll of its own for narrow panels). Putting the
+    horizontal scrolls underneath instead gives one per row, and `_hLane` asserts
+    the moment a second position attaches to it, which is what `_positionOf`
+    exists to survive. The only arrangement that satisfies both is to drop the
+    lanes' horizontal *viewport* and offset them by a transform, with `_hLane`
+    anchored on the ruler band — and that costs horizontal trackpad panning over
+    the lanes, the very fault the `dragDevices` comment in the panel records as
+    invisible to anyone using a mouse. Not worth it. `blockHeights` stays
+    whichever way it goes: `layerDropSlot`, `layerDragTarget` and `LayerDragSlide`
+    each want every block's height, not one row's. What the merge was really
+    reaching for has landed instead — each layer is now decided **once** into a
+    `LayerRow` (its fold rows, its open Sequence view, its height) and both halves
+    read that, so they can differ in what they draw but no longer in what a layer
+    is. The scroll mirror and its guard flag stay.
 - **The lane keyframe selection selects and eases, nothing more** - moving or
     deleting a *whole lane selection* is not built (the graph view has both), nor
     are `=`/`-`/`\` or edge-follow during playback.

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -143,38 +143,82 @@ class LayerDrag {
   int get hashCode => Object.hash(from, to);
 }
 
-/// Every layer's block height: its own row plus whatever fold rows it shows.
+/// One layer as **both halves of the table see it**: the rows it shows, the
+/// room an open Sequence view wants, and the height those come to.
 ///
-/// Worked out **once per panel build and handed to both halves**, rather than
-/// each half measuring its own rows. Two measurements that must agree are two
-/// chances to disagree — and a half-pixel of disagreement is a table whose
-/// lanes drift out of line with their names as it scrolls.
-List<double> layerBlockHeights({
+/// The outline and the lane area are still two widget trees, and they have to
+/// be: they sit in two scroll views, and only the lane half rebuilds when the
+/// zoom moves (K-293). What they must never be is two *opinions*. Each half
+/// used to walk [layerFoldRows] for itself, test `open` for itself and look up
+/// `sequenceExtra` for itself, and the table was level only because all three
+/// pairs happened to agree — a layer could grow a row on one side and not the
+/// other, and nothing would say so. Decided once here, the halves can differ in
+/// what they draw but not in what a layer *is*.
+class LayerRow {
+  final BridgeLayerEntry entry;
+
+  /// The layer's id as a string, which is the key everything else is filed
+  /// under — worked out once rather than at each of the dozen places that
+  /// wanted it.
+  final String id;
+
+  /// Twirled open — whether [foldRows] are **drawn**.
+  final bool open;
+
+  /// The rows this layer's fold-out has, open or shut.
+  ///
+  /// Held for a shut layer too, because snapping wants them: a keyframe is
+  /// somewhere in time whether or not its row is on screen, and a key drag or
+  /// a razor cut can land on it either way (`_snapTargets`, K-292). Everything
+  /// that *draws* reads [drawnRows] instead — the one place that difference is
+  /// written down, rather than an `open` test remembered at each of five call
+  /// sites.
+  final List<LayerFoldRow> foldRows;
+
+  /// The rows the table draws under this layer: its fold-out when it is
+  /// twirled open, nothing when it is not.
+  List<LayerFoldRow> get drawnRows => open ? foldRows : const [];
+
+  /// How much taller an open Sequence view makes this row (K-248), or null
+  /// when the layer has no view open. **The outline reserves exactly the room
+  /// the lanes draw the view in**, or every row below sits at a different
+  /// height on the two sides.
+  final double? sequenceExtra;
+
+  const LayerRow({
+    required this.entry,
+    required this.id,
+    required this.open,
+    required this.foldRows,
+    required this.sequenceExtra,
+  });
+
+  /// This block's height: its own row, the rows it draws, and its open view.
+  double get height =>
+      _rowHeight * (1 + drawnRows.length) + (sequenceExtra ?? 0);
+}
+
+/// Decide every layer's row, once for the whole panel.
+List<LayerRow> layerRows({
   required List<BridgeLayerEntry> layers,
   required Set<String> open,
   required Map<String, bool> hasAudio,
-
-  /// How much taller each open sequence view makes its layer's row, by layer
-  /// id (K-248). **Both halves of the Timeline read this**: the outline
-  /// reserves the same room the lanes draw the view in, or the two stop lining
-  /// up and every row below sits at a different height on each side.
   Map<String, double> sequenceExtra = const {},
-}) =>
-    [
-      for (final entry in layers)
-        _rowHeight *
-                (1 +
-                    (open.contains(entry.layer.internallayerId.toString())
-                        ? layerFoldRows(
-                            entry: entry,
-                            open: open,
-                            hasAudio: hasAudio[
-                                    entry.layer.internallayerId.toString()] ??
-                                false,
-                          ).length
-                        : 0)) +
-            (sequenceExtra[entry.layer.internallayerId.toString()] ?? 0),
-    ];
+}) {
+  final out = <LayerRow>[];
+  for (final entry in layers) {
+    final id = entry.layer.internallayerId.toString();
+    out.add(LayerRow(
+      entry: entry,
+      id: id,
+      open: open.contains(id),
+      foldRows: layerFoldRows(
+          entry: entry, open: open, hasAudio: hasAudio[id] ?? false),
+      sequenceExtra: sequenceExtra[id],
+    ));
+  }
+  return out;
+}
 
 /// How far the block at [index] slides while a drag is in flight, in pixels;
 /// positive is down.
@@ -730,12 +774,11 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
   /// Where each open sequence view sits down the table, as (top, bottom) in
   /// the rows' own coordinates — what the row seams skip over, so an open view
   /// reads as one cell rather than six ruled rows.
-  List<(double, double)> _sequenceBlanks(
-      List<BridgeLayerEntry> layers, List<double> heights) {
+  List<(double, double)> _sequenceBlanks(List<LayerRow> rows) {
     final out = <(double, double)>[];
     var y = 0.0;
-    for (var i = 0; i < layers.length && i < heights.length; i++) {
-      final extra = _sequenceExtra[layers[i].layer.internallayerId.toString()];
+    for (final row in rows) {
+      final extra = row.sequenceExtra;
       if (extra != null) {
         // **From the top of the layer's own row.** The view takes that row as
         // the first of its three clip rows, so a seam ruled under it would cut
@@ -745,7 +788,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
         // line above it and the fold-out below still has one over it.
         out.add((y, y + _rowHeight + extra));
       }
-      y += heights[i];
+      y += row.height;
     }
     return out;
   }
@@ -1886,6 +1929,16 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
     // has ends, and they must be known the moment it comes back.
     _refreshBounds(ui.model, fpsNum, fpsDen);
 
+    // What each layer is, decided **once for the whole panel** and read by
+    // everything below — the outline, the lanes, the drag maths and the row
+    // seams alike. It used to be worked out four times over from the same
+    // three inputs, once per reader.
+    final rows = layerRows(
+        layers: layers,
+        open: _open,
+        hasAudio: _hasAudio,
+        sequenceExtra: _sequenceExtra);
+
     // The property rows on screen, in display order — what a Shift+click
     // range runs along — and the graph channels the selection resolves to,
     // each with its stroke colour for the outline's labels to match.
@@ -1894,15 +1947,9 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
     // that can be picked (and copied), so a Shift+click has to be able to run
     // over one. Waveforms are not a row anything selects.
     _visiblePropertyPaths = [
-      for (final e in layers)
-        if (_open.contains(e.layer.internallayerId.toString()))
-          for (final row in layerFoldRows(
-            entry: e,
-            open: _open,
-            hasAudio: _hasAudio[e.layer.internallayerId.toString()] ?? false,
-          ))
-            if (row is! FoldWaveformRow)
-              foldRowPath(e.layer.internallayerId.toString(), row),
+      for (final layer in rows)
+        for (final row in layer.drawnRows)
+          if (row is! FoldWaveformRow) foldRowPath(layer.id, row),
     ];
     final channels =
         graphChannels(layers: ui.model.layers, selected: _selectedProperties);
@@ -1910,14 +1957,12 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
     // ruler draws it, the lanes and the curves are washed by it, and the two
     // are one span.
     final work = workAreaFrames(comp);
-    // One walk of the row stack for the whole panel: both halves slide their
-    // blocks by these heights during a drag, so neither can measure the table
-    // differently from the other (K-208).
-    final blockHeights = layerBlockHeights(
-        sequenceExtra: _sequenceExtra,
-        layers: layers,
-        open: _open,
-        hasAudio: _hasAudio);
+    // The block heights, as a plain list. Still needed even though the rows
+    // now carry their own height: a drag measures its travel against the
+    // *stack* ([layerDragTarget]), a drop reads a slot out of it
+    // ([layerDropSlot]) and [LayerDragSlide] slides one block by the ones it
+    // passes — all three want every height, not this row's.
+    final blockHeights = [for (final row in rows) row.height];
     final graphColours = <String, List<Color>>{};
     for (final channel in channels) {
       (graphColours[channel.path] ??= [])
@@ -2152,9 +2197,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                                       controller: _vOutline,
                                                       child: _Outline(
                                                         comp: comp,
-                                                        layers: layers,
-                                                        sequenceExtra:
-                                                            _sequenceExtra,
+                                                        rows: rows,
                                                         onOpenSequence:
                                                             _toggleSequenceView,
                                                         layerDrag: _layerDrag,
@@ -2176,8 +2219,6 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                                             _selectProperty,
                                                         onEditProperty:
                                                             _selectOnEdit,
-                                                        open: _open,
-                                                        hasAudio: _hasAudio,
                                                         onToggle: _toggle,
                                                         playheadFrame: ui
                                                             .playheadFrame
@@ -2245,8 +2286,8 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                             // carried up by however far the rows
                                             // have scrolled.
                                             blanks: [
-                                              for (final b in _sequenceBlanks(
-                                                  layers, blockHeights))
+                                              for (final b
+                                                  in _sequenceBlanks(rows))
                                                 (
                                                   b.$1 -
                                                       (_positionOf(_vOutline)
@@ -2526,15 +2567,12 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                                     width: axis.width,
                                                     child: _LayerArea(
                                                       comp: comp,
-                                                      layers: layers,
+                                                      rows: rows,
                                                       selectedIds:
                                                           ui.selectedLayerIds,
                                                       layerDrag: _layerDrag,
                                                       blockHeights:
                                                           blockHeights,
-                                                      open: _open,
-                                                      sequenceExtra:
-                                                          _sequenceExtra,
                                                       onOpenSequence:
                                                           _toggleSequenceView,
                                                       onGraphHeight: (entry,
@@ -2545,9 +2583,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                                                   .internallayerId
                                                                   .toString()] = h),
                                                       sequenceBlanks:
-                                                          _sequenceBlanks(
-                                                              layers,
-                                                              blockHeights),
+                                                          _sequenceBlanks(rows),
                                                       hScroll: _hLane,
                                                       onClipPreview: (entry,
                                                               clip, keys) =>
@@ -2561,7 +2597,6 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                                                         retime: BridgeScalar
                                                             .keyframed(keys),
                                                       ),
-                                                      hasAudio: _hasAudio,
                                                       peaks: _peaks,
                                                       waveformStyle:
                                                           _waveformStyle,
@@ -4759,7 +4794,11 @@ Future<void> _showLayerMenu(
 /// The left column: one row per layer, with its switches and columns.
 class _Outline extends StatelessWidget {
   final CompositionReference comp;
-  final List<BridgeLayerEntry> layers;
+
+  /// The layers as the panel decided them — the same [LayerRow] list the lane
+  /// area draws from, so a row's fold-out, its open Sequence view and its
+  /// height are one answer rather than two that agree.
+  final List<LayerRow> rows;
 
   /// The column groups in their current order and at their current widths
   /// (docs/07 §4.2) — rows draw their cells to match the header's.
@@ -4781,14 +4820,9 @@ class _Outline extends StatelessWidget {
   final Map<String, List<Color>> graphColours;
   final ValueChanged<String> onSelectProperty;
   final ValueChanged<String> onEditProperty;
-  final Set<String> open;
 
-  /// How much taller each open sequence view makes its row, by layer id, and
-  /// how to toggle one (K-248). The outline reserves exactly what the lanes
-  /// draw, so the two halves stay in step.
-  final Map<String, double> sequenceExtra;
+  /// Open or close a Sequence layer's view (K-248).
   final void Function(BridgeLayerEntry entry)? onOpenSequence;
-  final Map<String, bool> hasAudio;
   final ValueChanged<String> onToggle;
   final int playheadFrame;
   final ValueChanged<int> onSeek;
@@ -4806,7 +4840,7 @@ class _Outline extends StatelessWidget {
 
   const _Outline({
     required this.comp,
-    required this.layers,
+    required this.rows,
     required this.groupOrder,
     required this.widths,
     required this.selectedIds,
@@ -4815,10 +4849,7 @@ class _Outline extends StatelessWidget {
     required this.graphColours,
     required this.onSelectProperty,
     required this.onEditProperty,
-    required this.open,
-    this.sequenceExtra = const {},
     this.onOpenSequence,
-    required this.hasAudio,
     required this.onToggle,
     required this.playheadFrame,
     required this.onSeek,
@@ -4833,10 +4864,14 @@ class _Outline extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final valueColumn = valueColumnFor(groupOrder, widths);
+    // The layer entries, for the parent picker's menu — every layer is on
+    // offer as a parent, and they come from the row list rather than from a
+    // second list handed in beside it.
+    final layers = [for (final row in rows) row.entry];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        for (var i = 0; i < layers.length; i++)
+        for (var i = 0; i < rows.length; i++)
           LayerDragSlide(
             drag: layerDrag,
             heights: blockHeights,
@@ -4845,30 +4880,25 @@ class _Outline extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 _OutlineRow(
-                  key: ValueKey<String>(
-                      'tl-row-${layers[i].layer.internallayerId}'),
+                  key: ValueKey<String>('tl-row-${rows[i].id}'),
                   comp: comp,
-                  entry: layers[i],
-                  onOpenSequence: () => onOpenSequence?.call(layers[i]),
+                  entry: rows[i].entry,
+                  onOpenSequence: () => onOpenSequence?.call(rows[i].entry),
                   layers: layers,
                   groupOrder: groupOrder,
                   widths: widths,
                   index: i,
-                  count: layers.length,
+                  count: rows.length,
                   // A local compare, not a bridge call: both ids already sit here.
                   selected:
-                      selectedIds.contains(layers[i].layer.internallayerId),
+                      selectedIds.contains(rows[i].entry.layer.internallayerId),
                   // A layer marks itself when its fold was last touched, and when
                   // a selected property is one of its own (docs/07 §4.3).
-                  highlighted: highlighted ==
-                          layers[i].layer.internallayerId.toString() ||
-                      selectedProperties.any((p) => isUnderPath(
-                          layers[i].layer.internallayerId.toString(), p)),
-                  open:
-                      open.contains(layers[i].layer.internallayerId.toString()),
-                  onToggleOpen: () =>
-                      onToggle(layers[i].layer.internallayerId.toString()),
-                  onSelect: () => onSelect(layers[i].layer),
+                  highlighted: highlighted == rows[i].id ||
+                      selectedProperties.any((p) => isUnderPath(rows[i].id, p)),
+                  open: rows[i].open,
+                  onToggleOpen: () => onToggle(rows[i].id),
+                  onSelect: () => onSelect(rows[i].entry.layer),
                   onChanged: onChanged,
                   layerDrag: layerDrag,
                   renameRequest: renameRequest,
@@ -4878,50 +4908,40 @@ class _Outline extends StatelessWidget {
                 // outline has nothing to put here — the clips and their envelope are
                 // the lane's to draw — but it must leave exactly the same gap, or
                 // every row below this one sits at a different height on the two
-                // sides of the Timeline and the halves stop lining up.
-                if (sequenceExtra
-                    .containsKey(layers[i].layer.internallayerId.toString()))
+                // sides of the Timeline and the halves stop lining up. Both sides
+                // ask the same [LayerRow], so the gap and the view cannot be
+                // opened by one half and not the other.
+                if (rows[i].sequenceExtra != null)
                   SizedBox(
-                    key: ValueKey<String>(
-                        'tl-seq-room-${layers[i].layer.internallayerId}'),
-                    height: sequenceExtra[
-                        layers[i].layer.internallayerId.toString()],
+                    key: ValueKey<String>('tl-seq-room-${rows[i].id}'),
+                    height: rows[i].sequenceExtra,
                   ),
                 // The fold-out, from the same list the lanes leave room for.
-                if (open.contains(layers[i].layer.internallayerId.toString()))
-                  for (final row in layerFoldRows(
-                    entry: layers[i],
-                    open: open,
-                    hasAudio:
-                        hasAudio[layers[i].layer.internallayerId.toString()] ??
-                            false,
-                  ))
-                    // A raw pointer listener, not a gesture: touching a sub-item
-                    // highlights its layer, and it must never fight the row's own
-                    // taps and drags for the gesture arena.
-                    Listener(
-                      onPointerDown: (_) => onHighlight(
-                          layers[i].layer.internallayerId.toString()),
-                      child: _FoldRow(
-                        comp: comp,
-                        layer: layers[i].layer,
-                        row: row,
-                        valueColumn: valueColumn,
-                        timingsColumn: timingsColumnFor(groupOrder, widths),
-                        baseIndent: identityStart(groupOrder, widths),
-                        path: foldRowPath(
-                            layers[i].layer.internallayerId.toString(), row),
-                        selectedProperties: selectedProperties,
-                        graphColours: graphColours,
-                        onSelectProperty: onSelectProperty,
-                        onEditProperty: onEditProperty,
-                        playheadFrame: playheadFrame,
-                        onSeek: onSeek,
-                        onToggle: onToggle,
-                        onChanged: onChanged,
-                        locked: layers[i].info.switches.locked,
-                      ),
+                for (final row in rows[i].drawnRows)
+                  // A raw pointer listener, not a gesture: touching a sub-item
+                  // highlights its layer, and it must never fight the row's own
+                  // taps and drags for the gesture arena.
+                  Listener(
+                    onPointerDown: (_) => onHighlight(rows[i].id),
+                    child: _FoldRow(
+                      comp: comp,
+                      layer: rows[i].entry.layer,
+                      row: row,
+                      valueColumn: valueColumn,
+                      timingsColumn: timingsColumnFor(groupOrder, widths),
+                      baseIndent: identityStart(groupOrder, widths),
+                      path: foldRowPath(rows[i].id, row),
+                      selectedProperties: selectedProperties,
+                      graphColours: graphColours,
+                      onSelectProperty: onSelectProperty,
+                      onEditProperty: onEditProperty,
+                      playheadFrame: playheadFrame,
+                      onSeek: onSeek,
+                      onToggle: onToggle,
+                      onChanged: onChanged,
+                      locked: rows[i].entry.info.switches.locked,
                     ),
+                  ),
               ],
             ),
           ),
@@ -5669,21 +5689,19 @@ class _OutlineRowState extends State<_OutlineRow> {
 /// The right column: the ruler, the playhead, and one bar per layer.
 class _LayerArea extends StatelessWidget {
   final CompositionReference comp;
-  final List<BridgeLayerEntry> layers;
+
+  /// The layers as the panel decided them — the same [LayerRow] list the
+  /// outline draws from. Which rows a layer shows, whether its Sequence view
+  /// is open and how tall the block is are read here rather than worked out
+  /// again, so this half cannot come to a different answer from the other.
+  final List<LayerRow> rows;
 
   /// The selection as ids, the same set the outline draws from (K-217) — a bar
   /// outlines when its name row is lit, so the two halves of the table never
   /// disagree about what is chosen.
   final Set<UuidValue> selectedIds;
 
-  /// Which layers are twirled open in the outline. Read only to leave the same
-  /// room their property rows take, so a bar never drifts away from its name.
-  final Set<String> open;
-
-  /// How much taller each open sequence view makes its row, by layer id, and
-  /// how to toggle one (K-248). The outline reserves exactly what the lanes
-  /// draw, so the two halves stay in step.
-  final Map<String, double> sequenceExtra;
+  /// Open or close a Sequence layer's view (K-248).
   final void Function(BridgeLayerEntry entry)? onOpenSequence;
 
   /// The graph half of a sequence view has been dragged to a new height.
@@ -5701,10 +5719,6 @@ class _LayerArea extends StatelessWidget {
 
   /// Where the open sequence views sit, so the row seams skip them (K-248).
   final List<(double, double)> sequenceBlanks;
-
-  /// Which layers carry sound — passed through only so the row list this side
-  /// builds is identical to the outline's.
-  final Map<String, bool> hasAudio;
 
   /// Each layer's source peaks, for the waveform lanes.
   final Map<String, BridgeAudioPeaks> peaks;
@@ -5779,16 +5793,13 @@ class _LayerArea extends StatelessWidget {
 
   const _LayerArea({
     required this.comp,
-    required this.layers,
+    required this.rows,
     required this.selectedIds,
-    required this.open,
-    this.sequenceExtra = const {},
     this.onOpenSequence,
     this.onGraphHeight,
     this.sequenceBlanks = const [],
     this.hScroll,
     this.onClipPreview,
-    required this.hasAudio,
     required this.peaks,
     required this.waveformStyle,
     required this.fps,
@@ -5815,24 +5826,14 @@ class _LayerArea extends StatelessWidget {
     required this.onWheel,
   });
 
-  /// The fold rows the lanes leave room for, per layer — one walk shared by
-  /// the lane column, the marquee's hit maths and the diamonds.
-  List<LayerFoldRow> _rowsOf(BridgeLayerEntry entry) => layerFoldRows(
-        entry: entry,
-        open: open,
-        hasAudio: hasAudio[entry.layer.internallayerId.toString()] ?? false,
-      );
-
   /// Every keyframe the box caught, walking the same rows the lanes draw —
   /// y from the row stack, x from the key's frame on the axis.
   Set<String> _keysIn(Rect rect) {
     final caught = <String>{};
     var y = 0.0;
-    for (final entry in layers) {
-      final id = entry.layer.internallayerId.toString();
+    for (final layer in rows) {
       y += _rowHeight; // the layer's own bar row
-      if (!open.contains(id)) continue;
-      for (final row in _rowsOf(entry)) {
+      for (final row in layer.drawnRows) {
         final rowTop = y;
         y += _rowHeight;
         if (rowTop + _rowHeight < rect.top || rowTop > rect.bottom) continue;
@@ -5840,7 +5841,7 @@ class _LayerArea extends StatelessWidget {
         for (var i = 0; i < keys.length; i++) {
           final x = axis.xOf(laneKeyFrame(keys[i], fps));
           if (x >= rect.left && x <= rect.right) {
-            caught.add('${foldRowPath(id, row)}#$i');
+            caught.add('${foldRowPath(layer.id, row)}#$i');
           }
         }
       }
@@ -5985,7 +5986,7 @@ class _LayerArea extends StatelessWidget {
                             Column(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               children: [
-                                for (var i = 0; i < layers.length; i++)
+                                for (var i = 0; i < rows.length; i++)
                                   // The block slides by the same rule and
                                   // the same heights the outline's does, so
                                   // a layer dragged up the stack takes its
@@ -6010,10 +6011,7 @@ class _LayerArea extends StatelessWidget {
                                       // paints over the content and
                                       // occupies no layout at all.
                                       foregroundDecoration:
-                                          sequenceExtra.containsKey(layers[i]
-                                                  .layer
-                                                  .internallayerId
-                                                  .toString())
+                                          rows[i].sequenceExtra != null
                                               ? BoxDecoration(
                                                   border: Border.all(
                                                     color: t.accent
@@ -6035,56 +6033,50 @@ class _LayerArea extends StatelessWidget {
                                           // bar drawn across the first of
                                           // them would put a seam through
                                           // the middle of it (K-248).
-                                          if (!sequenceExtra.containsKey(
-                                              layers[i]
-                                                  .layer
-                                                  .internallayerId
-                                                  .toString()))
+                                          if (rows[i].sequenceExtra == null)
                                             _Bar(
                                               key: ValueKey<String>(
-                                                  'tl-bar-${layers[i].layer.internallayerId}'),
+                                                  'tl-bar-${rows[i].id}'),
                                               comp: comp,
-                                              entry: layers[i],
+                                              entry: rows[i].entry,
                                               axis: axis,
                                               razor: razor,
                                               selected: selectedIds.contains(
-                                                  layers[i]
+                                                  rows[i]
+                                                      .entry
                                                       .layer
                                                       .internallayerId),
                                               playheadFrame: () =>
                                                   playhead.value,
                                               onRazor: (frame) =>
-                                                  onRazor(layers[i], frame),
+                                                  onRazor(rows[i].entry, frame),
                                               razorFrameAt: razorFrameAt,
                                               onSelect: () =>
-                                                  onSelect(layers[i].layer),
-                                              onOpenSequence: layers[i]
+                                                  onSelect(rows[i].entry.layer),
+                                              onOpenSequence: rows[i]
+                                                          .entry
                                                           .info
                                                           .kind ==
                                                       BridgeLayerKind.sequence
                                                   ? () => onOpenSequence
-                                                      ?.call(layers[i])
+                                                      ?.call(rows[i].entry)
                                                   : null,
                                               onChanged: onChanged,
                                               dragPreview: dragPreview,
-                                              bounds: bounds[layers[i]
-                                                      .layer
-                                                      .internallayerId
-                                                      .toString()] ??
+                                              bounds: bounds[rows[i].id] ??
                                                   BarBounds.free,
                                             ),
                                           // A Sequence layer's own clips and
                                           // their speed envelope, in the room
-                                          // the row grew for them (K-248).
-                                          if (sequenceExtra.containsKey(
-                                              layers[i]
-                                                  .layer
-                                                  .internallayerId
-                                                  .toString()))
+                                          // the row grew for them (K-248) —
+                                          // the same `sequenceExtra` the
+                                          // outline left the gap for, so the
+                                          // view and its room are one answer.
+                                          if (rows[i].sequenceExtra != null)
                                             SequenceViewFrb(
                                               key: ValueKey<String>(
-                                                  'tl-seq-${layers[i].layer.internallayerId}'),
-                                              entry: layers[i],
+                                                  'tl-seq-${rows[i].id}'),
+                                              entry: rows[i].entry,
                                               axis: axis,
                                               fps: fps,
                                               fpsNum: fpsNum,
@@ -6093,45 +6085,44 @@ class _LayerArea extends StatelessWidget {
                                               style: waveformStyle,
                                               razor: razor,
                                               onRazor: (frame) =>
-                                                  onRazor(layers[i], frame),
+                                                  onRazor(rows[i].entry, frame),
                                               razorFrameAt: razorFrameAt,
                                               onSelect: () =>
-                                                  onSelect(layers[i].layer),
+                                                  onSelect(rows[i].entry.layer),
                                               onClose: () => onOpenSequence
-                                                  ?.call(layers[i]),
-                                              graphHeight: (sequenceExtra[
-                                                          layers[i]
-                                                              .layer
-                                                              .internallayerId
-                                                              .toString()] ??
-                                                      sequenceViewHeight) -
-                                                  sequenceClipExtra,
+                                                  ?.call(rows[i].entry),
+                                              graphHeight:
+                                                  (rows[i].sequenceExtra ??
+                                                          sequenceViewHeight) -
+                                                      sequenceClipExtra,
                                               onGraphHeight: (h) =>
                                                   onGraphHeight?.call(
-                                                      layers[i], h),
+                                                      rows[i].entry, h),
                                               onPreview: (clip, keys) =>
                                                   onClipPreview?.call(
-                                                      layers[i], clip, keys),
+                                                      rows[i].entry,
+                                                      clip,
+                                                      keys),
                                               onChanged: onChanged,
                                             ),
                                           // One lane per fold-out row the outline shows,
                                           // from the same list it builds: keyframe rows
                                           // draw their diamonds, the waveform row its
                                           // peaks (K-172), the rest leave their room.
-                                          if (open.contains(layers[i]
-                                              .layer
-                                              .internallayerId
-                                              .toString()))
+                                          if (rows[i].open)
                                             Column(
                                               key: ValueKey<String>(
-                                                  'tl-lanes-${layers[i].layer.internallayerId}'),
+                                                  'tl-lanes-${rows[i].id}'),
                                               children: [
                                                 for (final row
-                                                    in _rowsOf(layers[i]))
+                                                    in rows[i].drawnRows)
                                                   SizedBox(
                                                     height: _rowHeight,
-                                                    child: _lane(t, layers[i],
-                                                        row, snap),
+                                                    child: _lane(
+                                                        t,
+                                                        rows[i].entry,
+                                                        row,
+                                                        snap),
                                                   ),
                                               ],
                                             ),
@@ -6207,13 +6198,13 @@ class _LayerArea extends StatelessWidget {
   /// panel from the read model and the memoised marker list — so it costs no
   /// bridge calls, and no lane pays for another lane's targets.
   List<SnapTarget> _snapTargets() => snapTargetsOf(
-        layers: layers,
+        layers: [for (final row in rows) row.entry],
         compMarkers: markersOf(comp),
         keyRows: [
-          for (final entry in layers)
-            for (final row in _rowsOf(entry))
+          for (final layer in rows)
+            for (final row in layer.foldRows)
               (
-                rowId: foldRowPath(entry.layer.internallayerId.toString(), row),
+                rowId: foldRowPath(layer.id, row),
                 frames: [
                   for (final k in laneKeysOf(row)) laneKeyFrame(k, fps),
                 ],


### PR DESCRIPTION
> **Stacked on #76** (the alignment tests are this refactor's net). Merge #76 first and this retargets to `main`.

## The backlog entry was wrong, and this PR says so

`docs/TODO.md` asked for the Timeline's two halves to become one row inside one vertical scrollable, "which gives alignment by construction" and "deletes `blockHeights`". **Both halves of that are wrong**, and the entry is rewritten here so nobody re-derives it.

**Why the merge cannot be built.** The ruler and cache bar scroll horizontally with the lanes and must not scroll vertically. That forces the horizontal scrollable to be an *ancestor* of the vertical one — which is how it is nested today. But a `Scrollable` has a single subtree, so everything inside the vertical view then scrolls sideways too, including the outline halves the merge exists to put there. The outline must not move when the lanes scroll sideways; alignment test 5 asserts exactly that.

Stated generally: **two subtrees with independent horizontal offsets cannot share one vertical `Scrollable`.** Whichever horizontal scrollable is outermost applies to both, and neither can be innermost without becoming per-row — which trips the multi-position assert (`_positionOf`) and throws on every `_hLane.offset` read.

The escapes were checked. Nesting per half is today's layout re-nested. A pinned sliver puts the halves in different slivers *and* grows `maxScrollExtent` by the outline width, silently corrupting `zoomAnchorOffset`'s frame-span maths. A true two-dimensional scroll view is a new dependency and a panel rewrite.

The one shape that satisfies the letter of it replaces the lanes' horizontal viewport with a transform offset — **losing horizontal trackpad panning over the lanes**, the precise regression the `ScrollConfiguration` comment records as having been invisible to anyone on a mouse. It also adds a per-row clip/translate plus stacking care for five cross-row overlays, so it costs more machinery than it deletes.

## What this does instead

The real fault was never the scroll mirror. It was that **both trees computed the same per-layer facts independently and were correct only because they happened to agree.**

A layer is now decided once, into a `LayerRow`, and both halves read that decision:

- **`layerFoldRows` went from up to five walks per layer per build to one**
- the `open` test, evaluated independently by each half, is now one field
- the sequence-extra branch — three separate `containsKey` tests across the outline spacer, the lane view and the bar suppression, all of which had to agree — is one nullable value, and the lane's `graphHeight` reads exactly what the outline reserved
- `internallayerId.toString()` fell from 40 occurrences to 21
- `_Outline` no longer takes a layer list beside its rows, so the two cannot disagree about which layers exist
- `_LayerArea._rowsOf` is gone; both halves lose their `open`, `hasAudio` and `sequenceExtra` fields; `layerBlockHeights` becomes one line

**The scroll architecture is deliberately untouched**, and `blockHeights` stays — drop-slot and drag-target geometry still need it.

## One asymmetry preserved rather than tidied away

The lane gathered fold rows **unconditionally**, so `_snapTargets` takes snap targets from *closed* layers' keyframes while everything else gates on `open`. That is invisible in the old code and easy to lose in a refactor. `LayerRow` keeps every layer's rows and exposes `drawnRows` for the four places that draw, so the difference is written down once instead of being an `open` test remembered at five call sites.

## Verification

7,357 → 7,348 lines. No behaviour change. The eight alignment tests pass **untouched** (that file is not modified by this PR), with the panel, drag, snap and razor suites — **148 tests**. `flutter analyze` clean.