### PR TITLE
Retime clock at the footage rate, and scrub modifiers

### DIFF
--- a/docs/04-RETIMING.md
+++ b/docs/04-RETIMING.md
@@ -491,7 +491,10 @@ vertically after the edited segment.
 - **The Retime row's own value reads as a timecode** (`HH:MM:SS:FF`, with a leading minus
   for a source time before zero), not as a number of seconds — K-287, realising K-075's
   value lens for the outline row. It is dragged and typed in whole source frames, at the
-  composition's rate until the read model carries the footage's own. Settings ▸ Interface ▸
+  **footage's own rate** — 600 fps footage counts to `:599` whatever the comp's rate is.
+  The rate is probed from the media when the row appears; until it answers, and for a
+  source that is not footage or cannot be probed, the composition's rate stands in so the
+  clock is always usable. Settings ▸ Interface ▸
   Editing ▸ *Retime values in seconds* puts the decimal seconds field back, which is also
   the only way to state a position between two frames.
 - Graph editor header: speed at the playhead (per cent, one decimal), resolved source

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -1050,7 +1050,10 @@ measurement — the panel shows the numbers, it does not turn them on.
   The rows are one implementation shared with the Effect controls panel
   (`transform_rows_frb.dart`, `effect_param_row_frb.dart`) rather than a second copy, so a
   parameter behaves the same wherever it is shown. A drag stages the value, previews it through
-  the engine's patched clone, and commits once on release: one undo step for the gesture. The
+  the engine's patched clone, and commits once on release: one undo step for the gesture.
+  Every scrub-drag obeys the modifier convention After Effects uses: holding `Shift` is
+  coarse (×10 per pixel), holding `Ctrl` is fine (×0.1), and pressing or releasing the
+  modifier mid-drag takes effect at once. The
   fold-out is worked out once as a list of rows (`layer_fold_frb.dart`) that *both* halves of
   the table walk — the outline drawing each row, the lane side leaving its height — so bars
   cannot drift away from their names. Each property row leads with its keyframe controls —

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -4590,6 +4590,27 @@ class _RetimeRowState extends State<_RetimeRow> {
     super.dispose();
   }
 
+  /// The footage's own rate, probed once when the row mounts. Null until the
+  /// probe answers, or when the source is not footage (or carries no video
+  /// stream) — the comp rate stands in then, so the clock is always usable.
+  (int, int)? _sourceFps;
+
+  @override
+  void initState() {
+    super.initState();
+    _probeSourceFps();
+  }
+
+  Future<void> _probeSourceFps() async {
+    final item = widget.layer.getSourceItem();
+    if (item is! ItemReference_Footage) return;
+    final info = await item.field0.mediaInfo();
+    if (!mounted || info == null || info.fpsNum <= 0 || info.fpsDen <= 0) {
+      return;
+    }
+    setState(() => _sourceFps = (info.fpsNum, info.fpsDen));
+  }
+
   /// Whether this gesture already planted its key — one plant per drag.
   bool _planted = false;
 
