### PR TITLE
Opening a project shows one card, and the transparency grid finally sees through

### DIFF
--- a/crates/lumit-bridge/src/api/composition.rs
+++ b/crates/lumit-bridge/src/api/composition.rs
@@ -1481,20 +1481,34 @@ impl CompositionReference {
         ))
     }
 
-    /// Set what the Viewer looks *through*: `stops` of exposure and whether the
-    /// tone map is engaged (K-314, docs/07 §2.2 items 12-13).
+    /// Set what the Viewer looks *through*, whole: `stops` of exposure and
+    /// whether the tone map is engaged (K-314, docs/07 §2.2 items 12-13), and
+    /// whether the comp's background colour is left out of the composite so
+    /// the transparency grid can show through what nothing covers (K-352).
     ///
-    /// **Preview only.** It moves the display encode of every frame the session
-    /// renderer composites from here on and nothing else — no document, no op,
-    /// no undo step. An export builds its own renderer and this is never sent
-    /// to it, so the export is neutral by construction.
+    /// **Preview only.** It moves how every frame the session renderer makes
+    /// from here on is composited and display-encoded, and nothing else — no
+    /// document, no op, no undo step. An export builds its own renderer and
+    /// this is never sent to it, so an export is neutral and draws the
+    /// backdrop by construction.
     ///
-    /// The frontend follows this with its ordinary request for the frame under
-    /// the playhead: a setting changes what the *next* frame looks like, and
-    /// without an ask the picture would not move until something else did.
+    /// One call carrying the whole look, so the renderer can never hold half
+    /// of one. The frontend follows a *change* with its ordinary request for
+    /// the frame under the playhead: a setting changes what the next frame is
+    /// made of, and without an ask the picture would not move until something
+    /// else did.
     #[frb(sync)]
-    pub fn set_display_view(&self, stops: f64, tone_map: bool) -> Result<(), BridgeError> {
-        self.dispatch(WorkerRequest::SetDisplayView { stops, tone_map })
+    pub fn set_viewer_look(
+        &self,
+        stops: f64,
+        tone_map: bool,
+        transparent_background: bool,
+    ) -> Result<(), BridgeError> {
+        self.dispatch(WorkerRequest::SetViewerLook {
+            stops,
+            tone_map,
+            transparent_background,
+        })
     }
 
     /// Stop playing, and silence the sound. Harmless when nothing is playing.

--- a/crates/lumit-bridge/src/api/state.rs
+++ b/crates/lumit-bridge/src/api/state.rs
@@ -506,7 +506,11 @@ impl LumitBridgeState {
         }
     }
 
-    #[frb(sync)]
+    /// Deliberately **not** `#[frb(sync)]`, unlike its `new_project` sibling:
+    /// reading a `.lum` parses a whole document and stats every media file it
+    /// names, and on the UI isolate that froze the window for as long as it
+    /// took. Async puts it on a worker thread, which is what lets Dart hold the
+    /// previous document on screen behind a progress bar until this returns.
     pub fn open_project(
         path: &str,
         on_change_stream: Option<CallbackStream>,

--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -1285,13 +1285,18 @@ pub enum WorkerRequest {
     Play(PlayRequest),
     /// Stop playing. Harmless when nothing is playing.
     StopPlayback,
-    /// Set the Viewer's exposure and tone map (K-314). A *setting*, not a
-    /// picture: it changes how every frame from here on is display-encoded and
-    /// nothing about the document. Preview only — an export builds its own
-    /// renderer, which nobody sends this to.
-    SetDisplayView {
+    /// Set the whole of how the Viewer is looking, in one message: exposure
+    /// and tone map (K-314) plus whether the comp's background colour is left
+    /// out of the composite while the transparency grid is up (K-352). A
+    /// *setting*, not a picture: it changes how every frame from here on is
+    /// made and display-encoded and nothing about the document. Preview only —
+    /// an export builds its own renderer, which nobody sends this to. One
+    /// message rather than one per control, so the renderer can never hold
+    /// half a look.
+    SetViewerLook {
         stops: f64,
         tone_map: bool,
+        transparent_background: bool,
     },
 }
 
@@ -2617,10 +2622,17 @@ fn handle_requests(
                     state.playback = None;
                     Ok(())
                 }
-                WorkerRequest::SetDisplayView { stops, tone_map } => {
+                WorkerRequest::SetViewerLook {
+                    stops,
+                    tone_map,
+                    transparent_background,
+                } => {
                     state
                         .renderer
                         .set_display_view(lumit_render::DisplayParams::from_stops(stops, tone_map));
+                    state
+                        .renderer
+                        .set_transparent_background(transparent_background);
                     Ok(())
                 }
             };
@@ -2654,7 +2666,7 @@ fn classify_request(r: &WorkerRequest) -> DrainClass {
         WorkerRequest::SamplePixels(_) => DrainClass::Sample,
         WorkerRequest::Play(_)
         | WorkerRequest::StopPlayback
-        | WorkerRequest::SetDisplayView { .. } => DrainClass::PictureKeepAll,
+        | WorkerRequest::SetViewerLook { .. } => DrainClass::PictureKeepAll,
         WorkerRequest::RenderComp(_) | WorkerRequest::RenderCompWithPreview(_) => {
             DrainClass::PictureNewestWins
         }

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 329358268;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1269538195;
 
 // Section: executor
 
@@ -590,15 +590,16 @@ fn wire__crate__api__state__LumitBridgeState_new_project_impl(
     )
 }
 fn wire__crate__api__state__LumitBridgeState_open_project_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "LumitBridgeState_open_project",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
             let message = unsafe {
@@ -618,13 +619,15 @@ fn wire__crate__api__state__LumitBridgeState_open_project_impl(
                 >,
             >>::sse_decode(&mut deserializer);
             deserializer.end();
-            transform_result_sse::<_, BridgeError>((move || {
-                let output_ok = crate::api::state::LumitBridgeState::open_project(
-                    &api_path,
-                    api_on_change_stream,
-                )?;
-                Ok(output_ok)
-            })())
+            move |context| {
+                transform_result_sse::<_, BridgeError>((move || {
+                    let output_ok = crate::api::state::LumitBridgeState::open_project(
+                        &api_path,
+                        api_on_change_stream,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -2403,43 +2406,6 @@ fn wire__crate__api__composition__composition_reference_sample_pixels_impl(
         },
     )
 }
-fn wire__crate__api__composition__composition_reference_set_display_view_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "composition_reference_set_display_view",
-            port: None,
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that =
-                <crate::api::composition::CompositionReference>::sse_decode(&mut deserializer);
-            let api_stops = <f64>::sse_decode(&mut deserializer);
-            let api_tone_map = <bool>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, BridgeError>((move || {
-                let output_ok = crate::api::composition::CompositionReference::set_display_view(
-                    &api_that,
-                    api_stops,
-                    api_tone_map,
-                )?;
-                Ok(output_ok)
-            })())
-        },
-    )
-}
 fn wire__crate__api__composition__composition_reference_set_markers_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2541,6 +2507,45 @@ fn wire__crate__api__composition__composition_reference_set_settings_impl(
                 let output_ok = crate::api::composition::CompositionReference::set_settings(
                     &api_that,
                     api_settings,
+                )?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__composition__composition_reference_set_viewer_look_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "composition_reference_set_viewer_look",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that =
+                <crate::api::composition::CompositionReference>::sse_decode(&mut deserializer);
+            let api_stops = <f64>::sse_decode(&mut deserializer);
+            let api_tone_map = <bool>::sse_decode(&mut deserializer);
+            let api_transparent_background = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, BridgeError>((move || {
+                let output_ok = crate::api::composition::CompositionReference::set_viewer_look(
+                    &api_that,
+                    api_stops,
+                    api_tone_map,
+                    api_transparent_background,
                 )?;
                 Ok(output_ok)
             })())
@@ -10665,6 +10670,12 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
+        13 => wire__crate__api__state__LumitBridgeState_open_project_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
         20 => wire__crate__api__layer__bridge_mask_mode_default_impl(
             port,
             ptr,
@@ -10755,7 +10766,6 @@ fn pde_ffi_dispatcher_sync_impl(
 9 => wire__crate__api__effect__BridgeEffectInstance_set_value_impl(ptr, rust_vec_len, data_len),
 11 => wire__crate__api__state__LumitBridgeState_get_current_project_impl(ptr, rust_vec_len, data_len),
 12 => wire__crate__api__state__LumitBridgeState_new_project_impl(ptr, rust_vec_len, data_len),
-13 => wire__crate__api__state__LumitBridgeState_open_project_impl(ptr, rust_vec_len, data_len),
 14 => wire__crate__api__audio__audio_clock_impl(ptr, rust_vec_len, data_len),
 15 => wire__crate__api__audio__audio_pause_impl(ptr, rust_vec_len, data_len),
 16 => wire__crate__api__audio__audio_seek_impl(ptr, rust_vec_len, data_len),
@@ -10806,10 +10816,10 @@ fn pde_ffi_dispatcher_sync_impl(
 63 => wire__crate__api__composition__composition_reference_render_frame_with_transform_preview_impl(ptr, rust_vec_len, data_len),
 64 => wire__crate__api__composition__composition_reference_render_scope_impl(ptr, rust_vec_len, data_len),
 65 => wire__crate__api__composition__composition_reference_sample_pixels_impl(ptr, rust_vec_len, data_len),
-66 => wire__crate__api__composition__composition_reference_set_display_view_impl(ptr, rust_vec_len, data_len),
-67 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
-68 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
-69 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
+66 => wire__crate__api__composition__composition_reference_set_markers_impl(ptr, rust_vec_len, data_len),
+67 => wire__crate__api__composition__composition_reference_set_motion_blur_enabled_impl(ptr, rust_vec_len, data_len),
+68 => wire__crate__api__composition__composition_reference_set_settings_impl(ptr, rust_vec_len, data_len),
+69 => wire__crate__api__composition__composition_reference_set_viewer_look_impl(ptr, rust_vec_len, data_len),
 70 => wire__crate__api__composition__composition_reference_set_work_area_impl(ptr, rust_vec_len, data_len),
 71 => wire__crate__api__composition__composition_reference_start_export_impl(ptr, rust_vec_len, data_len),
 72 => wire__crate__api__composition__composition_reference_stop_playback_impl(ptr, rust_vec_len, data_len),

--- a/crates/lumit-gpu/src/fx/engine.rs
+++ b/crates/lumit-gpu/src/fx/engine.rs
@@ -314,7 +314,7 @@ impl FxEngine {
                 compilation_options: Default::default(),
                 cache: None,
             });
-        let lens_flare = super::LensFlareFx::new(ctx);
+        let lens_flare = super::LazyFlare::spawn(ctx);
         Self {
             lens_flare,
             blur,

--- a/crates/lumit-gpu/src/fx/lens_flare.rs
+++ b/crates/lumit-gpu/src/fx/lens_flare.rs
@@ -19,7 +19,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     mpsc::{channel, Receiver, Sender},
     Arc, Mutex, OnceLock,
 };
@@ -546,6 +546,96 @@ struct GpuLight {
     row: [f32; 8],
 }
 
+/// The Lens flare's pipelines, built on a thread of their own.
+///
+/// # In plain terms
+///
+/// Compiling a shader is the graphics card's driver turning our code into
+/// something it can run, and it happens when the program starts rather than
+/// when it was written. Most of Lumit's kernels take a few milliseconds each.
+/// The flare's ray tracer is not most kernels — it is the largest shader in the
+/// program by a distance, and on a real card its three pipelines take about six
+/// and a half seconds to compile.
+///
+/// That was six and a half seconds between opening a project and seeing
+/// anything at all, because the render worker built every pipeline before it
+/// would answer its first request — including for a composition with nothing in
+/// it, and for the overwhelming majority of projects that contain no lens flare
+/// at all. So the flare's pipelines are built on a background thread while the
+/// rest of the engine gets on with the first frame, and the first frame that
+/// actually draws a flare waits for that thread to finish. By then it long
+/// since has.
+///
+/// Nothing about what the effect *draws* changes: this is only about when the
+/// compiling happens.
+pub(super) struct LazyFlare {
+    /// For the fallback build: a device handle is cheap to hold (it is a
+    /// reference-counted handle, not a copy of the card).
+    device: wgpu::Device,
+    /// The background build, taken and joined by the first [`Self::get`].
+    building: Mutex<Option<std::thread::JoinHandle<LensFlareFx>>>,
+    ready: OnceLock<LensFlareFx>,
+    /// [`FxEngine::set_deferred_flare_bakes`] can be answered before there is
+    /// an engine to tell — the worker sets it at start-up, which is precisely
+    /// the moment this exists to keep free. Held here and applied on build.
+    deferred: AtomicBool,
+}
+
+impl LazyFlare {
+    pub(super) fn spawn(ctx: &GpuContext) -> Self {
+        let device = ctx.device.clone();
+        let building = std::thread::Builder::new()
+            .name("lumit-flare-pipelines".into())
+            .spawn({
+                let device = device.clone();
+                move || LensFlareFx::with_device(&device)
+            })
+            .ok();
+        Self {
+            device,
+            building: Mutex::new(building),
+            ready: OnceLock::new(),
+            deferred: AtomicBool::new(false),
+        }
+    }
+
+    /// The engine, waiting for the background build if it has not landed.
+    ///
+    /// A machine that would give us no thread, or a build thread that died,
+    /// builds here instead — slowly, but on the path that actually needs it
+    /// rather than never.
+    pub(super) fn get(&self) -> &LensFlareFx {
+        self.ready.get_or_init(|| {
+            let built = self
+                .building
+                .lock()
+                .ok()
+                .and_then(|mut held| held.take())
+                .and_then(|thread| thread.join().ok())
+                .unwrap_or_else(|| LensFlareFx::with_device(&self.device));
+            built
+                .deferred
+                .store(self.deferred.load(Ordering::Relaxed), Ordering::Relaxed);
+            built
+        })
+    }
+
+    /// The engine only if it is already built — for the questions asked on
+    /// every frame (is a bake pending? what generation are we on?), which must
+    /// never be the thing that waits for a compile. Neither has an answer worth
+    /// having before the first flare is drawn anyway: nothing has been baked.
+    pub(super) fn ready(&self) -> Option<&LensFlareFx> {
+        self.ready.get()
+    }
+
+    pub(super) fn set_deferred(&self, deferred: bool) {
+        self.deferred.store(deferred, Ordering::Relaxed);
+        if let Some(lf) = self.ready.get() {
+            lf.deferred.store(deferred, Ordering::Relaxed);
+        }
+    }
+}
+
 impl LensFlareFx {
     /// See [`Self::cache`]. Raised from eight at K-263: a bake is a surface
     /// buffer and one 256² sprite, about a megabyte, so holding a couple of
@@ -553,8 +643,9 @@ impl LensFlareFx {
     /// trying lenses — the way the picker is actually used.
     const CACHE_CAP: usize = 24;
 
-    pub(super) fn new(ctx: &GpuContext) -> Self {
-        let device = &ctx.device;
+    /// Everything here is built from the device alone, which is what lets
+    /// [`LazyFlare`] build it on a thread that has no `GpuContext` to hand.
+    pub(super) fn with_device(device: &wgpu::Device) -> Self {
         let storage_entry =
             |binding: u32, read_only: bool, vis: wgpu::ShaderStages| wgpu::BindGroupLayoutEntry {
                 binding,
@@ -1305,7 +1396,7 @@ impl FxEngine {
     ) -> wgpu::Texture {
         use wgpu::util::DeviceExt;
         let out = work_texture(ctx, w, h, "fx-lens-flare-out");
-        let lf = &self.lens_flare;
+        let lf = self.lens_flare.get();
 
         // Neutral short-circuit mirror (the combine kernel also guards, but
         // skipping the whole pipeline is the honest fast path).
@@ -1899,7 +1990,7 @@ impl FxEngine {
         h: u32,
     ) -> Vec<[f32; 4]> {
         use wgpu::util::DeviceExt;
-        let lf = &self.lens_flare;
+        let lf = self.lens_flare.get();
         // The debug trace wants the real bake, whatever the policy: it is a
         // test and diagnostic path, and an answer for the previous lens would
         // be an answer to a question nobody asked.

--- a/crates/lumit-gpu/src/fx/mod.rs
+++ b/crates/lumit-gpu/src/fx/mod.rs
@@ -96,7 +96,7 @@ pub struct FxEngine {
     /// Lens flare (docs/08 §3.27, K-256): the one effect that owns a render
     /// pass — its pipelines, layouts and bake cache live in their own
     /// sub-struct rather than six more fields here.
-    lens_flare: LensFlareFx,
+    lens_flare: lens_flare::LazyFlare,
     layout: wgpu::BindGroupLayout,
     /// The adjustment blend's own layout: three sampled inputs (below,
     /// processed, coverage) where every effect kernel takes two.
@@ -123,15 +123,19 @@ impl FxEngine {
     /// still being baked draws the lens the last frame drew (or, with none
     /// yet, no flare) instead of stopping for half a second of optics.
     pub fn set_deferred_flare_bakes(&self, deferred: bool) {
-        self.lens_flare
-            .deferred
-            .store(deferred, std::sync::atomic::Ordering::Relaxed);
+        self.lens_flare.set_deferred(deferred);
     }
 
     /// Whether a flare bake is being made right now.
+    ///
+    /// Answered without waiting for the flare's own pipelines to finish
+    /// compiling (see [`lens_flare::LazyFlare`]): nothing can be baking before
+    /// there is anything to bake with.
     #[must_use]
     pub fn flare_bake_pending(&self) -> bool {
-        self.lens_flare.bake_pending()
+        self.lens_flare
+            .ready()
+            .is_some_and(lens_flare::LensFlareFx::bake_pending)
     }
 
     /// A number that moves whenever a flare bake is queued or lands.
@@ -144,9 +148,11 @@ impl FxEngine {
     /// that outlives every edit and undo that might have fixed it.
     #[must_use]
     pub fn flare_bake_generation(&self) -> u64 {
-        self.lens_flare
-            .generation
-            .load(std::sync::atomic::Ordering::Relaxed)
+        // Zero until the flare engine exists, and honestly so: a bake cannot
+        // have been queued or landed before there is one.
+        self.lens_flare.ready().map_or(0, |lf| {
+            lf.generation.load(std::sync::atomic::Ordering::Relaxed)
+        })
     }
 
     /// Start making a lens's bake now, before any frame asks to draw it.
@@ -160,7 +166,9 @@ impl FxEngine {
     /// already baking, or when this machine gave us no bake thread. Queueing
     /// is never required — a miss makes the bake either way.
     pub fn warm_flare_bake(&self, key: u64, bake: &lens_flare::FlareBake) -> bool {
-        self.lens_flare.warm(key, bake)
+        // The one flare call that *does* wait for the pipelines: a caller
+        // asking for a bake by name has decided a flare is wanted.
+        self.lens_flare.get().warm(key, bake)
     }
 
     /// One compute pass: `src` and `orig` sampled, `dst` written, `params`

--- a/crates/lumit-render/examples/first_frame_probe.rs
+++ b/crates/lumit-render/examples/first_frame_probe.rs
@@ -1,0 +1,110 @@
+//! Temporary by-hand probe: what does the FIRST preview cost, before any
+//! footage is involved? Run with:
+//!   cargo run --release -p lumit-render --features shared-texture --example first_frame_probe
+//! Needs no media at all — the whole point is that a brand-new empty comp in a
+//! brand-new project takes noticeable time to show anything, so this times the
+//! startup that stands between "worker started" and "first frame out".
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use lumit_core::model::{Composition, Document, LinearColour, ProjectItem};
+use lumit_core::time::{Duration, FrameRate, Rational};
+use lumit_render::{HeadlessRenderer, Quality};
+use std::time::Instant;
+use uuid::Uuid;
+
+const W: u32 = 1920;
+const H: u32 = 1080;
+
+fn empty_doc() -> (std::sync::Arc<Document>, Uuid) {
+    let mut doc = Document::new();
+    let comp_id = Uuid::now_v7();
+    doc.items.push(ProjectItem::Composition(Composition {
+        id: comp_id,
+        name: "Probe".into(),
+        width: W,
+        height: H,
+        frame_rate: FrameRate::new(60, 1).unwrap(),
+        duration: Duration(Rational::new(10, 1).unwrap()),
+        background: LinearColour::BLACK,
+        work_area: None,
+        layers: Vec::new(),
+        markers: Vec::new(),
+        motion_blur: lumit_core::model::MotionBlur::default(),
+        extra: serde_json::Map::new(),
+    }));
+    (std::sync::Arc::new(doc), comp_id)
+}
+
+fn ms(at: Instant) -> f64 {
+    at.elapsed().as_secs_f64() * 1000.0
+}
+
+fn main() {
+    // --- 1. The parts of a renderer, one at a time. ---
+    let t = Instant::now();
+    let gpu = lumit_gpu::GpuContext::headless().expect("gpu");
+    println!("{:44} {:8.1} ms", "GpuContext::headless", ms(t));
+
+    let t = Instant::now();
+    let _colour = lumit_gpu::ColourEngine::new(&gpu);
+    println!("{:44} {:8.1} ms", "ColourEngine::new", ms(t));
+
+    let t = Instant::now();
+    let _compositor = lumit_gpu::Compositor::new(&gpu);
+    println!("{:44} {:8.1} ms", "Compositor::new", ms(t));
+
+    let t = Instant::now();
+    let _fx = lumit_gpu::fx::FxEngine::new(&gpu);
+    println!(
+        "{:44} {:8.1} ms",
+        "FxEngine::new (every WGSL kernel)",
+        ms(t)
+    );
+
+    let t = Instant::now();
+    let _scope = lumit_gpu::scope::ScopeEngine::new(&gpu);
+    println!("{:44} {:8.1} ms", "ScopeEngine::new", ms(t));
+
+    // --- 2. The whole thing, as the worker builds it. ---
+    let t = Instant::now();
+    let mut r = HeadlessRenderer::new().expect("gpu");
+    println!(
+        "{:44} {:8.1} ms",
+        "HeadlessRenderer::new (worker start)",
+        ms(t)
+    );
+
+    // --- 3. The first frame of an empty comp, then the ones after it. ---
+    let (doc, comp) = empty_doc();
+    let q = Quality {
+        draft: false,
+        auto_res: false,
+        display_scale: 1.0,
+        divisor: 1,
+    };
+
+    let t = Instant::now();
+    let first = r
+        .render_prepared(&doc, comp, 0, q, true, false)
+        .expect("render");
+    println!("{:44} {:8.1} ms", "empty comp, FIRST frame", ms(t));
+
+    #[cfg(all(windows, feature = "shared-texture"))]
+    {
+        let t = Instant::now();
+        r.present_prepared(&first).expect("present");
+        println!("{:44} {:8.1} ms", "empty comp, FIRST present", ms(t));
+    }
+    drop(first);
+
+    for f in 1..4 {
+        let t = Instant::now();
+        let p = r
+            .render_prepared(&doc, comp, f, q, true, false)
+            .expect("render");
+        #[cfg(all(windows, feature = "shared-texture"))]
+        r.present_prepared(&p).expect("present");
+        drop(p);
+        println!("{:44} {:8.1} ms", format!("empty comp, frame {f}"), ms(t));
+    }
+}

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -157,6 +157,13 @@ pub struct HeadlessRenderer {
     /// the promise is a property of the code's shape rather than a rule anyone
     /// has to remember — and `an_export_ignores_the_viewer_view` pins it.
     view: lumit_gpu::DisplayParams,
+    /// Whether the fronted comp's own background colour is left out of the
+    /// composite, so pixels nothing covers stay transparent and the Viewer's
+    /// transparency grid shows through them (K-352). The Viewer sets it to
+    /// follow its grid button; like [`Self::view`] it is a way of *looking*,
+    /// and the export renderer — which nobody calls this on — always draws
+    /// the backdrop.
+    transparent_background: bool,
     /// The Windows zero-copy Viewer targets (K-177): **one per size, kept and
     /// reused**, most recently used last.
     ///
@@ -524,6 +531,7 @@ impl HeadlessRenderer {
             watching: false,
             measuring: false,
             view: lumit_gpu::DisplayParams::NEUTRAL,
+            transparent_background: false,
             #[cfg(all(windows, feature = "shared-texture"))]
             shared: Vec::new(),
             #[cfg(all(target_os = "linux", feature = "shared-texture-linux"))]
@@ -626,6 +634,19 @@ impl HeadlessRenderer {
         self.view = view;
     }
 
+    /// Leave the fronted comp's background colour out of the composite, so
+    /// pixels nothing covers stay transparent and the Viewer's transparency
+    /// grid shows through them (K-352). A way of looking, like the display
+    /// view above — the export renderer never has this called on it, so an
+    /// export always draws the backdrop.
+    ///
+    /// The flag is folded into the frame's name (see [`Self::named_under_view`]):
+    /// the two backdrops are two different pictures, and a frame banked under
+    /// one must never be served as the other.
+    pub fn set_transparent_background(&mut self, transparent: bool) {
+        self.transparent_background = transparent;
+    }
+
     /// A content name with the Viewer's own way of looking folded in.
     ///
     /// Neutral returns the name untouched — byte-for-byte what
@@ -634,14 +655,17 @@ impl HeadlessRenderer {
     /// the same hash the name was built with, under its own tag so a look can
     /// never be confused for content.
     fn named_under_view(&self, base: u128) -> u128 {
-        if self.view.is_neutral() {
+        if self.view.is_neutral() && !self.transparent_background {
             return base;
         }
         let mut h = blake3::Hasher::new();
         h.update(b"view/");
         h.update(&base.to_le_bytes());
         h.update(&self.view.gain.to_bits().to_le_bytes());
-        h.update(&[u8::from(self.view.tone_map)]);
+        h.update(&[
+            u8::from(self.view.tone_map),
+            u8::from(self.transparent_background),
+        ]);
         let bytes = h.finalize();
         let mut k = [0u8; 16];
         k.copy_from_slice(&bytes.as_bytes()[..16]);
@@ -876,7 +900,15 @@ impl HeadlessRenderer {
             }
             let draws =
                 crate::build::build_comp_draws(doc, comp, t, &pixels_by_layer, &mut visited);
-            let background = comp.background.0.map(f64::from);
+            // The comp's backdrop is a way of viewing, not a layer (K-241);
+            // with the transparency grid up the Viewer asks for none at all,
+            // so what nothing covers arrives with zero alpha and the grid
+            // shows through it (K-352).
+            let background = if self.transparent_background {
+                [0.0; 4]
+            } else {
+                comp.background.0.map(f64::from)
+            };
             if let Some(w) = &watcher {
                 w.compositing(draws.len() as u32);
             }
@@ -2316,6 +2348,52 @@ mod tests {
         assert_eq!(alpha, 255, "the solid is opaque");
     }
 
+    /// **The transparency grid can see through an empty comp (K-352).** The
+    /// comp's backdrop is opaque black by default, so every pixel nothing
+    /// covers used to reach the Viewer with alpha 1 and the checkerboard
+    /// behind the picture could never show — even with every layer hidden.
+    /// With the flag on, the interactive path leaves the backdrop out and
+    /// uncovered pixels arrive with zero alpha; off again, the backdrop is
+    /// back. Fails without the `transparent_background` branch in
+    /// `preview_display_texture_fmt`.
+    ///
+    /// An export stays opaque the same way it stays neutral (see
+    /// `an_export_ignores_the_viewer_view`): `export::run` builds its own
+    /// renderer, and nothing ever calls `set_transparent_background` on it.
+    #[test]
+    fn the_transparent_background_flag_uncovers_the_grid() {
+        let mut r = match HeadlessRenderer::new() {
+            Ok(r) => r,
+            Err(_) => {
+                lumit_gpu::no_adapter();
+                return;
+            }
+        };
+        let mut doc = Document::new();
+        let comp_id = push_comp(&mut doc, "Empty", 8, 8);
+        let store = DocumentStore::new(doc);
+        let doc = store.snapshot();
+        let q = Quality::default();
+
+        let (rgba, w, h) = r
+            .render_preview(&doc, comp_id, 0, q, 1.0)
+            .expect("opaque render");
+        let idx = (((h / 2) * w + w / 2) * 4) as usize;
+        assert_eq!(rgba[idx + 3], 255, "born opaque: the backdrop is drawn");
+
+        r.set_transparent_background(true);
+        let (rgba, _, _) = r
+            .render_preview(&doc, comp_id, 0, q, 1.0)
+            .expect("transparent render");
+        assert_eq!(rgba[idx + 3], 0, "nothing covers this pixel, so no alpha");
+
+        r.set_transparent_background(false);
+        let (rgba, _, _) = r
+            .render_preview(&doc, comp_id, 0, q, 1.0)
+            .expect("opaque again");
+        assert_eq!(rgba[idx + 3], 255, "grid down, backdrop back");
+    }
+
     /// `scale` below 1 downsamples the output buffer; the centre stays the solid
     /// colour, proving the resize path is wired and does not corrupt the frame.
     #[test]
@@ -2441,6 +2519,26 @@ mod tests {
             r.frame_key(&doc, comp_id, 0, q),
             neutral,
             "returning to neutral returns the frame's own name"
+        );
+
+        // The backdrop is part of the picture too (K-352): a frame composited
+        // without it must never be served as one composited with it, so the
+        // transparency-grid flag names frames apart exactly as a view does.
+        r.set_transparent_background(true);
+        let transparent = r.frame_key(&doc, comp_id, 0, q);
+        assert!(
+            transparent.is_some(),
+            "a transparent backdrop still names the frame"
+        );
+        assert!(
+            !seen.contains(&transparent),
+            "the two backdrops are two different pictures"
+        );
+        r.set_transparent_background(false);
+        assert_eq!(
+            r.frame_key(&doc, comp_id, 0, q),
+            neutral,
+            "backdrop back, name back — frames banked opaque are hits again"
         );
     }
 

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -8331,3 +8331,59 @@ permanently unnameable.
 Not fixed here, and unchanged: the flare's raster still draws the cells it culled, and the
 `wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals` bit-stability question is
 still open (both remain in TODO).
+
+**K-351 · DECIDED · Opening a project shows one loading card and nothing else, and no
+shader a project does not use is compiled before its first frame.** Two halves of the same
+complaint — the first preview took the better part of ten seconds, and the interface spent
+that time looking loaded but empty.
+
+**The measurement first**, because the cause was not where it looked. On this machine a
+render worker took **7.7 s to start**, and 6.5 s of that was `LensFlareFx::new`: the flare's
+ray tracer is the largest shader in the program and its three pipelines dominate every other
+kernel put together (`crates/lumit-render/examples/first_frame_probe.rs` is the probe that
+says so). Every project paid it, including one with an empty composition and no flare
+anywhere in it, because the worker built every pipeline before answering its first request.
+The flare's pipelines are now built on a **thread of their own** (`LazyFlare`) and joined by
+the first frame that actually draws a flare — which, by the time anyone applies one, has long
+since finished. Worker start is 1.1 s. Nothing about what the effect draws changes: this is
+only about *when* the compiling happens, and the bake-deferral machinery of K-350 is
+untouched — the flag set before the pipelines exist is applied when they do.
+
+**And the reading of the document is off the drawing thread.** `open_project` is no longer
+`#[frb(sync)]`: parsing a `.lum` and stating every media file it names froze the window for
+as long as it took. It now runs on a worker thread, which is what makes the second half
+possible.
+
+**One swap, not a fill.** While a document is being read *and* until the Viewer has
+something to show of it, the shell stands behind a single card with a progress bar
+(`OpeningOverlay`) and the panels behind it still hold the previous project. Panels that
+filled one by one while the picture was still coming read as a slow editor; everything
+appearing at once reads as an application loading, which is what it is. The card lifts on
+the first reply from the new project's worker — any reply, not the frame alone, so a first
+render that faults cannot leave the interface covered — or, for a project that fronts no
+composition, as soon as the session restore says there is no picture to wait for.
+
+Not fixed here: the 1.1 s that remains is the graphics device (0.6 s) and the other engines
+(0.5 s), and a project's own footage still probes on first use.
+
+**K-352 · DECIDED · The transparency grid actually sees transparency: while it is up, the
+Viewer's renderer leaves the comp's background colour out of the composite.** docs/07 §2.2
+item 4 always said the grid is a checkerboard "instead of the comp background colour", and
+it never was: the comp you are looking at cleared to its backdrop at full alpha (nested
+comps clear transparent, K-241, but the top of the walk did not), so every uncovered pixel
+reached the Viewer opaque and the board behind the picture could never show — even with
+every layer hidden. The grid button was a control that did nothing visible.
+
+The grid state now lives in `LumitUiState` (not the panel) and rides the Viewer's one
+look message: `set_viewer_look` carries exposure, tone map (K-314) and this flag together,
+so the renderer can never hold half a look and each control costs no channel of its own.
+Renderer-owned, deduplicated against the last look actually sent (the record clears on
+project adoption, so a worker just born cannot disagree with the button), and never sent
+to an export's own renderer — an export always draws the backdrop. The two backdrops are two different pictures, so the flag is folded into the
+frame's cache name beside the view (K-346's mechanism); the one-time cost is that frames
+banked under a non-neutral view before this entry take new names.
+
+Also fixed here, the board's edge: the picture and its board share one rectangle, but the
+board is painted anti-aliased while the platform texture is not, so a fractional rectangle
+bled a soft row of board out under the picture at some zooms. The shared rectangle is now
+snapped to whole device pixels (`snapToDevicePixels`), where the two rasterise identically.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3474,6 +3474,44 @@ cannot report a module that took its time or came up degraded. Noted in
 engine behind it at all falls back to a canned list, so the placeholder still
 opens on something honest rather than a blank rectangle.
 
+### Opening a project, and why the old one stays on screen
+
+Opening a `.lum` is not a small read. The engine parses the whole document and
+then checks every media file it names is where the file says it is, and on a
+large project that is long enough to notice. Two things follow from it, both in
+`LumitState.openProject` in `main.dart`.
+
+**The read happens away from the interface.** `open_project` is one of the few
+bridge calls that is deliberately *not* marked `sync`: a sync call runs on the
+same thread that draws, so a slow one freezes the window until it is done, to the
+point where Windows offers to close the program for you. Unmarked, frb runs it on
+a worker thread and hands Dart a promise, and the interface keeps drawing.
+
+**Nothing changes over until all of it is ready — including the picture.** While
+the read is running, the `opening` flag is up and the shell covers itself with a
+card and a moving bar (`OpeningOverlay` in `shell/splash.dart`). Behind the card
+the panels are still drawing the *previous* document — that is deliberate. The
+alternative is watching an editor come apart and reassemble panel by panel as
+the new document arrives.
+
+The card does not lift when the document is in. It lifts when the Viewer has
+something to show of it, or when the session restore says there is nothing to
+show — a project that opens with no composition fronted. Panels filling while
+the preview was still coming read as a slow editor; everything arriving at once
+reads as an application loading (K-351). What ends it is `previewReady`, called
+on the first reply from the new project's render worker: any reply, not the
+frame alone, so a first render that fails cannot leave the shell covered for
+good.
+
+There is a subtlety worth knowing, because it caused a bug. Opening a project
+clears the engine's registry of open projects, so **every handle Dart is holding
+dies at that moment** — including any question already asked and not yet
+answered. The missing-file badge in the Viewer asks each footage layer whether
+its file is still there, one round trip each; if the document is replaced while
+those answers are in flight, the rest of them come back as errors. They are
+caught and dropped rather than reported: there is no missing media in a document
+that is gone, and the panel is about to be rebuilt from the new one anyway.
+
 ### The bridge
 
 `crates/lumit-bridge` builds to one shared library the app loads at startup. It
@@ -3660,6 +3698,35 @@ computing, so the bake thread takes everything waiting, keeps the newest, and dr
 rest before they start — the same "is my work still wanted" habit the rest of the engine
 has.
 
+### The six and a half seconds nobody was using (K-351)
+
+A shader is a small program the graphics card runs, and the card's driver has to
+translate ours into its own instructions before any of them can run. That
+translation happens when Lumit starts a render worker, not when the shader was
+written, and for most of Lumit's forty-odd kernels it takes a few milliseconds
+each.
+
+The lens flare is not most kernels. Its ray tracer is by a distance the largest
+shader in the program, and on a real card its pipelines take about six and a half
+seconds to compile — which the render worker paid *before it would answer its
+first request*. Every project paid it: a project with one empty composition, a
+project with no flare in it anywhere, every time one was opened. It was almost
+the whole of the wait between opening a project and seeing a picture.
+
+So the flare's pipelines are now built on a thread of their own (`LazyFlare` in
+`lumit-gpu`) while the rest of the engine gets on with the first frame, and the
+first frame that actually draws a flare waits for that thread — by which time,
+in practice, it finished long ago. Nothing about what the effect draws changes;
+only when the compiling happens. Worker start went from 7.7 seconds to 1.1.
+
+If you want to see the numbers on your own machine,
+`crates/lumit-render/examples/first_frame_probe.rs` is the stopwatch that found
+this, and it prints each part of a renderer's start-up in turn:
+
+```
+cargo run --release -p lumit-render --features shared-texture --example first_frame_probe
+```
+
 ### How the picture reaches the screen
 
 Video frames are far too large to pass through function calls sixty times a
@@ -3768,6 +3835,19 @@ tidy and read as a fault — leave the tone map on and the whole cache ladder is
 switched off for the session, with nothing on screen to say so. Naming each look
 separately costs only that several looks compete for the same budget, which the
 tiers already know how to sort out by eviction.
+
+**The transparency grid is a way of looking too (K-352).** The checkerboard the
+Viewer draws behind the picture can only show through pixels that are actually
+transparent, and for a long time none were: the comp being looked at was always
+composited onto its own background colour at full alpha, so even an empty comp
+arrived as solid black. While the grid button is on, the engine now leaves that
+backdrop out entirely — what nothing covers stays transparent, and the board
+shows through it, which is the whole point of the button. It follows every rule
+the exposure does — in fact it travels in the same message: the engine is told
+the whole look (exposure, tone map, grid) in one call, so it can never hold
+half of one. Folded into the frame's cache name like the rest (an opaque frame
+and a see-through frame are two different pictures), and never sent to an
+export, which always draws the backdrop.
 
 **The cache bar** under the time ruler shows what is held: mint at the current
 preview resolution, dimmed mint only at a coarser one, steel-blue on disk,

--- a/docs/NEXT-FEATURES.md
+++ b/docs/NEXT-FEATURES.md
@@ -1,0 +1,254 @@
+# Next features — the implementation plan
+
+**Status: living.** The implementation companion to [TODO.md](TODO.md) for the next
+tranche of work: what to build, in what order, and exactly how — so a session can pick an
+entry up cold. Delete an entry when it lands (its regression tests are the record, per
+[14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md)); when an entry changes a spec or
+reverses a decision, that edit and the [02-DECISIONS.md](02-DECISIONS.md) entry land in
+the same commit as the code.
+
+In plain terms: this is the "how" file for the work the backlog only names. The two
+biggest entries — the lens flare rework and lights — came out of a research pass
+(2026-08-12) over how the industry actually does this on real footage; the sources are
+cited inline so the reasoning can be checked rather than trusted.
+
+Standing obligations every entry inherits (they are why the estimates are not smaller):
+each feature lands with its regression tests, its `app_en.arb` strings (plus
+`engine_labels.dart` for anything the engine sends — the `engine_labels_test.dart` gate),
+its GUIDE.md plain-English section, and its spec/decision edits, all in the same change.
+New effects follow [08-EFFECTS.md](08-EFFECTS.md) §2's contract (CPU oracle beside the
+WGSL kernel, bit-stable draw order, px@comp point parameters — K-260).
+
+---
+
+## 0. First, the standing blocker: the flare is not bit-stable
+
+Before any flare work below, the existing regression in TODO's **Now** must be
+understood: `wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals` fails its
+"GPU lens flare must be bit-stable" assertion on clean `main` — two runs of the same
+flare give different pixels. Every flare entry below adds passes to that pipeline, and
+none of them can be validated honestly while the baseline itself wobbles. Find which
+stage varies (bisect by reading back after each pass: bright-pass → trace → blur → draw)
+before changing anything. [impl/lens-flare.md](impl/lens-flare.md) §2.4 explains why the
+additive draw order is the property everything else protects.
+
+---
+
+## 1. Lens flare v2 — flares that follow a light, not a threshold
+
+**The problem, precisely.** The shipped flare (docs/08 §3.27) is screen-space: a
+bright-pass finds hot pixels, ghosts are traced from them. On graphics that is fine; on
+*footage* it is the wrong tool, and the research is blunt about why — any bright pixel
+(sky, white shirt, specular glint) spawns ghosts, and pixels crossing the threshold
+frame to frame make the whole flare **flicker**. Even the technique's author recommends
+sprite-based flares for prominent light sources
+([Chapman](https://john-chapman.github.io/2017/11/05/pseudo-lens-flare.html)). What
+Video Copilot's Optical Flares actually is, conceptually: **no bright pass at all** — a
+user-supplied 2D light position drives a designer-authored stack of elements placed
+along the line from the light through frame centre
+([Optical Flares](https://www.videocopilot.net/products/opticalflares)). Deterministic on
+video, zero flicker, art-directable. That is the single biggest "usable with footage"
+win available.
+
+**What already exists to build on** — more than the pitch above implies, so read
+[impl/lens-flare.md](impl/lens-flare.md) first (`crates/lumit-gpu/src/fx/lens_flare.rs`):
+
+- **Manual mode is already position-driven** — a px@comp pair (K-260) drives the whole
+  physically-traced flare, so the deterministic-on-footage workflow half-exists today;
+  what it lacks is art-directable *elements* around the physical ghosts.
+- **The starburst already exists and is already baked** per lens/aperture; the owed
+  **image aperture file** parameter (TODO's flare follow-ups) plugs into that bake
+  rather than needing a new mechanism.
+- The source-mode enum already reserves `2 = Lights` "until light layers land (K-257)";
+  `MAX_LIGHTS = 16` and the `GpuLight` layout mean every element below runs per light
+  for free on the existing dispatch axis.
+- The lens designer and `lens_file` (K-264) — where element-stack presets live.
+
+**The build, in two steps:**
+
+1. **Element stack in the lens file.** Beside the traced ghosts, a flare gains a list
+   of authored elements, each: `kind` (glow, iris polygon, ring/halo, streak), `offset`
+   (signed position along the light→centre axis: 1.0 = on the light, −1.0 = mirrored
+   across centre — the Optical Flares model), `scale`, `tint`, `opacity`. Data, not
+   shaders: one draw pass of N procedural quads, trivially cheap next to the ray
+   tracer, feeding the same K-289 combine. Keep the additive order fixed (element
+   index, never anything measured) so §2.4's bit-stability holds by construction.
+2. **The one genuinely new kernel: the anamorphic streak** — the Kawase streak filter:
+   downsample ~1/16, then 3–4 passes each sampling 4 taps along the streak direction at
+   distance 4^pass, weight `a^(b·dist)`, attenuation ~0.9–0.95
+   ([Oat, scene postprocessing](https://www.chrisoat.com/papers/Oat-ScenePostprocessing.pdf)).
+   A directional variant of the blur passes already in the file.
+
+Sources stay as they are: Manual (soon: Lights, entry 3) is the footage workflow;
+Matte keeps the detector for graphics, hardened by entry 2. Full lens-prescription
+ray tracing beyond what the bake already does (Hullin 2011) is ~12 ms/frame class —
+wrong genre; do not chase it.
+
+**Files:** `lens_flare.rs` + its WGSL siblings, `lumit-core/src/fx/lens_flare.rs`
+(params), the lens-file schema (K-264), Effect controls rows (the pair row's dropper on
+px@comp pairs is already owed — K-260). **Spec edits:** docs/08 §3.27 gains the element
+stack; [impl/lens-flare.md](impl/lens-flare.md) gains a §for it (algorithms above, test
+plan below); a K-entry records the design.
+
+**Test plan:** CPU oracle for each element kind at a known position (docs/08 §2 pattern);
+bit-stability (two renders, identical bytes); a two-frame "video" fixture where a bright
+region moves — assert the element stack's output moves *continuously* (no threshold pop);
+the baked starburst keyed by aperture hash (same aperture → cache hit, no re-FFT).
+
+**Size:** the biggest entry here — the element system is real design work. Land it in
+slices: streak element first (pure shader work, immediate visual payoff), then the stack,
+then the baked starburst.
+
+## 2. Harden Matte mode's detection on footage (small, do early)
+
+Matte mode already has half of what the literature asks for: the luma gate is soft
+(`threshold` + `threshold_softness`, `lens_flare::threshold_gate`), and K-267's tile
+flux summing already weighs an area source as its area rather than one pixel. What
+still flickers on video, and the fixes
+([Froyok's UE writeup](https://www.froyok.fr/blog/2021-09-ue4-custom-lens-flare/),
+[LearnOpenGL PBB](https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom)):
+
+1. **Fireflies** — a single hot pixel (sensor sparkle, specular glint) rides the tile
+   sum and pops a source for one frame. The Karis-average idea, adapted to the
+   detector: weight each pixel's contribution to its tile's flux by `1/(1+luma)`, so
+   one outlier cannot own the anchor. Same formula in `detect_lights` (the CPU twin)
+   and the WGSL reduction, or the matte-mode frame oracle fails — which is the test.
+2. **Anchor jumping** — a source's anchor position quantises to its brightest pixel,
+   which wanders inside the practical frame to frame. A flux-weighted centroid over
+   the anchor's tiles (still deterministic, still index-ordered summation per §2.4)
+   steadies the position without any cross-frame state.
+
+**Temporal smoothing is a recorded non-option**, not an oversight: a frame must be a
+function of the document and the frame alone (docs/14 determinism; the caches name
+frames on exactly that promise), and a detector that remembers the previous frame
+breaks random access, export/preview identity and the frame oracle in one move. The
+footage answer to "the threshold pops" is the Manual/Lights element path (entries 1
+and 3), not history buffers.
+
+This entry must not land before the bit-stability blocker (entry 0) is understood —
+it edits the passes under suspicion, and would muddy the bisect.
+
+## 3. Light layers, and area lights via LTC
+
+**What exists:** nothing in the model — `LayerKind` has no Light; the flare reserves
+Lights mode "until light layers land (K-257)"; the roadmap parks lights in Phase 5.
+The user-visible goal: a light you can aim at *footage* and have it read as light.
+
+**Step 3a — the Light layer (model + UI, no shading yet).**
+`LayerKind::Light` in [03-DATA-MODEL.md](03-DATA-MODEL.md) — a decision-sized model
+change, logged in 02-DECISIONS. Kinds: **point**, **spot**, **area (rect)** — the rect
+is the one that earns the entry. Properties (all animatable `Property`s): colour,
+intensity, radius/size (a rect light has width × height), falloff. Transform reuses the
+layer transform (a rect light is a rectangle in 2.5D space exactly as a layer is — same
+position/rotation basis the camera pose already uses). Like a Camera, it draws no
+pixels; like a Null, it needs a pickable gizmo in the Viewer (the Camera's no-box
+carve-out in `viewer_panel_frb.dart::_boxes` is the pattern — do not repeat its "cannot
+be picked" gap for lights). Bridge: fold into `BridgeLayerInfo`/the comp read model, an
+`addLightLayer` op, Timeline identity colour (docs/15 §6.1 reserves token values).
+
+**Step 3b — flare Lights mode (K-257, cheap once 3a lands).**
+Resolve each Light layer's comp-space position at the frame, project through the active
+camera pose (the same maths `comp.camera_pose(t)` feeds the realiser), fill the
+`GpuLight` slots the flare already dispatches. A flare that follows a keyframed light is
+the tracked-flare workflow with no tracker. Delete the "resolves as Manual" fallback and
+its comment.
+
+**Step 3c — area-light shading of layers: Linearly Transformed Cosines.**
+The state of the art for real-time polygonal area lights, and comfortably WGSL-shaped
+([Heitz et al. 2016](https://eheitzresearch.wordpress.com/415-2/),
+[tutorial](https://learnopengl.com/Guest-Articles/2022/Area-Lights)):
+
+- Two **64×64 LUT textures** (a 3×3 inverse-matrix in RGBA + Fresnel/form-factor
+  scalars), indexed by (roughness, view angle), bilinear-filtered. The data is
+  published — [selfshadow/ltc_code](https://github.com/selfshadow/ltc_code) — embed it
+  as bytes, no fitting work. Licence-check the repo before vendoring; re-deriving the
+  tables from the paper is the fallback.
+- Per shaded pixel: fetch matrix, transform the light rect's four vertices into
+  cosine space, sum an analytic integral per edge, apply the form-factor correction.
+  Diffuse is the same integral with the identity matrix.
+- Measured cost in the literature: ~0.5 ms *full-screen* on a 2014 laptop GPU; shading
+  layer quads it is noise.
+
+For a 2.5D compositor the geometry collapses beautifully: the shaded surface is a flat
+layer plane (normal = layer orientation), the light is a rect in the same space — LTC
+diffuse over a quad produces exactly the smooth gradient an editor expects a softbox to
+throw across footage. Ship that as the default look; per-pixel normals (normal-map
+AOVs, luminance-derived fake normals) are explicitly out of scope for the first landing
+— both are content-dependent quality cliffs, and the flat-plane result is already the
+honest 2.5D answer ([Nuke's Relight](https://learn.foundry.com/nuke/content/reference_guide/3d_nodes/relight.html)
+is the ceiling to aim at later, not now).
+
+Where it runs: a compositor pass on each lit layer's quad (the realiser already walks
+layers with their 3D poses — the shading term multiplies into the layer sample). Gate it
+behind a per-layer **"accepts lights"** switch defaulting on for 3D layers, so 2D
+montage work pays nothing. **Spec edits:** 06-RENDER-PIPELINE gains the lighting pass;
+08-EFFECTS is untouched (this is not an effect); 03-DATA-MODEL gains the switch.
+
+**Test plan:** CPU oracle of the LTC integral for a handful of (roughness, angle, rect)
+cases against the published reference implementation's numbers; a GPU oracle rendering
+one lit quad and asserting the gradient's monotonic falloff and its peak under the
+light's centre; determinism (two renders, identical bytes); a no-lights comp renders
+byte-identical to today (the pass must be a true no-op when absent).
+
+## 4. Light wrap — the cheapest "light meets footage" feature that exists
+
+The compositing classic for keyed foregrounds: blur the *background*, mask it by the
+inverted-and-blurred alpha edge of the foreground, screen it back over the edges — the
+background's light "wraps" the subject
+([explainer](https://max-klomeier.medium.com/introduction-light-wrapping-70b03f2092c3)).
+One blur plus two mask multiplies, entirely out of kernels the engine already has; per
+line of code nothing else in this file comes close, and it pairs naturally with entry 3
+(a rect light behind a keyed subject + wrap = the money shot).
+
+Build as an ordinary effect (docs/08 §2 contract): parameters **width** (px@comp),
+**intensity**, **wrap source** (the layer stack below, the way Fast motion blur's
+adjustment-layer case names it — note that TODO's "fast motion blur only works on
+footage layers" entry describes the same below-stack plumbing; whichever lands first
+digs the tunnel the other reuses). CPU oracle + WGSL kernel + arb/engine-label strings
++ an 08-EFFECTS §3 entry.
+
+## 5. Viewer bar completion — the two owed halves of what just landed
+
+Natural follow-ups to K-352 and the resolution dropdown, both small and both already
+specified in docs/07 §2.2:
+
+- **Third and Auto resolution rows, stored per comp** (item 2). Third = scale 1/3 (the
+  adaptive ladder already renders it — `resolutionThird` exists as a tier name). Auto =
+  render only the pixels the magnification can display, which is what
+  `reportViewerScale` already measures — the row mostly *names* existing behaviour.
+  Per-comp storage rides the session blob exactly as `viewerLooks` does (K-314's
+  pattern, K-245's blob).
+- **Background colour swatch** (item 10): per-comp background colour (a document write,
+  undoable, unlike the looks) plus quick black/white/checker. The checker option is
+  K-352's flag; the swatch is the first UI for `comp.background` at all.
+
+## 6. Region of interest (docs/07 §2.2 item 7)
+
+Drag a rectangle; the engine composites only that region. The realiser already
+composites at a scaled raster (K-186 / the preview-scale work), so the mechanism is a
+scissor/viewport on the composite target plus an offset in the present — not a new
+pipeline. One-click clear; never affects export (same construction as the preview
+scale: the export renderer never receives it). Frame names must fold the region in
+(the K-346/K-352 mechanism — a cropped frame is not the full frame) or refuse names
+while a region is set; folding is better, scrubbing inside a region is the use case.
+
+---
+
+## Suggested order
+
+| # | Entry | Why this position |
+|---|-------|-------------------|
+| 1 | 0 — flare bit-stability | Blocks honest validation of 1 and 2 |
+| 2 | 2 — bright-pass hardening | Small, immediate payoff on footage, de-risks 1 |
+| 3 | 5 — viewer bar completion | Small, finishes surfaces this week opened |
+| 4 | 1 — flare element stack | The headline; slice it (streak → stack → starburst) |
+| 5 | 3a/3b — Light layer + flare wiring | Model decision first, wiring is cheap |
+| 6 | 4 — light wrap | Anytime after its below-stack plumbing exists |
+| 7 | 3c — LTC area lights | The deep cut; lands on a model already proven by 3b |
+| 8 | 6 — region of interest | Independent; whenever the Viewer is next open |
+
+Skipped deliberately, so they are not re-proposed: per-frame FFT diffraction and full
+lens simulation (offline-class cost), temporal history buffers for flare smoothing
+(tracked positions make them unnecessary), ML relighting (non-deterministic, wrong
+weight class), representative-point sphere/tube lights (LTC covers the rect case a
+compositor actually needs; add spheres only if a use case shows up).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -61,12 +61,12 @@ These are v1-scope surfaces it does not yet match.
 **Viewer bar ([07-UI-SPEC.md](07-UI-SPEC.md) §2.2):**
 - The wireframe/overlay *menu*; guides menu; region-of-interest;
     background-colour swatch.
-- **Preview resolution is a menu row, not yet a bar dropdown** (§2.2 item 2).
-    Full / Half / Quarter work end to end — the View menu, the three chords and
-    the command palette all set the `scale` every render request carries — but
-    the dropdown the bar is supposed to carry is not built, **Third** and
-    **Auto** have no rows, and the choice is shell-wide rather than stored per
-    composition in the project as §2.2 asks.
+- **Preview resolution is on the bar, but only Full / Half / Quarter** (§2.2
+    item 2). The bar dropdown, the View menu, the three chords and the command
+    palette all set the `scale` every render request carries, and the dropdown
+    is disabled while adaptive playback chooses the tier itself — but **Third**
+    and **Auto** have no rows, and the choice is shell-wide rather than stored
+    per composition in the project as §2.2 asks.
 - **The colour-management badge is a readout and cannot yet be clicked**
     (§2.2 item 8). It is built: always on the bar, naming the display
     transform, and saying the picture is not the export while the exposure or
@@ -281,7 +281,13 @@ imported theme travels with the user rather than the machine's settings.
     passes at `--concurrency=1`, which is what CI runs. They contend for the
     shared engine (audio device, render worker) across test *files*. Give those
     files a serial marker or make the engine per-file - the serial run is a
-    mitigation, not the fix, and it costs wall-clock.
+    mitigation, not the fix, and it costs wall-clock. A concrete signature,
+    measured 2026-08-12 *within* `viewer_panel_frb_test.dart` alone on the
+    owner's machine: five frame-arrival tests fail late in the file with
+    "Could not create the renderer … device request failed: Not enough memory
+    left" — the workers the earlier tests spun up exhaust the device, so the
+    failing set shifts run to run and every member passes alone. Whatever fixes
+    the contention should make that message impossible, not rarer.
 - **Beat tap has no key left** - [07-UI-SPEC.md](07-UI-SPEC.md) §10 wants `8`
     during playback to tap a beat, and K-254 gave the bare digits to the numbered
     markers. Needs its own chord or a modal reading.

--- a/flutter_ui/lib/l10n/app_en.arb
+++ b/flutter_ui/lib/l10n/app_en.arb
@@ -204,6 +204,10 @@
       }
     }
   },
+  "openingProject": "Opening project…",
+  "@openingProject": {
+    "description": "Card shown over the interface while a project file is being read from disk."
+  },
   "couldNotOpenLink": "Could not open {url}",
   "@couldNotOpenLink": {
     "description": "Bottom-strip notice when a Help menu link could not be handed to the machine's browser. {url} is a web address and is not translated.",
@@ -3990,6 +3994,14 @@
   "tipPlayheadTime": "Playhead time",
   "@tipPlayheadTime": {
     "description": "Tooltip on the Timeline's time readout. Under five words."
+  },
+  "tipPreviewResolution": "Preview resolution",
+  "@tipPreviewResolution": {
+    "description": "Tooltip on the Viewer bar's resolution dropdown (Full, Half, Quarter). Under five words."
+  },
+  "tipPreviewResolutionAdaptive": "Adaptive playback chooses the resolution",
+  "@tipPreviewResolutionAdaptive": {
+    "description": "Tooltip on the Viewer bar's resolution dropdown while it is disabled because adaptive playback picks the resolution automatically."
   },
   "tipProperties": "Properties",
   "@tipProperties": {

--- a/flutter_ui/lib/main.dart
+++ b/flutter_ui/lib/main.dart
@@ -263,15 +263,44 @@ class LumitState extends ChangeNotifier {
     _adopt(LumitBridgeState.newProject(onChangeStream: _changeSink()));
   }
 
-  void openProject(String path) {
+  /// True from the moment a document starts being read until the Viewer has
+  /// something to show of it. The shell draws its progress bar over the
+  /// previous project and swaps nothing until this goes back to false.
+  ///
+  /// **It covers the picture, not just the read.** Reading the file is the
+  /// first half; the second is the new project's render worker starting and
+  /// serving a frame, and a shell that filled its panels between the two read
+  /// as an editor that had loaded and then sat there. Everything appears
+  /// together instead — which is what an application loading looks like.
+  /// [previewReady] is what ends it.
+  final ValueNotifier<bool> opening = ValueNotifier(false);
+
+  /// The Viewer has something to show, or there is nothing for it to show —
+  /// either way the shell can come out from behind its progress bar.
+  ///
+  /// Called on the first sign of life from the new project's worker (any reply
+  /// at all, not only a frame: a project whose first render faults must not
+  /// leave the interface covered), and by the session restore when it fronts no
+  /// composition, which is a project with no picture to wait for.
+  void previewReady() {
+    if (opening.value) opening.value = false;
+  }
+
+  Future<void> openProject(String path) async {
+    // One at a time: the change sink below is a single pending field, and two
+    // opens in flight would have the second take the first's.
+    if (opening.value) return;
+    opening.value = true;
     // Null means the file would not open; the previous project stays loaded
     // rather than the app being left with none.
-    final opened =
-        LumitBridgeState.openProject(path: path, onChangeStream: _changeSink());
+    final opened = await LumitBridgeState.openProject(
+        path: path, onChangeStream: _changeSink());
     if (opened == null) {
       postNotice(l10n.couldNotOpen(path), error: true);
+      opening.value = false;
       return;
     }
+    // Deliberately still `opening`: the document is in, the picture is not.
     _adopt(opened);
   }
 
@@ -1379,6 +1408,10 @@ class LumitUiState extends ChangeNotifier {
       model.refresh();
     });
     sub = state.onWorkerResponse.listen((msg) {
+      // Any reply at all means the new project's worker is up and answering,
+      // which is what the opening card is waiting on. Not the frame alone: a
+      // first render that faults would otherwise leave the shell covered.
+      state.previewReady();
       switch (msg) {
         case WorkerResponse_RenderedDMABuf frame:
           previewTier.value = frame.field0.tier;
@@ -1534,9 +1567,32 @@ class LumitUiState extends ChangeNotifier {
     return (stops: stored.stops, toneMap: false);
   }
 
-  /// The last look actually sent to the engine, so a neutral push onto an
-  /// already-neutral renderer can be skipped. A worker is born neutral.
-  ViewerLook _pushedLook = neutralLook;
+  /// The whole look the engine was last told — exposure, tone map and the
+  /// transparency grid — or null when a freshly adopted worker has been told
+  /// nothing yet. One record for the three, because they travel as one
+  /// message ([pushViewerLook]) and a push can be skipped only when *all* of
+  /// it is already in force.
+  ({double stops, bool toneMap, bool grid})? _pushedView;
+
+  /// Whether the Viewer's transparency grid is up (K-352). While it is, the
+  /// engine leaves the comp's background colour out of the composite, so
+  /// pixels nothing covers arrive transparent and the grid shows through.
+  ///
+  /// Held here rather than in the Viewer panel because the engine has to be
+  /// told: it rides [pushViewerLook]'s one look message, and project adoption
+  /// clears [_pushedView] so a worker just born — which starts opaque — is
+  /// told afresh on the first front.
+  bool viewerGrid = true;
+
+  /// Flip the transparency grid. The push and the re-render are
+  /// [pushViewerLook]'s: the grid is part of the one look message, and the
+  /// change of record is what makes it ask for the frame again.
+  void setViewerGrid(bool on) {
+    if (viewerGrid == on) return;
+    viewerGrid = on;
+    notifyListeners();
+    pushViewerLook();
+  }
 
   /// Set the exposure, leaving the tone map as it is; and the mirror of it.
   ///
@@ -1565,27 +1621,34 @@ class LumitUiState extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Tell the engine what the Viewer is looking through, and ask for the frame
-  /// again — a setting changes what the *next* frame looks like, so without the
-  /// ask the picture would not move until something else moved it.
+  /// Tell the engine what the Viewer is looking through — exposure, tone map
+  /// and the transparency grid, one message carrying the whole look — and ask
+  /// for the frame again, because a setting changes what the *next* frame is
+  /// made of.
   ///
-  /// Neutral onto a renderer already neutral is nothing to say and nothing to
-  /// undo, so it is skipped — which is every fronting in a session where
-  /// nobody has touched either control, and the renderer is born neutral. The
-  /// re-render is the expensive half: fronting a comp asks for its frame
-  /// anyway, and asking twice is a whole extra composite each time.
+  /// A look the renderer already holds ([_pushedView]) is nothing to say and
+  /// nothing to re-render, so it is skipped — which is every fronting where
+  /// nothing changed, and what keeps an exposure drag to one message per
+  /// actual movement. The record clears on project adoption, because a new
+  /// worker is born neutral-and-opaque and must be told afresh.
   void pushViewerLook() {
     final comp = selectedComp;
     if (comp == null) return;
     final look = viewerLook;
-    if (look == neutralLook && _pushedLook == neutralLook) return;
-    _pushedLook = look;
+    final target = (stops: look.stops, toneMap: look.toneMap, grid: viewerGrid);
+    if (target == _pushedView) return;
     try {
-      comp.setDisplayView(stops: look.stops, toneMap: look.toneMap);
+      comp.setViewerLook(
+        stops: target.stops,
+        toneMap: target.toneMap,
+        transparentBackground: target.grid,
+      );
     } catch (_) {
-      // No worker yet, or a comp that has gone. The next change asks again.
+      // No worker yet, or a comp that has gone. The next change asks again —
+      // and _pushedView stays as it was, so the ask is not skipped.
       return;
     }
+    _pushedView = target;
     requestFrame();
   }
 
@@ -1688,8 +1751,10 @@ class LumitUiState extends ChangeNotifier {
       clearSelection();
       playheadFrame.value = 0;
       viewerLooks.clear();
-      // A new project is a new worker, and a new worker is born neutral.
-      _pushedLook = neutralLook;
+      // A new project is a new worker, and a new worker is born knowing
+      // nothing of this session's look — the null record is what makes the
+      // first front tell it everything, the grid included.
+      _pushedView = null;
       setSelectedComp(null);
 
       final path = project?.path();
@@ -1732,6 +1797,11 @@ class LumitUiState extends ChangeNotifier {
       }
     } finally {
       _restoring = false;
+      // A project that opens with no composition fronted has no picture to
+      // wait for, so the opening card would stand for ever waiting on a frame
+      // nobody is going to ask for. In the `finally` because every early
+      // return above is one of those cases.
+      if (selectedComp == null) _app.previewReady();
     }
   }
 
@@ -1990,6 +2060,10 @@ class _LumitAppViewState extends State<LumitAppView> {
 
   bool _handleKey(KeyEvent event) {
     if (!mounted) return false;
+    // The overlay swallows the pointer; keys are routed globally rather than
+    // through the tree, so they have to be swallowed here. A command aimed at
+    // the document being replaced has nothing left to run against.
+    if (context.read<LumitState>().opening.value) return true;
     return _onKey(
             context.read<LumitState>(), context.read<LumitUiState>(), event) ==
         KeyEventResult.handled;
@@ -2004,7 +2078,20 @@ class _LumitAppViewState extends State<LumitAppView> {
     // falls back to the enclosing scope rather than to nothing.
     return FocusScope(
       autofocus: true,
-      child: Column(
+      child: Stack(children: [
+        _shell(uiState, state),
+        // Over everything while a document is being read (see OpeningOverlay):
+        // the shell behind it is still the previous project and swaps in one go.
+        ValueListenableBuilder<bool>(
+          valueListenable: state.opening,
+          builder: (context, opening, _) =>
+              opening ? const OpeningOverlay() : const SizedBox.shrink(),
+        ),
+      ]),
+    );
+  }
+
+  Widget _shell(LumitUiState uiState, LumitState state) => Column(
         children: [
           LumitMenuBarFrb(app: state),
           // The tools, under the menu and above everything else — where a
@@ -2023,9 +2110,7 @@ class _LumitAppViewState extends State<LumitAppView> {
           // progress and Cancel, reachable without the dialogue open.
           const StatusLineFrb(),
         ],
-      ),
-    );
-  }
+      );
 
   /// Which keymap context the focused panel is. Panels with no bindings of
   /// their own resolve to `Global`, which is also the fallback for every other

--- a/flutter_ui/lib/panels/project_panel_frb.dart
+++ b/flutter_ui/lib/panels/project_panel_frb.dart
@@ -758,7 +758,11 @@ class _ProjectPanelFrbState extends State<ProjectPanelFrb> {
             if (_missing[id] != isMissing) {
               setState(() => _missing[id] = isMissing);
             }
-          });
+            // A probe can outlive its document: opening a project clears the
+            // engine's registry and every reference held from the outgoing one
+            // throws. Nothing is missing in a document that is gone, and the
+            // panel is about to be rebuilt from the new one.
+          }).catchError((_) {});
         }
       }
       if (item is ItemReference_Folder) {

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -95,7 +95,6 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
   /// the panel as it is resized.
   double? _zoom;
   ViewerChannel _channel = ViewerChannel.rgb;
-  bool _grid = true;
 
   /// Whether the layer controls — the wireframe boxes, the handles and the
   /// hover highlight — are drawn over the picture (K-217). On by default,
@@ -325,7 +324,9 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
           builder: (context, tier, _) => _Toolbar(
             zoom: _zoom,
             channel: _channel,
-            grid: _grid,
+            // Session state rather than panel state (K-352): the engine has to
+            // be told when it flips, and [LumitUiState] is what talks to it.
+            grid: ui.viewerGrid,
             wireframes: _wireframes,
             look: ui.viewerLook,
             showToneMap: ui.workspace.interface.showToneMap,
@@ -341,7 +342,7 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
             // which is what the measured rectangle in the layout builder knows.
             onZoom: (z) => _goToZoom(z, Offset.zero, from: _shownScale),
             onChannel: (c) => setState(() => _channel = c),
-            onGrid: () => setState(() => _grid = !_grid),
+            onGrid: () => ui.setViewerGrid(!ui.viewerGrid),
             onWireframes: () => setState(() => _wireframes = !_wireframes),
             onPlayPause: _togglePlay,
             onSeek: (f) => _seek(comp, ui, f),
@@ -397,7 +398,7 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
                 comp: comp,
                 uiState: ui,
                 fitted: fitted,
-                grid: _grid,
+                grid: ui.viewerGrid,
                 wireframes: _wireframes,
                 channel: _channel,
                 compSize: size,
@@ -498,7 +499,15 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
       (constraints.maxWidth - drawn.width) / 2,
       (constraints.maxHeight - drawn.height) / 2,
     );
-    return (centre + pan) & drawn;
+    // Snapped to the device-pixel grid before anyone sees it: the
+    // checkerboard is painted anti-aliased while the platform texture is not,
+    // so a fractional edge bled a soft row of board out under the picture at
+    // some zooms. Snapping here rather than at a call site keeps the
+    // invariant wherever the rect travels.
+    return snapToDevicePixels(
+      (centre + pan) & drawn,
+      MediaQuery.devicePixelRatioOf(context),
+    );
   }
 
   /// One wheel notch is ~12 % in or out, smooth on a trackpad (the delta is
@@ -1313,7 +1322,16 @@ class _MissingBadgeState extends State<_MissingBadge> {
   Future<void> _probe() async {
     var count = 0;
     for (final f in widget.footage) {
-      if (await f.getStatus() == LumitMediaStatus.missing) count++;
+      // A probe outlives the document it was started for: opening a project
+      // clears the engine's registry, and every reference held from the
+      // outgoing one throws from here on. There is no missing media in a
+      // document that is gone — drop the count and wait to be rebuilt with the
+      // new project's footage.
+      try {
+        if (await f.getStatus() == LumitMediaStatus.missing) count++;
+      } catch (_) {
+        return;
+      }
     }
     if (mounted && count != _missing) setState(() => _missing = count);
   }
@@ -1432,6 +1450,19 @@ ColorFilter? channelFilterFor(ViewerChannel channel) => switch (channel) {
 /// magnification.
 Rect checkerArea(Rect picture, Size panel) =>
     picture.intersect(Offset.zero & panel);
+
+/// [rect] with every edge on a whole device pixel.
+///
+/// The picture and its checkerboard are given the same rectangle, but they
+/// rasterise it differently — the board through an anti-aliased canvas, the
+/// platform texture without — so a fractional edge showed as a soft row of
+/// board sticking out under the picture. Snapping the shared rectangle is
+/// what makes "the same rectangle" true on screen and not just in the layout.
+Rect snapToDevicePixels(Rect rect, double dpr) {
+  double snap(double v) => (v * dpr).roundToDouble() / dpr;
+  return Rect.fromLTRB(
+      snap(rect.left), snap(rect.top), snap(rect.right), snap(rect.bottom));
+}
 
 
 /// The transparency checkerboard behind the picture.
@@ -1594,6 +1625,15 @@ class _Toolbar extends StatelessWidget {
                       : '${(_zoomSteps[i]! * 100).round()}%',
               onChanged: (i) => onZoom(_zoomSteps[i]),
             ),
+          ),
+          const SizedBox(width: 6),
+          // The preview resolution (docs/07 §2.2 item 2): how many pixels the
+          // engine is asked to make, beside the magnification it is so easily
+          // mistaken for. Muted while adaptive playback is choosing the tier
+          // itself — a choice something else is making is not yours to make.
+          const SizedBox(
+            width: 76,
+            child: _ResolutionDropdown(),
           ),
           const SizedBox(width: 6),
           SizedBox(
@@ -1911,6 +1951,35 @@ String get _transportName => switch (_transport) {
       BridgeViewerTransport.dmaBuf => l10n.transportDmaBuf,
       BridgeViewerTransport.readBack => l10n.transportReadBack,
     };
+
+/// The preview resolution, on the bar (docs/07 §2.2 item 2).
+///
+/// The same choice the View menu's Resolution rows make — [LumitUiState] holds
+/// it, so the menu tick and this face cannot disagree. Disabled while playback
+/// is adaptive: the engine is walking the degradation ladder itself, and a
+/// dropdown that claimed the choice while something else made it would be a
+/// control that lies.
+class _ResolutionDropdown extends StatelessWidget {
+  const _ResolutionDropdown();
+
+  @override
+  Widget build(BuildContext context) {
+    final ui = Provider.of<LumitUiState>(context);
+    final adaptive = ui.workspace.performance.playback == PlaybackMode.adaptive;
+    return LumitTooltip(
+      message: adaptive
+          ? l10n.tipPreviewResolutionAdaptive
+          : l10n.tipPreviewResolution,
+      child: BareDropdown<PreviewResolution>(
+        key: const ValueKey('viewer-resolution'),
+        value: ui.previewResolution,
+        options: PreviewResolution.values,
+        label: (resolution) => resolution.title,
+        onChanged: adaptive ? null : ui.setPreviewResolution,
+      ),
+    );
+  }
+}
 
 /// Which of the two playback behaviours is in force — the name of the mode and
 /// nothing else (K-287).

--- a/flutter_ui/lib/shell/menu_bar_frb.dart
+++ b/flutter_ui/lib/shell/menu_bar_frb.dart
@@ -917,7 +917,7 @@ Future<void> openProjectFrb(LumitState app,
     {Future<String?> Function()? picker}) async {
   final path = await (picker ?? pickProjectToOpen)();
   if (path == null) return;
-  app.openProject(path);
+  await app.openProject(path);
 }
 
 Future<void> importFootageFrb(LumitState app,

--- a/flutter_ui/lib/shell/recovery_dialog_frb.dart
+++ b/flutter_ui/lib/shell/recovery_dialog_frb.dart
@@ -45,7 +45,7 @@ Future<RecoveryChoice?> showRecoveryDialogFrb({
     case RecoveryChoice.journal:
       state.project?.restoreJournal(projectPath: projectPath);
     case RecoveryChoice.autosave:
-      state.openProject(autosaves.first.path);
+      await state.openProject(autosaves.first.path);
     case RecoveryChoice.discard:
       break;
   }

--- a/flutter_ui/lib/shell/splash.dart
+++ b/flutter_ui/lib/shell/splash.dart
@@ -21,6 +21,74 @@ const List<String> bootLines = [
   'shell',
 ];
 
+/// The card shown while a document is being read off disk.
+///
+/// Its job is what it *hides*: opening a project replaces the whole document,
+/// and the panels behind this are still drawing the previous one. Rather than
+/// letting them empty out panel by panel as the new document arrives, the shell
+/// leaves whatever was on screen standing and covers it with this until the new
+/// project is adopted — one swap, no half-loaded interface.
+///
+/// The bar is indeterminate: reading a `.lum` reports no progress, so it sweeps
+/// rather than claiming to know how far along it is.
+class OpeningOverlay extends StatefulWidget {
+  const OpeningOverlay({super.key});
+
+  @override
+  State<OpeningOverlay> createState() => _OpeningOverlayState();
+}
+
+class _OpeningOverlayState extends State<OpeningOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _sweep = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 900),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _sweep.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    // Nothing underneath is clickable while the document it belongs to is being
+    // replaced, and the scrim is what says so.
+    return AbsorbPointer(
+      child: ColoredBox(
+        color: t.scrim,
+        child: Center(
+          child: Container(
+            width: 260,
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: t.surface1,
+              borderRadius: BorderRadius.circular(t.tokens.floatRadius),
+              border: Border.all(color: t.hairline),
+              boxShadow: t.floatShadow,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(l10n.openingProject, style: t.bodyPrimary),
+                const SizedBox(height: 12),
+                AnimatedBuilder(
+                  animation: _sweep,
+                  builder: (context, _) =>
+                      HouseProgressBar(fraction: _sweep.value),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class SplashOverlay extends StatefulWidget {
   final VoidCallback onDone;
 

--- a/flutter_ui/lib/src/rust/api/composition.dart
+++ b/flutter_ui/lib/src/rust/api/composition.dart
@@ -887,22 +887,6 @@ class CompositionReference {
               scale: scale,
               layer: layer);
 
-  /// Set what the Viewer looks *through*: `stops` of exposure and whether the
-  /// tone map is engaged (K-314, docs/07 §2.2 items 12-13).
-  ///
-  /// **Preview only.** It moves the display encode of every frame the session
-  /// renderer composites from here on and nothing else — no document, no op,
-  /// no undo step. An export builds its own renderer and this is never sent
-  /// to it, so the export is neutral by construction.
-  ///
-  /// The frontend follows this with its ordinary request for the frame under
-  /// the playhead: a setting changes what the *next* frame looks like, and
-  /// without an ask the picture would not move until something else did.
-  void setDisplayView({required double stops, required bool toneMap}) =>
-      BridgeLib.instance.api
-          .crateApiCompositionCompositionReferenceSetDisplayView(
-              that: this, stops: stops, toneMap: toneMap);
-
   /// Replace the whole marker list — one op, trivially invertible, which is
   /// also how beat detection commits a regenerated set.
   void setMarkers({required List<BridgeMarker> markers}) =>
@@ -930,6 +914,33 @@ class CompositionReference {
   void setSettings({required BridgeCompSettings settings}) =>
       BridgeLib.instance.api.crateApiCompositionCompositionReferenceSetSettings(
           that: this, settings: settings);
+
+  /// Set what the Viewer looks *through*, whole: `stops` of exposure and
+  /// whether the tone map is engaged (K-314, docs/07 §2.2 items 12-13), and
+  /// whether the comp's background colour is left out of the composite so
+  /// the transparency grid can show through what nothing covers (K-352).
+  ///
+  /// **Preview only.** It moves how every frame the session renderer makes
+  /// from here on is composited and display-encoded, and nothing else — no
+  /// document, no op, no undo step. An export builds its own renderer and
+  /// this is never sent to it, so an export is neutral and draws the
+  /// backdrop by construction.
+  ///
+  /// One call carrying the whole look, so the renderer can never hold half
+  /// of one. The frontend follows a *change* with its ordinary request for
+  /// the frame under the playhead: a setting changes what the next frame is
+  /// made of, and without an ask the picture would not move until something
+  /// else did.
+  void setViewerLook(
+          {required double stops,
+          required bool toneMap,
+          required bool transparentBackground}) =>
+      BridgeLib.instance.api
+          .crateApiCompositionCompositionReferenceSetViewerLook(
+              that: this,
+              stops: stops,
+              toneMap: toneMap,
+              transparentBackground: transparentBackground);
 
   /// Set the work area, or clear it with `None`.
   void setWorkArea({BridgeSpan? span}) =>

--- a/flutter_ui/lib/src/rust/api/state.dart
+++ b/flutter_ui/lib/src/rust/api/state.dart
@@ -30,7 +30,12 @@ abstract class LumitBridgeState implements RustOpaqueInterface {
       BridgeLib.instance.api.crateApiStateLumitBridgeStateNewProject(
           onChangeStream: onChangeStream);
 
-  static ProjectReference? openProject(
+  /// Deliberately **not** `#[frb(sync)]`, unlike its `new_project` sibling:
+  /// reading a `.lum` parses a whole document and stats every media file it
+  /// names, and on the UI isolate that froze the window for as long as it
+  /// took. Async puts it on a worker thread, which is what lets Dart hold the
+  /// previous document on screen behind a progress bar until this returns.
+  static Future<ProjectReference?> openProject(
           {required String path,
           RustStreamSink<ScopedChange>? onChangeStream}) =>
       BridgeLib.instance.api.crateApiStateLumitBridgeStateOpenProject(

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -88,7 +88,7 @@ class BridgeLib
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 329358268;
+  int get rustContentHash => -1269538195;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -136,7 +136,7 @@ abstract class BridgeLibApi extends BaseApi {
   ProjectReference crateApiStateLumitBridgeStateNewProject(
       {RustStreamSink<ScopedChange>? onChangeStream});
 
-  ProjectReference? crateApiStateLumitBridgeStateOpenProject(
+  Future<ProjectReference?> crateApiStateLumitBridgeStateOpenProject(
       {required String path, RustStreamSink<ScopedChange>? onChangeStream});
 
   BridgeAudioClock crateApiAudioAudioClock();
@@ -350,11 +350,6 @@ abstract class BridgeLibApi extends BaseApi {
       required double scale,
       LayerReference? layer});
 
-  void crateApiCompositionCompositionReferenceSetDisplayView(
-      {required CompositionReference that,
-      required double stops,
-      required bool toneMap});
-
   void crateApiCompositionCompositionReferenceSetMarkers(
       {required CompositionReference that,
       required List<BridgeMarker> markers});
@@ -365,6 +360,12 @@ abstract class BridgeLibApi extends BaseApi {
   void crateApiCompositionCompositionReferenceSetSettings(
       {required CompositionReference that,
       required BridgeCompSettings settings});
+
+  void crateApiCompositionCompositionReferenceSetViewerLook(
+      {required CompositionReference that,
+      required double stops,
+      required bool toneMap,
+      required bool transparentBackground});
 
   void crateApiCompositionCompositionReferenceSetWorkArea(
       {required CompositionReference that, BridgeSpan? span});
@@ -1259,14 +1260,15 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       );
 
   @override
-  ProjectReference? crateApiStateLumitBridgeStateOpenProject(
+  Future<ProjectReference?> crateApiStateLumitBridgeStateOpenProject(
       {required String path, RustStreamSink<ScopedChange>? onChangeStream}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(path, serializer);
         sse_encode_opt_StreamSink_scoped_change_Sse(onChangeStream, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_project_reference,
@@ -2805,38 +2807,6 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           );
 
   @override
-  void crateApiCompositionCompositionReferenceSetDisplayView(
-      {required CompositionReference that,
-      required double stops,
-      required bool toneMap}) {
-    return handler.executeSync(SyncTask(
-      callFfi: () {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_box_autoadd_composition_reference(that, serializer);
-        sse_encode_f_64(stops, serializer);
-        sse_encode_bool(toneMap, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_unit,
-        decodeErrorData:
-            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
-      ),
-      constMeta:
-          kCrateApiCompositionCompositionReferenceSetDisplayViewConstMeta,
-      argValues: [that, stops, toneMap],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta
-      get kCrateApiCompositionCompositionReferenceSetDisplayViewConstMeta =>
-          const TaskConstMeta(
-            debugName: "composition_reference_set_display_view",
-            argNames: ["that", "stops", "toneMap"],
-          );
-
-  @override
   void crateApiCompositionCompositionReferenceSetMarkers(
       {required CompositionReference that,
       required List<BridgeMarker> markers}) {
@@ -2845,7 +2815,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_list_bridge_marker(markers, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2873,7 +2843,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_bool(on_, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2903,7 +2873,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_composition_reference(that, serializer);
         sse_encode_box_autoadd_bridge_comp_settings(settings, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2921,6 +2891,39 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
           const TaskConstMeta(
             debugName: "composition_reference_set_settings",
             argNames: ["that", "settings"],
+          );
+
+  @override
+  void crateApiCompositionCompositionReferenceSetViewerLook(
+      {required CompositionReference that,
+      required double stops,
+      required bool toneMap,
+      required bool transparentBackground}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_composition_reference(that, serializer);
+        sse_encode_f_64(stops, serializer);
+        sse_encode_bool(toneMap, serializer);
+        sse_encode_bool(transparentBackground, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_unit,
+        decodeErrorData:
+            sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBridgeError,
+      ),
+      constMeta: kCrateApiCompositionCompositionReferenceSetViewerLookConstMeta,
+      argValues: [that, stops, toneMap, transparentBackground],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta
+      get kCrateApiCompositionCompositionReferenceSetViewerLookConstMeta =>
+          const TaskConstMeta(
+            debugName: "composition_reference_set_viewer_look",
+            argNames: ["that", "stops", "toneMap", "transparentBackground"],
           );
 
   @override

--- a/flutter_ui/lib/widgets/controls.dart
+++ b/flutter_ui/lib/widgets/controls.dart
@@ -571,7 +571,12 @@ class BareDropdown<T> extends StatelessWidget {
   final T value;
   final List<T> options;
   final String Function(T) label;
-  final ValueChanged<T> onChanged;
+
+  /// Null disables the control — the closed face still names the value, drawn
+  /// in [HouseButton]'s own disabled style, and opens nothing. For a choice
+  /// something else is currently making (the Viewer's resolution while
+  /// adaptive playback picks the tier itself).
+  final ValueChanged<T>? onChanged;
 
   /// The heading an option sits under, or null for none. Options keep their
   /// given order; a heading is drawn each time the answer changes, so a list
@@ -602,49 +607,51 @@ class BareDropdown<T> extends StatelessWidget {
       // 12.1, which clears 3 by nothing at all. Horizontal is the button's own,
       // so nothing moves sideways.
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
-      onPressed: () async {
-        final box = context.findRenderObject()! as RenderBox;
-        final origin = box.localToGlobal(Offset.zero);
-        final picked = await showLumitPopup<T>(
-          context: context,
-          position: origin + Offset(0, box.size.height + 2),
-          // IntrinsicWidth bounds the stretch: a float in the overlay has
-          // unbounded width, and a stretched Column inside one otherwise
-          // forces an infinite width (the settings-dropdown crash).
-          builder: (close) => FloatSurface(
-            child: IntrinsicWidth(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (var i = 0; i < options.length; i++) ...[
-                    if (group != null &&
-                        group!(options[i]) != null &&
-                        (i == 0 ||
-                            group!(options[i - 1]) != group!(options[i])))
-                      Padding(
-                        padding:
-                            EdgeInsets.fromLTRB(10, i == 0 ? 6 : 10, 10, 2),
-                        child: Text(
-                          group!(options[i])!,
-                          style: t.small.copyWith(color: t.textMuted),
-                        ),
-                      ),
-                    MenuRow(
-                      selected: options[i] == value,
-                      onPressed: () => close(options[i]),
-                      child: Text(label(options[i])),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ),
-        );
-        if (picked != null) onChanged(picked);
-      },
+      onPressed: onChanged == null ? null : () => _open(context, t),
       child: _dropdownFace(t, label(value)),
     );
+  }
+
+  Future<void> _open(BuildContext context, LumitTheme t) async {
+    final box = context.findRenderObject()! as RenderBox;
+    final origin = box.localToGlobal(Offset.zero);
+    final picked = await showLumitPopup<T>(
+      context: context,
+      position: origin + Offset(0, box.size.height + 2),
+      // IntrinsicWidth bounds the stretch: a float in the overlay has
+      // unbounded width, and a stretched Column inside one otherwise
+      // forces an infinite width (the settings-dropdown crash).
+      builder: (close) => FloatSurface(
+        child: IntrinsicWidth(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (var i = 0; i < options.length; i++) ...[
+                if (group != null &&
+                    group!(options[i]) != null &&
+                    (i == 0 ||
+                        group!(options[i - 1]) != group!(options[i])))
+                  Padding(
+                    padding:
+                        EdgeInsets.fromLTRB(10, i == 0 ? 6 : 10, 10, 2),
+                    child: Text(
+                      group!(options[i])!,
+                      style: t.small.copyWith(color: t.textMuted),
+                    ),
+                  ),
+                MenuRow(
+                  selected: options[i] == value,
+                  onPressed: () => close(options[i]),
+                  child: Text(label(options[i])),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+    if (picked != null) onChanged!(picked);
   }
 }
 

--- a/flutter_ui/test/frb/menu_bar_frb_test.dart
+++ b/flutter_ui/test/frb/menu_bar_frb_test.dart
@@ -415,8 +415,13 @@ void main() {
       await tester.pump();
       expect(p.state.project!.getItems(), isEmpty);
 
+      // Reading the document is an async frb call now, so the open lands on
+      // settleFrb's real event-loop turns rather than on a pump. Adoption is
+      // what is being waited for: the held reference is another project's.
+      final before = p.state.project;
       await choose(tester, 'File', 'Open project…');
-      await tester.pump();
+      await settleFrb(tester,
+          until: () => !identical(p.state.project, before));
 
       final names = allItems(p.state).map((i) => i.name()).toList();
       expect(names, contains('hero.mov'));

--- a/flutter_ui/test/frb/session_restore_frb_test.dart
+++ b/flutter_ui/test/frb/session_restore_frb_test.dart
@@ -73,7 +73,13 @@ void main() {
     // state the application is never in.
     state.comps();
 
+    // Not awaited: reading a document is an async frb call whose continuation
+    // only lands on the real event-loop turns settleFrb provides. What is
+    // waited for is the *adoption* — `opening` also covers the first frame,
+    // which a widget test with no Viewer mounted never receives.
+    final adopted = state.project;
     state.openProject(path);
+    await settleFrb(tester, until: () => !identical(state.project, adopted));
 
     expect(layoutOf(workspace), arranged,
         reason: 'the panels came back where this project had them');
@@ -109,7 +115,9 @@ void main() {
       ),
     );
 
+    final adopted = state.project;
     state.openProject(path);
+    await settleFrb(tester, until: () => !identical(state.project, adopted));
 
     expect(ui.openComps, isEmpty, reason: 'a comp that is gone opens no tab');
     expect(ui.selectedComp, isNull);
@@ -148,7 +156,10 @@ void main() {
     expect(other.sessionFor(path), isNull, reason: 'never opened here');
     expect(layoutOf(other), isNot(arranged));
 
+    final adopted = otherState.project;
     otherState.openProject(path);
+    await settleFrb(
+        tester, until: () => !identical(otherState.project, adopted));
 
     expect(layoutOf(other), arranged,
         reason: 'the arrangement came out of the file');

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -15,6 +15,7 @@
 // run at all. They are among the tests most worth having; the skip is a
 // statement about the runner, not about them.
 
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
@@ -32,6 +33,7 @@ import 'package:lumit_flutter/panels/viewer_zoom.dart';
 import 'package:lumit_flutter/state/dropper.dart';
 import 'package:lumit_flutter/state/tools.dart';
 import 'package:lumit_flutter/state/settings.dart';
+import 'package:lumit_flutter/state/viewer_view.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/src/rust/api/audio.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
@@ -374,6 +376,40 @@ void main() {
       expect(find.byKey(const ValueKey('viewer-grid')), findsOneWidget);
       await tester.tap(find.byKey(const ValueKey('viewer-grid')));
       await tester.pump();
+    });
+
+    /// **The resolution dropdown is on the bar, and adaptive playback owns it
+    /// while adaptive playback is choosing** (docs/07 §2.2 item 2). Adaptive is
+    /// the default mode, so out of the box the dropdown is a muted readout;
+    /// switching to every-frame playback hands the choice back.
+    testWidgets(
+        'the resolution dropdown chooses, and is disabled while playback'
+        ' is adaptive', (tester) async {
+      final p = withLayer();
+      await mount(tester, p);
+
+      final dropdown = find.byKey(const ValueKey('viewer-resolution'));
+      expect(dropdown, findsOneWidget);
+
+      // Adaptive (the default): the engine walks the ladder itself, so the
+      // dropdown opens nothing.
+      await tester.tap(dropdown);
+      await tester.pumpAndSettle();
+      expect(find.text('Quarter'), findsNothing,
+          reason: 'disabled while adaptive playback picks the resolution');
+
+      p.uiState.workspace.performance.playback = PlaybackMode.everyFrame;
+      p.uiState.workspace.touch();
+      await tester.pump();
+
+      await tester.tap(dropdown);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Half').last);
+      await tester.pumpAndSettle();
+      expect(p.uiState.previewResolution, PreviewResolution.half,
+          reason: 'the bar reaches the same state the View menu sets — the '
+              'resolution→scale arithmetic itself is pinned in '
+              'menu_bar_frb_test.dart');
     });
 
     /// A scrub of [pixels] on a [DragValueField]. The first `kDragSlopDefault`
@@ -2613,6 +2649,41 @@ void main() {
       await tester.pump();
       expect(p.uiState.playheadFrame.value, 1);
       expect(audioClock().seconds, greaterThanOrEqualTo(0));
+    });
+
+    /// **LAST in this file**: `openProject` clears the engine's project
+    /// registry, so every reference an earlier test holds dies here.
+    ///
+    /// The missing-file badge probes each footage layer over the bridge, one
+    /// round trip each, and those answers can still be in flight when another
+    /// document replaces the one they were asked about — which is exactly what
+    /// opening a project does. Unguarded, the probe threw `InvalidProject` into
+    /// nobody's hands and the console filled with an unhandled exception.
+    testWidgets('a footage probe survives the document being replaced',
+        (tester) async {
+      final dir = Directory.systemTemp.createTempSync('lumit-viewer-swap');
+      final other = '${dir.path}/other.lum';
+
+      final p = withLayer();
+      // Enough layers that the probe loop — one bridge round trip per layer,
+      // in order — is still working through them when the open lands.
+      for (var i = 0; i < 30; i++) {
+        final gone =
+            p.state.project!.importFootage(path: 'C:/nowhere/gone$i.mp4');
+        p.comp.addFootageLayer(footage: gone, asSequence: false);
+      }
+      p.state.project!.save(path: other);
+      await settleFrb(tester, until: () => File(other).existsSync());
+
+      await mount(tester, p);
+      // Straight into the open, with the badge's probes unanswered: the
+      // registry is cleared while they are on the wire.
+      final adopted = p.state.project;
+      p.state.openProject(other);
+      await settleFrb(
+          tester, until: () => !identical(p.state.project, adopted));
+
+      expect(tester.takeException(), isNull);
     });
   }, skip: !engineAvailable);
 }

--- a/flutter_ui/test/viewer_checker_test.dart
+++ b/flutter_ui/test/viewer_checker_test.dart
@@ -58,4 +58,29 @@ void main() {
       expect(area.isEmpty, isTrue);
     });
   });
+
+  // The board and the picture are given the same rectangle, but a fractional
+  // one rasterises differently through an anti-aliased canvas than through the
+  // platform texture — a soft row of board stuck out under the picture at some
+  // zooms. Snapping the shared rectangle to whole device pixels is the fix.
+  group('snapToDevicePixels', () {
+    test('lands every edge on a whole device pixel', () {
+      final snapped = snapToDevicePixels(
+          const Rect.fromLTRB(10.3, 20.7, 410.5, 320.2), 1.0);
+      expect(snapped, const Rect.fromLTRB(10, 21, 411, 320));
+    });
+
+    test('snaps to the device grid, not the logical one', () {
+      // At 150 % scaling a device pixel is two thirds of a logical one.
+      final snapped =
+          snapToDevicePixels(const Rect.fromLTRB(0, 0, 100.2, 50.4), 1.5);
+      expect(snapped.right * 1.5, closeTo((100.2 * 1.5).roundToDouble(), 1e-9));
+      expect(snapped.bottom * 1.5, closeTo((50.4 * 1.5).roundToDouble(), 1e-9));
+    });
+
+    test('whole pixels pass through untouched', () {
+      const whole = Rect.fromLTRB(10, 20, 410, 320);
+      expect(snapToDevicePixels(whole, 2.0), whole);
+    });
+  });
 }


### PR DESCRIPTION
Two finished pieces of work that had been sitting uncommitted.

## K-351 — startup

A render worker took **7.7 s** to start on this machine, and 6.5 s of that was compiling the lens flare's ray tracer — paid by every project, including an empty one with no flare anywhere in it. The flare's pipelines now build on a thread of their own and are joined by the first frame that actually draws a flare. **Worker start is 1.1 s.**

`open_project` is no longer `#[frb(sync)]`, so parsing a `.lum` and stating its media no longer freezes the window; and while a document is being read the shell stands behind a single `OpeningOverlay` card until the Viewer has something to show, rather than filling panel by panel.

## K-352 — the transparency grid

The grid could never show through anything. The comp being looked at was always composited onto its own background colour at full alpha (nested comps clear transparent per K-241, the top of the walk did not), so even an empty comp with every layer hidden arrived opaque. docs/07 §2.2 item 4 always said the checkerboard replaces the comp background; it never did.

While the grid is up the engine now leaves the backdrop out of the composite, so what nothing covers stays transparent. It travels in one `set_viewer_look` message beside the exposure and tone map — so the renderer can never hold half a look — is folded into the frame's cache name (an opaque frame and a see-through frame are two different pictures), and is never sent to an export's own renderer.

The picture's rectangle is also snapped to whole device pixels: the board is painted anti-aliased and the platform texture is not, which is what left a soft row of board sticking out under the picture at some zoom levels.

## Also

The preview resolution is now a dropdown on the Viewer bar (docs/07 §2.2 item 2), sharing state with the View menu and disabled while adaptive playback is choosing the tier itself.

## New strings — Crowdin upload owed

`openingProject`, `tipPreviewResolution`, `tipPreviewResolutionAdaptive`. Every other language falls back to English until the source file is pushed.

## Verification

- New Rust regression tests pass on a real adapter: an empty comp renders alpha 0 with the flag and 255 without; the frame-naming test pins that the two backdrops take different cache names.
- `cargo check`, `cargo fmt --check`, `cargo clippy`, `flutter analyze` all clean.
- `viewer_checker_test`, `menu_bar_frb_test`, `session_restore_frb_test` pass in full.
- `viewer_panel_frb_test.dart`: the grid and resolution tests pass. Five or six frame-arrival tests in that file fail late in the run with "Could not create the renderer … Not enough memory left" — the known shared-engine contention already in docs/TODO.md. Each passes alone, the failing set shifts run to run, and the same failures reproduce with this change fully disabled. The measured signature is now recorded in that TODO entry.