@@ -4639,7 +4660,9 @@ class _RetimeRowState extends State<_RetimeRow> {
     // Which face the row wears (K-287): the clock by default, seconds for
     // anyone who asked for them in Settings ▸ Interface ▸ Editing.
     final seconds = ui.workspace.interface.retimeInSeconds;
-    final (fpsNum, fpsDen) = ui.model.fpsExact;
+    // The clock face counts *source* frames, so it runs at the footage's own
+    // rate — 600 fps footage counts to :599 whatever the comp's rate says.
+    final (fpsNum, fpsDen) = _sourceFps ?? ui.model.fpsExact;
 
     return ValueListenableBuilder<int>(
       valueListenable: playhead,
@@ -4736,8 +4759,9 @@ class _RetimeRowState extends State<_RetimeRow> {
 
   /// A source time in seconds as a whole source frame, and back.
   ///
-  /// At the composition's rate: the read model does not carry the footage's own
-  /// rate yet, and every other time in the panel is counted in comp frames.
+  /// At the footage's own rate where the source is footage whose rate is
+  /// known; at the composition's rate until the probe answers, and for
+  /// everything else.
   static int _frameOfSeconds(double seconds, int fpsNum, int fpsDen) {
     if (fpsDen <= 0 || fpsNum <= 0) return 0;
     return (seconds * fpsNum / fpsDen).round();

--- a/flutter_ui/lib/widgets/controls.dart
+++ b/flutter_ui/lib/widgets/controls.dart
@@ -1927,6 +1927,17 @@ class _TickPainter extends CustomPainter {
   bool shouldRepaint(_TickPainter old) => old.color != color;
 }
 
+/// How much a scrub tick is worth right now, from the modifier keys — the
+/// After Effects convention: Shift makes a drag coarse (×10), Ctrl makes it
+/// fine (×0.1), and nothing held is ×1. Sampled inside the drag handler on
+/// every update, so pressing or releasing a modifier mid-drag takes effect at
+/// once.
+double scrubFactor() => HardwareKeyboard.instance.isShiftPressed
+    ? 10
+    : HardwareKeyboard.instance.isControlPressed
+        ? 0.1
+        : 1;
+
 /// egui's DragValue: drag horizontally to adjust, click to type, right-click
 /// for Reset / Copy / Paste (egui's built-in drag-value menu). [resetTo] is the
 /// field's known default — Reset appears only when a call site supplies one.
@@ -2229,10 +2240,15 @@ class _DragValueFieldState extends State<DragValueField>
             widget.onChangeStart?.call();
           },
           onHorizontalDragUpdate: (d) {
-            _dragAccum += d.delta.dx * widget.speed;
-            if (_dragAccum.abs() >= widget.speed) {
-              final next =
-                  (widget.value + _dragAccum).clamp(widget.min, widget.max);
+            final factor = scrubFactor();
+            _dragAccum += d.delta.dx * widget.speed * factor;
+            if (_dragAccum.abs() >= widget.speed * factor) {
+              // The drag runs from its own last tick, not from `widget.value`:
+              // pointer events arrive faster than rebuilds, and a base read
+              // from the stale prop dropped every chunk but the frame's last —
+              // a fast drag lost most of its travel.
+              final next = ((_lastDragValue ?? widget.value) + _dragAccum)
+                  .clamp(widget.min, widget.max);
               _dragAccum = 0;
               _lastDragValue = next;
               (widget.onChangeLive ?? widget.onChanged)(next);

--- a/flutter_ui/lib/widgets/time_readout.dart
+++ b/flutter_ui/lib/widgets/time_readout.dart
@@ -242,7 +242,9 @@ class _TimeReadoutState extends State<TimeReadout>
             : null,
         onHorizontalDragUpdate: widget.draggable
             ? (d) {
-                _dragAccum += d.delta.dx;
+                // Shift scrubs coarse (×10), Ctrl fine (×0.1) — with whole
+                // frames, fine means ten times the drag per frame.
+                _dragAccum += d.delta.dx * scrubFactor();
                 final steps = (_dragAccum / _pixelsPerFrame).truncate();
                 if (steps == 0) return;
                 _dragAccum -= steps * _pixelsPerFrame;

--- a/flutter_ui/test/frb/timeline_panel_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_panel_frb_test.dart
@@ -1618,6 +1618,34 @@ void main() {
           reason: 'the setting puts the seconds field back');
     });
 
+    /// The Retime clock counts *source* frames at the footage's own rate.
+    /// Half a second into 600 fps footage is frame 300 — a clock at the comp's
+    /// 60 fps would call the same moment frame 30, and could never say :599.
+    testWidgets('the Retime clock runs at the footage rate, not the comp rate',
+        (tester) async {
+      final p = withComp();
+      final footage =
+          p.state.project!.importFootage(path: _highRateVideoFile('fast.y4m'));
+      p.comp.addFootageLayer(footage: footage, asSequence: false);
+      final layer = p.comp.getLayers().single;
+      layer.toggleRetimeProperty();
+      // Half a second at the comp's 60 fps: the identity map reads 0.5 s of
+      // source here.
+      p.uiState.playheadFrame.value = 30;
+      p.uiState.model.refresh();
+      await mount(tester, p);
+      await tester.tap(
+          find.byKey(ValueKey<String>('tl-twirl-${layer.internallayerId}')));
+      await tester.pump();
+
+      // The row probes the footage's rate over an async frb call; real
+      // event-loop turns deliver the answer.
+      await settleFrb(tester,
+          until: () => find.text('00:00:00:300').evaluate().isNotEmpty);
+      expect(find.text('00:00:00:300'), findsOneWidget,
+          reason: 'the clock counts source frames at 600 fps, not comp frames');
+    });
+
     /// An animated value stays editable in the outline (docs/07 §4.3): on a
     /// keyframe the edit lands in that key; between keyframes it plants one.
     /// Fails if the cell falls back to a read-only "animated" label, or if it
@@ -4519,4 +4547,24 @@ Uint8List _tinyWav() {
   }
   out.add(data);
   return out.toBytes();
+}
+
+/// A real, probeable 600 fps video on disk: one second of 2×2 YUV4MPEG.
+///
+/// y4m because it is the one video container a test can write by hand — a
+/// plain-text header carrying the exact rational rate, then raw frames — and
+/// FFmpeg reads it natively, so the engine's probe reports 600/1 for real.
+String _highRateVideoFile(String name) {
+  final dir = Directory.systemTemp.createTempSync('lumit-retime');
+  final file = File('${dir.path}/$name');
+  final out = BytesBuilder();
+  out.add('YUV4MPEG2 W2 H2 F600:1 Ip A1:1 C420\n'.codeUnits);
+  // 600 frames of grey: per frame, 4 luma bytes and one byte per chroma plane.
+  final frame = Uint8List.fromList(
+      [...'FRAME\n'.codeUnits, 128, 128, 128, 128, 128, 128]);
+  for (var i = 0; i < 600; i++) {
+    out.add(frame);
+  }
+  file.writeAsBytesSync(out.toBytes());
+  return file.path;
 }

--- a/flutter_ui/test/scrub_modifiers_test.dart
+++ b/flutter_ui/test/scrub_modifiers_test.dart
@@ -1,0 +1,167 @@
+// Scrub modifiers, the After Effects convention: holding Shift makes a value
+// drag coarse (×10), holding Ctrl makes it fine (×0.1), and pressing either
+// mid-drag takes effect at once. Covers both drag surfaces — DragValueField
+// and the draggable TimeReadout clock.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/state/timecode.dart';
+import 'package:lumit_flutter/theme/theme.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
+import 'package:lumit_flutter/widgets/time_readout.dart';
+
+Widget _host(Widget child) => Directionality(
+      textDirection: TextDirection.ltr,
+      child: ThemeScope(
+        theme: LumitTheme.dark(),
+        animationLevel: AnimationLevel.none,
+        showTooltips: false,
+        child: Center(child: child),
+      ),
+    );
+
+void main() {
+  /// Drags a DragValueField 10 px with [modifier] held and returns how far the
+  /// value moved. The first 30 px cross the gesture slop and are pumped away
+  /// before the baseline is taken, so the measured move is exactly 10 px.
+  Future<num> dragBy10px(WidgetTester tester,
+      {LogicalKeyboardKey? modifier}) async {
+    num value = 0;
+    await tester.pumpWidget(_host(StatefulBuilder(
+      builder: (_, setState) => DragValueField(
+        value: value,
+        min: -1000000,
+        max: 1000000,
+        onChanged: (v) => setState(() => value = v),
+      ),
+    )));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(DragValueField)),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(30, 0));
+    await tester.pump();
+    final before = value;
+
+    if (modifier != null) await tester.sendKeyDownEvent(modifier);
+    await gesture.moveBy(const Offset(10, 0));
+    await tester.pump();
+    if (modifier != null) await tester.sendKeyUpEvent(modifier);
+
+    await gesture.up();
+    await tester.pump();
+    return value - before;
+  }
+
+  testWidgets('a plain drag moves the value one unit per pixel',
+      (tester) async {
+    expect(await dragBy10px(tester), 10);
+  });
+
+  testWidgets('shift makes the drag coarse: ten units per pixel',
+      (tester) async {
+    expect(
+        await dragBy10px(tester, modifier: LogicalKeyboardKey.shiftLeft), 100);
+  });
+
+  testWidgets('ctrl makes the drag fine: a tenth of a unit per pixel',
+      (tester) async {
+    expect(await dragBy10px(tester, modifier: LogicalKeyboardKey.controlLeft),
+        closeTo(1, 1e-9));
+  });
+
+  /// A fast drag delivers several pointer events per frame — quicker than the
+  /// caller can rebuild the field with each staged value. No travel may be
+  /// lost to that: the drag keeps its own running value between rebuilds.
+  /// Before this, every tick within a frame restarted from the stale prop, so
+  /// a screen-wide scrub lost most of its distance and read as acceleration.
+  testWidgets('a drag faster than the rebuilds loses no travel',
+      (tester) async {
+    final emitted = <num>[];
+    // The value prop is frozen at 0 — the harshest case: no rebuild ever
+    // catches up with the drag.
+    await tester.pumpWidget(_host(DragValueField(
+      value: 0,
+      min: -1000000,
+      max: 1000000,
+      onChanged: emitted.add,
+    )));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(DragValueField)),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(30, 0));
+    await tester.pump();
+    final base = emitted.isEmpty ? 0 : emitted.last;
+    // Ten moves, no pump between them: every tick lands on the same build.
+    for (var i = 0; i < 10; i++) {
+      await gesture.moveBy(const Offset(10, 0));
+    }
+    await gesture.up();
+    await tester.pump();
+    expect(emitted.last - base, 100,
+        reason: 'all ten 10 px moves count, not only the last one');
+  });
+
+  /// Drags the clock readout with [modifier] held and returns how many frames
+  /// it moved during the measured stretch. As above, an unmeasured first move
+  /// crosses the slop; the measured move is exactly [px] pixels.
+  Future<int> dragClock(WidgetTester tester,
+      {required double px, LogicalKeyboardKey? modifier}) async {
+    final live = <int>[];
+    await tester.pumpWidget(_host(TimeReadout(
+      key: const ValueKey('clock'),
+      frame: 10,
+      format: (f) => timecodeOfRate(f, 24, 1),
+      parse: (text) => framesOfTimecode(text, 24, 1),
+      widthChars: timecodeChars(24, 1),
+      style: LumitTheme.dark().mono,
+      minFrame: 0,
+      maxFrame: 100000,
+      draggable: true,
+      onDragLive: live.add,
+      onCommit: (_) {},
+    )));
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const ValueKey('clock'))),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(40, 0));
+    await tester.pump();
+    final before = live.isEmpty ? 10 : live.last;
+
+    if (modifier != null) await tester.sendKeyDownEvent(modifier);
+    await gesture.moveBy(Offset(px, 0));
+    await tester.pump();
+    if (modifier != null) await tester.sendKeyUpEvent(modifier);
+
+    await gesture.up();
+    await tester.pump();
+    return (live.isEmpty ? 10 : live.last) - before;
+  }
+
+  testWidgets('the clock ticks one frame per four pixels, plain',
+      (tester) async {
+    expect(await dragClock(tester, px: 4), 1);
+  });
+
+  testWidgets('shift drags the clock ten frames per four pixels',
+      (tester) async {
+    expect(
+        await dragClock(tester, px: 4, modifier: LogicalKeyboardKey.shiftLeft),
+        10);
+  });
+
+  testWidgets('ctrl drags the clock one frame per forty pixels',
+      (tester) async {
+    expect(
+        await dragClock(tester,
+            px: 40, modifier: LogicalKeyboardKey.controlLeft),
+        1);
+  });
+}


### PR DESCRIPTION
Two things the owner asked for, plus one bug the second turned up.

## The Retime clock runs at the footage rate

The Retime row counted source frames at the **composition's** rate, so the frames field of its `HH:MM:SS:FF` wrapped at the comp's fps: 600 fps footage in a 24 fps comp could not say anything past `:23`.

The formatter could already count past 99 — it widens the frames field with the rate — it was simply being handed the wrong rate. The row now probes its source footage once when it mounts and runs the clock at the media's own rate, so that footage counts to `:599` whatever the comp says. Dragging and typing follow, both being in source frames. The comp rate stands in until the probe answers, and for a source that is not footage or cannot be probed, so the clock is never dead.

`docs/04-RETIMING.md` §9.3 had recorded the comp-rate stopgap — "until the read model carries the footage's own" — and now records the probe instead.

## Scrub modifiers

Holding `Shift` while scrubbing a value makes the drag coarse (×10) and holding `Ctrl` makes it fine (×0.1) — the convention After Effects uses. Both drag surfaces obey it: every numeric field, and the draggable clock readout, where fine means ten times the travel per whole frame. The modifier is sampled on every drag update, so pressing or releasing one mid-drag takes effect at once.

## A value drag that keeps all of its travel

Testing the modifiers turned up lost motion that felt like mouse acceleration: a drag from screen edge to screen edge landed hundreds off, with or without a modifier held.

A value drag computed each tick from `widget.value`, which only changes when the field rebuilds. Pointer events arrive faster than that, so every tick between rebuilds started from the same stale value and overwrote the last — all but the final chunk of movement was dropped. How much vanished depended on how fast the pointer moved, which is what made it read as acceleration. The drag now advances from its own last ticked value, as the clock readout already did.

## Tests

- The Retime clock: drives the real engine over a hand-written 600 fps y4m file — half a second in reads `00:00:00:300`, which a comp-rate clock would call frame 30. Fails without the fix.
- Scrub modifiers: six tests pinning the ×1 / ×10 / ×0.1 ratios on both drag surfaces.
- Lost travel: freezes the value prop and fires ten 10 px moves with no rebuild between them — 100 with the fix, 10 without.

Verified locally: `scrub_modifiers`, `time_readout`, `drag_value_menu` and the Retime cases in `timeline_panel_frb` all pass; analyzer and formatter clean.
