### PR TITLE
The flare draws the same picture twice, and the plan for making it properly accurate

### DIFF
--- a/crates/lumit-core/src/fx/builtins.rs
+++ b/crates/lumit-core/src/fx/builtins.rs
@@ -3029,6 +3029,29 @@ pub const BUILTINS: &[EffectSchema] = &[
                 },
             },
             ParamSchema {
+                id: "source_width",
+                label: "Source width",
+                // px@comp like the position (K-260), and the HALF-width of the
+                // emitting area: 0 — the default — is the point source the
+                // effect has always had, and anything larger makes it an AREA
+                // light whose ghosts take the shape of the source rather than
+                // of a point (K-355). Pairs with source_height into one row.
+                kind: ParamKind::Float {
+                    default: 0.0,
+                    slider: (0.0, 400.0),
+                    hard: (Some(0.0), None),
+                },
+            },
+            ParamSchema {
+                id: "source_height",
+                label: "Source height",
+                kind: ParamKind::Float {
+                    default: 0.0,
+                    slider: (0.0, 400.0),
+                    hard: (Some(0.0), None),
+                },
+            },
+            ParamSchema {
                 id: "intensity",
                 label: "Intensity",
                 // Master gain on everything the effect adds; 0 is the

--- a/crates/lumit-core/src/fx/lens_flare.rs
+++ b/crates/lumit-core/src/fx/lens_flare.rs
@@ -352,6 +352,11 @@ pub fn detect_lights(
     // spanning many tiles finally weighs as its whole lit area instead of
     // one pixel.
     let mut acc = vec![[0.0_f32; 3]; anchors.len()];
+    // The flux-weighted centroid of each anchor's contributing tiles, as
+    // (Σ w·x, Σ w·y, Σ w) — see where it is applied below. f32 throughout and
+    // in the fixed tile order, because the WGSL twin must add the same
+    // numbers in the same order.
+    let mut centroid = vec![[0.0_f32; 3]; anchors.len()];
     if !anchors.is_empty() {
         for (t, &(luma, idx)) in tiles.iter().enumerate() {
             if luma <= 0.0 {
@@ -385,15 +390,34 @@ pub fn detect_lights(
             for c in 0..3 {
                 acc[nearest][c] += src[c] * weight;
             }
+            let flux = luma * weight;
+            centroid[nearest][0] += (idx % w) as f32 * flux;
+            centroid[nearest][1] += (idx / w) as f32 * flux;
+            centroid[nearest][2] += flux;
         }
     }
     anchors
         .iter()
-        .zip(&acc)
-        .map(|(&(_, idx), rgb)| {
-            let (px, py) = (idx % w, idx / w);
+        .zip(acc.iter().zip(&centroid))
+        .map(|(&(_, idx), (rgb, cen))| {
+            // **Where the light IS, is the centre of its light** (K-354) —
+            // not whichever pixel happened to be brightest this frame.
+            //
+            // Pinning the anchor to its brightest pixel quantises the light's
+            // position to one pixel of a source that may span hundreds, and on
+            // FOOTAGE that pixel wanders: sensor noise and specular sparkle
+            // move it frame to frame, so the whole flare jitters even though
+            // the practical has not moved. The flux-weighted centroid of the
+            // tiles feeding this anchor is steady under exactly that noise,
+            // and for a one-tile point source it is that tile's own pixel, so
+            // nothing about a point light changes.
+            let (px, py) = if cen[2] > 0.0 {
+                (cen[0] / cen[2], cen[1] / cen[2])
+            } else {
+                ((idx % w) as f32, (idx / w) as f32)
+            };
             FlareLight {
-                pos: [(px as f32 + 0.5) / w as f32, (py as f32 + 0.5) / h as f32],
+                pos: [(px + 0.5) / w as f32, (py + 0.5) / h as f32],
                 rgb: [rgb[0] * tint[0], rgb[1] * tint[1], rgb[2] * tint[2]],
             }
         })

--- a/crates/lumit-core/src/fx/lens_flare.rs
+++ b/crates/lumit-core/src/fx/lens_flare.rs
@@ -80,6 +80,13 @@ pub struct LensFlareParams {
     /// 1 Matte (bright sources detected in a referenced layer), 2 Lights
     /// (prepared for light layers; resolves as Manual until they land).
     pub source: u32,
+    /// Manual mode: the half-width and half-height of the emitting area, in
+    /// raster pixels (px@comp, K-260). Zero — the default — is the point
+    /// source the effect has always had; anything larger is an AREA source,
+    /// rendered by sampling the flare across it so its ghosts take the shape
+    /// of the source rather than of a point (K-355). Matte mode measures this
+    /// from the detected source instead and ignores the dial.
+    pub source_size: [f32; 2],
     /// Matte mode: linear luma at/above which a detected source flares fully
     /// (open above; a soft gate, see `threshold_softness`).
     pub threshold: f32,
@@ -206,10 +213,19 @@ pub const STARBURST_SAMPLES: u32 = 100;
 /// Aperture-image side for the starburst FFT.
 pub const APERTURE_RES: u32 = 256;
 
-/// Most flare sources a frame renders (Matte mode's top-K cap; Manual is
-/// one). 16 since K-267: area sources anchor on one slot each, and eight
-/// anchors starved scenes with several practicals plus an area source.
-pub const MAX_LIGHTS: usize = 16;
+/// Distinct sources a frame detects (Matte mode's top-K cap; Manual is one).
+/// 16 since K-267: area sources anchor on one slot each, and eight anchors
+/// starved scenes with several practicals plus an area source.
+pub const MAX_SOURCES: usize = 16;
+
+/// Light slots the trace can carry in one frame.
+///
+/// Four per source since K-355, because a source is no longer always a point:
+/// an AREA source is rendered by sampling the flare across its emitting area,
+/// and every sample needs a slot of its own. A frame of sixteen point sources
+/// still costs sixteen slots; one big softbox spends its slots on being the
+/// right shape instead.
+pub const MAX_LIGHTS: usize = 64;
 /// Detection tile side, raster pixels (impl note §6).
 pub const DETECT_TILE: u32 = 32;
 /// Non-max suppression radius, in tiles (Chebyshev): one highlight must not
@@ -238,15 +254,122 @@ pub struct FlareLight {
     pub pos: [f32; 2],
     /// Source colour times gate weight; all-zero entries are dead slots.
     pub rgb: [f32; 3],
+    /// Half-extent of the emitting area, as a fraction of the raster (K-355).
+    /// Zero is a point source and behaves exactly as it always did; anything
+    /// larger is an AREA source and is rendered by sampling across it — see
+    /// [`area_samples`].
+    pub extent: [f32; 2],
+}
+
+/// How many samples an area source is split into along each axis, at most.
+///
+/// A flare from an extended source is the sum of the flares of the points
+/// making it up, and the failure mode of sampling it too sparsely is not noise
+/// but **ghost replication** — you see N overlapping copies of the aperture
+/// rather than one smeared ghost. So the count is chosen from the source's own
+/// size rather than fixed, and the ceiling is what a 2 s/frame budget affords
+/// (docs/NEXT-FEATURES.md entry 1).
+pub const AREA_SAMPLES_MAX: u32 = 5;
+
+/// The fraction of the raster below which a source is simply a point.
+const AREA_MIN_EXTENT: f32 = 0.004;
+
+/// Split one light into the point sources that make it up (K-355).
+///
+/// **Why sampling rather than something cleverer.** The flare of an area
+/// source is genuinely the integral of the point flares over the emitting
+/// area, and at a two-second budget we can afford to evaluate that integral
+/// directly instead of approximating it. Each sample carries its share of the
+/// source's flux, so total energy is unchanged however finely it is split —
+/// a source only ever gets *smoother*, never brighter.
+///
+/// This is what makes an area light's flare look right: a bar-shaped source
+/// draws bar-shaped ghosts, a window draws rectangular ones, because the ghost
+/// each sample contributes lands in a slightly different place and their sum
+/// carries the source's shape. A single point source returns exactly itself,
+/// so nothing about point lights moves.
+///
+/// The grid is regular and centred, which keeps it deterministic (docs/14) —
+/// no jitter, so the same frame renders the same way every time.
+pub fn area_samples(light: &FlareLight, max_side: u32) -> Vec<FlareLight> {
+    let cap = max_side.clamp(1, AREA_SAMPLES_MAX);
+    let side = |e: f32| -> u32 {
+        if e < AREA_MIN_EXTENT {
+            1
+        } else {
+            // One sample per AREA_MIN_EXTENT of width, capped — enough that
+            // neighbouring samples land closer together than a ghost is wide.
+            ((e / AREA_MIN_EXTENT).round() as u32).clamp(1, cap)
+        }
+    };
+    let (nx, ny) = (side(light.extent[0]), side(light.extent[1]));
+    if nx <= 1 && ny <= 1 {
+        return vec![*light];
+    }
+    let share = 1.0 / (nx * ny) as f32;
+    let mut out = Vec::with_capacity((nx * ny) as usize);
+    for iy in 0..ny {
+        for ix in 0..nx {
+            // Centred on the source: the samples span ±extent about `pos`,
+            // which is the standard deviation of its flux, so they cover the
+            // body of the light rather than its far tails.
+            let f = |i: u32, n: u32, e: f32, c: f32| {
+                if n <= 1 {
+                    return c;
+                }
+                let t = i as f32 / (n - 1) as f32 * 2.0 - 1.0;
+                c + t * e
+            };
+            out.push(FlareLight {
+                pos: [
+                    f(ix, nx, light.extent[0], light.pos[0]),
+                    f(iy, ny, light.extent[1], light.pos[1]),
+                ],
+                rgb: [
+                    light.rgb[0] * share,
+                    light.rgb[1] * share,
+                    light.rgb[2] * share,
+                ],
+                extent: [0.0, 0.0],
+            });
+        }
+    }
+    out
+}
+
+/// Every light in `lights`, split into its area samples and truncated to the
+/// [`MAX_LIGHTS`] the trace can carry. Brighter sources are split first, so a
+/// crowded frame spends its slots on the lights that matter.
+pub fn expand_area_lights(lights: &[FlareLight], max_side: u32) -> Vec<FlareLight> {
+    let mut out: Vec<FlareLight> = Vec::new();
+    for light in lights {
+        let samples = area_samples(light, max_side);
+        if out.len() + samples.len() > MAX_LIGHTS {
+            // No room to split this one faithfully: carry it as the single
+            // point it started as rather than half an area source, which would
+            // lose the rest of its flux.
+            if out.len() < MAX_LIGHTS {
+                out.push(*light);
+            }
+            continue;
+        }
+        out.extend(samples);
+    }
+    out
 }
 
 /// Manual mode's light list: one source at the parameter position (raster
 /// pixels over the raster `w × h` — the fraction the trace consumes),
-/// carrying the Light tint (white by default).
+/// carrying the Light tint (white by default) and the Source size dial's
+/// half-extent (K-355; zero is the point source it has always been).
 pub fn manual_light(p: &LensFlareParams, w: u32, h: u32) -> Vec<FlareLight> {
     vec![FlareLight {
         pos: [p.light[0] / w.max(1) as f32, p.light[1] / h.max(1) as f32],
         rgb: p.light_tint,
+        extent: [
+            p.source_size[0] / w.max(1) as f32,
+            p.source_size[1] / h.max(1) as f32,
+        ],
     }]
 }
 
@@ -286,6 +409,45 @@ pub fn threshold_gate(luma: f32, threshold: f32, softness: f32) -> f32 {
 /// (K-259/K-267) — so the same function serves "the practical's own colour
 /// flares", "this matte only says *where*", and area sources whose light
 /// is their whole lit extent rather than one pixel.
+/// What one detection tile knows about the light inside it (K-355).
+///
+/// Through K-354 a tile was a single pair — its brightest pixel's luma and
+/// index — and everything downstream used that one pixel for the tile's
+/// position AND its colour. That is what made a flare *jump* on real footage:
+/// inside a practical, which pixel is brightest changes frame to frame with
+/// sensor noise and specular sparkle, so the light's reported position hopped
+/// about inside a source that had not moved at all. These sums describe the
+/// whole lit area of the tile instead, and none of them can be moved by one
+/// pixel changing its mind.
+#[derive(Clone, Copy, Debug)]
+struct TileStat {
+    /// The brightest pixel's luma and linear index — still how anchors are
+    /// ranked and gated, so a small bright source is still found.
+    luma_max: f32,
+    index: u32,
+    /// Σ gate, Σ colour·gate: the tile's gated coverage and colour, whose
+    /// ratio is the mean colour of the light in it.
+    wsum: f32,
+    csum: [f32; 3],
+    /// Σ luma·gate and its first moments — the tile's flux and where in the
+    /// tile that flux actually sits.
+    fsum: f32,
+    fx: f32,
+    fy: f32,
+}
+
+impl TileStat {
+    const EMPTY: Self = Self {
+        luma_max: -1.0,
+        index: 0,
+        wsum: 0.0,
+        csum: [0.0; 3],
+        fsum: 0.0,
+        fx: 0.0,
+        fy: 0.0,
+    };
+}
+
 pub fn detect_lights(
     matte: &[f32],
     w: u32,
@@ -300,8 +462,7 @@ pub fn detect_lights(
     }
     let tx = w.div_ceil(DETECT_TILE) as usize;
     let ty = h.div_ceil(DETECT_TILE) as usize;
-    // Per-tile brightest pixel: (luma, linear index).
-    let mut tiles: Vec<(f32, u32)> = vec![(-1.0, 0); tx * ty];
+    let mut tiles: Vec<TileStat> = vec![TileStat::EMPTY; tx * ty];
     for y in 0..h {
         for x in 0..w {
             let i = ((y * w + x) * 4) as usize;
@@ -309,27 +470,44 @@ pub fn detect_lights(
                 + super::cpu::LUMA[1] * matte[i + 1]
                 + super::cpu::LUMA[2] * matte[i + 2];
             let t = (y / DETECT_TILE) as usize * tx + (x / DETECT_TILE) as usize;
-            if luma > tiles[t].0 {
-                tiles[t] = (luma, y * w + x);
+            let tile = &mut tiles[t];
+            if luma > tile.luma_max {
+                tile.luma_max = luma;
+                tile.index = y * w + x;
+            }
+            // Every lit pixel contributes, not just the brightest (K-355):
+            // `w` is the pixel's own gate, `f` its gated flux.
+            let g = threshold_gate(luma, threshold, softness);
+            if g > 0.0 {
+                let f = luma * g;
+                tile.wsum += g;
+                tile.csum[0] += matte[i].max(0.0) * g;
+                tile.csum[1] += matte[i + 1].max(0.0) * g;
+                tile.csum[2] += matte[i + 2].max(0.0) * g;
+                tile.fsum += f;
+                tile.fx += x as f32 * f;
+                tile.fy += y as f32 * f;
             }
         }
     }
     let mut suppressed = vec![false; tx * ty];
-    // Anchors: the top-K picks, position at each pick's brightest pixel.
+    // Anchors: the top-K picks, ranked by their brightest pixel so a small
+    // bright source is still found; where the light is reported is the flux
+    // centroid worked out below, not this pixel.
     let mut anchors: Vec<(usize, u32)> = Vec::new();
-    for _ in 0..MAX_LIGHTS {
+    for _ in 0..MAX_SOURCES {
         let mut best: Option<usize> = None;
-        for (t, &(luma, _)) in tiles.iter().enumerate() {
-            if suppressed[t] || luma <= 0.0 {
+        for (t, stat) in tiles.iter().enumerate() {
+            if suppressed[t] || stat.luma_max <= 0.0 {
                 continue;
             }
             match best {
-                Some(b) if tiles[b].0 >= luma => {}
+                Some(b) if tiles[b].luma_max >= stat.luma_max => {}
                 _ => best = Some(t),
             }
         }
         let Some(b) = best else { break };
-        let (luma, idx) = tiles[b];
+        let (luma, idx) = (tiles[b].luma_max, tiles[b].index);
         if threshold_gate(luma, threshold, softness) <= 0.0 {
             // Cells are visited brightest-first, so nothing dimmer passes.
             break;
@@ -352,17 +530,17 @@ pub fn detect_lights(
     // spanning many tiles finally weighs as its whole lit area instead of
     // one pixel.
     let mut acc = vec![[0.0_f32; 3]; anchors.len()];
-    // The flux-weighted centroid of each anchor's contributing tiles, as
-    // (Σ w·x, Σ w·y, Σ w) — see where it is applied below. f32 throughout and
-    // in the fixed tile order, because the WGSL twin must add the same
-    // numbers in the same order.
+    // Per anchor: the flux centroid as (Σ f·x, Σ f·y, Σ f), and the second
+    // moment (Σ f·x², Σ f·y²) that gives the source its EXTENT — how wide the
+    // light actually is, which is what an area source needs sampling across.
     let mut centroid = vec![[0.0_f32; 3]; anchors.len()];
+    let mut spread = vec![[0.0_f32; 2]; anchors.len()];
     if !anchors.is_empty() {
-        for (t, &(luma, idx)) in tiles.iter().enumerate() {
-            if luma <= 0.0 {
+        for (t, stat) in tiles.iter().enumerate() {
+            if stat.luma_max <= 0.0 {
                 continue;
             }
-            let weight = threshold_gate(luma, threshold, softness);
+            let weight = threshold_gate(stat.luma_max, threshold, softness);
             if weight <= 0.0 {
                 continue;
             }
@@ -377,48 +555,73 @@ pub fn detect_lights(
                     nearest = a;
                 }
             }
-            let i = (idx * 4) as usize;
-            let src = if use_source_colour {
+            // The tile's MEAN colour over its lit pixels, not its brightest
+            // pixel's (K-355). One sparkle among a thousand lit pixels now
+            // shifts the colour by a thousandth instead of defining it.
+            let src = if !use_source_colour {
+                [1.0, 1.0, 1.0]
+            } else if stat.wsum > 0.0 {
+                [
+                    stat.csum[0] / stat.wsum,
+                    stat.csum[1] / stat.wsum,
+                    stat.csum[2] / stat.wsum,
+                ]
+            } else {
+                let i = (stat.index * 4) as usize;
                 [
                     matte[i].max(0.0),
                     matte[i + 1].max(0.0),
                     matte[i + 2].max(0.0),
                 ]
-            } else {
-                [1.0, 1.0, 1.0]
             };
             for c in 0..3 {
                 acc[nearest][c] += src[c] * weight;
             }
-            let flux = luma * weight;
-            centroid[nearest][0] += (idx % w) as f32 * flux;
-            centroid[nearest][1] += (idx / w) as f32 * flux;
-            centroid[nearest][2] += flux;
+            // The tile's own first moments carry straight over: summing them
+            // across a source's tiles gives that source's flux centroid, with
+            // no pixel anywhere able to move it on its own.
+            centroid[nearest][0] += stat.fx;
+            centroid[nearest][1] += stat.fy;
+            centroid[nearest][2] += stat.fsum;
+            // Σ f·x² is accumulated from the tile's mean position rather than
+            // per pixel: the tiles are what span a source, and a tile-grained
+            // extent is all the sampling below can use anyway.
+            if stat.fsum > 0.0 {
+                let (mx, my) = (stat.fx / stat.fsum, stat.fy / stat.fsum);
+                spread[nearest][0] += stat.fsum * mx * mx;
+                spread[nearest][1] += stat.fsum * my * my;
+            }
         }
     }
     anchors
         .iter()
-        .zip(acc.iter().zip(&centroid))
-        .map(|(&(_, idx), (rgb, cen))| {
-            // **Where the light IS, is the centre of its light** (K-354) —
-            // not whichever pixel happened to be brightest this frame.
-            //
-            // Pinning the anchor to its brightest pixel quantises the light's
-            // position to one pixel of a source that may span hundreds, and on
-            // FOOTAGE that pixel wanders: sensor noise and specular sparkle
-            // move it frame to frame, so the whole flare jitters even though
-            // the practical has not moved. The flux-weighted centroid of the
-            // tiles feeding this anchor is steady under exactly that noise,
-            // and for a one-tile point source it is that tile's own pixel, so
-            // nothing about a point light changes.
+        .zip(acc.iter().zip(centroid.iter().zip(&spread)))
+        .map(|(&(_, idx), (rgb, (cen, spr)))| {
+            // **Where the light IS, is the centre of its light** (K-354, and
+            // K-355 made it immovable by any one pixel). Pinning the anchor to
+            // its brightest pixel quantised the light to one pixel of a source
+            // that may span hundreds, and on FOOTAGE that pixel wanders:
+            // sensor noise and specular sparkle move it frame to frame, so the
+            // whole flare jittered even though the practical had not moved.
             let (px, py) = if cen[2] > 0.0 {
                 (cen[0] / cen[2], cen[1] / cen[2])
             } else {
                 ((idx % w) as f32, (idx / w) as f32)
             };
+            // The source's half-extent, as the standard deviation of its flux
+            // about that centre (√(E[x²] − E[x]²)). A point source measures
+            // zero and is sampled once; a practical measures its real width
+            // and is sampled across it (see [`area_samples`]).
+            let half = |m2: f32, mean: f32| {
+                if cen[2] <= 0.0 {
+                    return 0.0;
+                }
+                (m2 / cen[2] - mean * mean).max(0.0).sqrt()
+            };
             FlareLight {
                 pos: [(px + 0.5) / w as f32, (py + 0.5) / h as f32],
                 rgb: [rgb[0] * tint[0], rgb[1] * tint[1], rgb[2] * tint[2]],
+                extent: [half(spr[0], px) / w as f32, half(spr[1], py) / h as f32],
             }
         })
         .collect()
@@ -1683,6 +1886,10 @@ pub fn bake_with(p: &LensFlareParams, lens_text: Option<&str>) -> FlareBaked {
         roundness: p.roundness,
         aperture_softness: p.aperture_softness,
         ghost_intensity: 1.0,
+        // A point source for the exposure probe whatever the user's Source
+        // size: the gain must be steered by bake-key inputs alone, and an
+        // area source is a frame-time dial.
+        source_size: [0.0, 0.0],
         ghost_softness: 0.05,
         max_ghosts: 32,
         dispersion: 1.0,
@@ -1978,6 +2185,12 @@ pub fn cpu_flare(
     if w == 0 || h == 0 || p.ghost_intensity <= 0.0 {
         return out;
     }
+    // Area sources are sampled across their extent here, exactly as the GPU
+    // does — Manual's list is expanded by the caller that builds the op, and
+    // Matte's inside the detection kernel, so the reference must expand too
+    // or the two stop being twins (K-355). A list of point sources is
+    // returned unchanged, so nothing about a point light moves.
+    let lights = &expand_area_lights(lights, AREA_SAMPLES_MAX)[..];
     let (tier_base, tier_lambda, _) = quality_ladder(p.quality);
     // The Detail dial scales the tier's base AND its wavelength count
     // before the per-pair budget (K-265); both the CPU reference and the
@@ -2426,6 +2639,10 @@ pub fn cpu_combine(
     if p.intensity <= 0.0 || p.mix <= 0.0 {
         return;
     }
+    // The same expansion `cpu_flare` makes: the starburst is stamped per
+    // light, so an area source stamps one per sample at its share of the
+    // flux, which is what the GPU's combine does over its filled slots.
+    let lights = &expand_area_lights(lights, AREA_SAMPLES_MAX)[..];
     let squeeze = p.anamorphic.clamp(0.25, 4.0);
     let fscale = p.scale.clamp(0.05, 20.0);
     let sb_res = STARBURST_RES as usize;

--- a/crates/lumit-core/src/fx/lens_flare.rs
+++ b/crates/lumit-core/src/fx/lens_flare.rs
@@ -860,10 +860,182 @@ pub fn coating_reflectance(
     (num / den).clamp(0.0, 1.0)
 }
 
+/// The design wavelength every coating in the library is cut for, nm.
+pub const COATING_DESIGN_NM: f32 = 550.0;
+/// Magnesium fluoride — the classic single-layer AR, and the outer layer of
+/// every stack below.
+pub const MGF2_N: f32 = 1.38;
+/// Alumina, the mid-index layer of a broadband stack.
+pub const AL2O3_N: f32 = 1.63;
+/// Zirconia, the high-index layer.
+pub const ZRO2_N: f32 = 2.10;
+/// Most layers a stack may have.
+pub const MAX_COATING_LAYERS: usize = 6;
+
+/// The canonical stack for a `.lens` coating column, **outermost first** —
+/// each entry `(refractive index, optical thickness in quarter waves at
+/// [`COATING_DESIGN_NM`])`.
+///
+/// A lens prescription publishes a layer *count*, never the recipe: real
+/// coating designs are manufacturer secrets, and the literature is unanimous
+/// that they can only be measured, not predicted (K-356). What a renderer can
+/// do is use the textbook design of each order, which is what these are:
+///
+/// - **1 layer** — MgF₂ quarter wave, the classic single coating. One
+///   reflectance minimum at 550 nm, a broad V.
+/// - **2 layers** — a V-coat: high-index quarter under a MgF₂ quarter. Deeper
+///   minimum, still one of them.
+/// - **3 layers** — the classic broadband W: quarter / half / quarter, which
+///   is what gives a real multicoated lens two minima and the green-magenta
+///   cast between them.
+/// - **4+** — the same W with extra quarter-wave pairs beneath, broadening it
+///   further and lowering the mean.
+///
+/// The shape matters more than the exact recipe: it is the *variation of
+/// reflectance with wavelength and angle* that makes ghosts change hue as a
+/// light crosses the frame, and a single number cannot produce it at all.
+pub fn coating_stack(layers: f32) -> [(f32, f32); MAX_COATING_LAYERS] {
+    let none = (0.0, 0.0);
+    let n = (layers.round().max(0.0) as usize).min(MAX_COATING_LAYERS);
+    let mut out = [none; MAX_COATING_LAYERS];
+    match n {
+        0 => {}
+        1 => out[0] = (MGF2_N, 1.0),
+        2 => {
+            out[0] = (MGF2_N, 1.0);
+            out[1] = (ZRO2_N, 1.0);
+        }
+        _ => {
+            out[0] = (MGF2_N, 1.0);
+            out[1] = (ZRO2_N, 2.0);
+            out[2] = (AL2O3_N, 1.0);
+            // Extra pairs alternate high/low beneath the W, each a quarter
+            // wave, which is how broadband stacks are actually extended.
+            for (i, slot) in out.iter_mut().enumerate().take(n).skip(3) {
+                *slot = if i % 2 == 0 {
+                    (AL2O3_N, 1.0)
+                } else {
+                    (ZRO2_N, 1.0)
+                };
+            }
+        }
+    }
+    out
+}
+
+/// Complex multiply, as `(re, im)` — the whole of the complex arithmetic the
+/// transfer matrix needs, spelled out rather than pulled in as a dependency.
+#[inline]
+fn cmul(a: (f32, f32), b: (f32, f32)) -> (f32, f32) {
+    (a.0 * b.0 - a.1 * b.1, a.0 * b.1 + a.1 * b.0)
+}
+
+/// Reflectance of a multi-layer thin-film stack by the **characteristic
+/// transfer matrix** — the standard treatment, and the one thing that gets
+/// ghost colour right (K-356).
+///
+/// Per layer the phase thickness is `δ = 2π n d cos θ / λ` and the optical
+/// admittance `η = n cos θ` (s polarisation) or `n / cos θ` (p); the layer's
+/// characteristic matrix is `[[cos δ, i sin δ / η], [i η sin δ, cos δ]]`.
+/// Chaining them and closing on the substrate's admittance gives `Y = C / B`,
+/// whence `r = (η₀ − Y) / (η₀ + Y)`. Both polarisations are computed and
+/// averaged, which is what unpolarised light asks for.
+///
+/// **Why the angle matters as much as the wavelength.** `δ` carries a `cos θ`,
+/// so the whole reflectance band shifts *blue* as the angle of incidence
+/// rises. Flare rays strike interfaces at large and varied angles, so this is
+/// the dominant term — and it is exactly the observed effect that a ghost
+/// changes hue as its source moves off axis. No scalar coating strength can
+/// express it.
+pub fn stack_reflectance(
+    cos_i: f32,
+    n1: f32,
+    n2: f32,
+    stack: &[(f32, f32); MAX_COATING_LAYERS],
+    lambda_nm: f32,
+) -> f32 {
+    let cos_i = cos_i.abs().clamp(1e-6, 1.0);
+    // Snell's invariant: n·sinθ is the same in every medium of the stack.
+    let sin_i = n1 * (1.0 - cos_i * cos_i).max(0.0).sqrt();
+    let cos_in_medium = |n: f32| -> Option<f32> {
+        let s = sin_i / n.max(1e-6);
+        let c2 = 1.0 - s * s;
+        (c2 > 0.0).then(|| c2.sqrt())
+    };
+    let Some(cos_sub) = cos_in_medium(n2) else {
+        // Total internal reflection somewhere in the stack: the film model
+        // has nothing to say, so fall back to the bare interface.
+        return fresnel_cos(cos_i, n1, n2);
+    };
+
+    // `s` polarisation then `p`; unpolarised light is their mean.
+    let mut total = 0.0;
+    for pol in 0..2 {
+        let admittance = |n: f32, c: f32| if pol == 0 { n * c } else { n / c };
+        let eta0 = admittance(n1, cos_i);
+        let eta_sub = admittance(n2, cos_sub);
+        // The identity matrix, as (m00, m01, m10, m11) of complex pairs.
+        let mut m = [(1.0f32, 0.0f32), (0.0, 0.0), (0.0, 0.0), (1.0, 0.0)];
+        let mut valid = true;
+        for &(n, quarters) in stack.iter() {
+            if n <= 0.0 || quarters <= 0.0 {
+                continue;
+            }
+            let Some(cos_l) = cos_in_medium(n) else {
+                valid = false;
+                break;
+            };
+            // Physical thickness from the optical one: `quarters` quarter
+            // waves at the design wavelength.
+            let d_nm = quarters * COATING_DESIGN_NM / (4.0 * n);
+            let delta = 2.0 * std::f32::consts::PI * n * d_nm * cos_l / lambda_nm.max(1e-6);
+            let eta = admittance(n, cos_l);
+            let (cd, sd) = (delta.cos(), delta.sin());
+            let l = [(cd, 0.0), (0.0, sd / eta), (0.0, eta * sd), (cd, 0.0)];
+            // m = m · l
+            let a = [
+                (
+                    cmul(m[0], l[0]).0 + cmul(m[1], l[2]).0,
+                    cmul(m[0], l[0]).1 + cmul(m[1], l[2]).1,
+                ),
+                (
+                    cmul(m[0], l[1]).0 + cmul(m[1], l[3]).0,
+                    cmul(m[0], l[1]).1 + cmul(m[1], l[3]).1,
+                ),
+                (
+                    cmul(m[2], l[0]).0 + cmul(m[3], l[2]).0,
+                    cmul(m[2], l[0]).1 + cmul(m[3], l[2]).1,
+                ),
+                (
+                    cmul(m[2], l[1]).0 + cmul(m[3], l[3]).0,
+                    cmul(m[2], l[1]).1 + cmul(m[3], l[3]).1,
+                ),
+            ];
+            m = a;
+        }
+        if !valid {
+            return fresnel_cos(cos_i, n1, n2);
+        }
+        // [B, C] = M · [1, η_sub]
+        let b = (m[0].0 + m[1].0 * eta_sub, m[0].1 + m[1].1 * eta_sub);
+        let c = (m[2].0 + m[3].0 * eta_sub, m[2].1 + m[3].1 * eta_sub);
+        // r = (η₀·B − C) / (η₀·B + C)
+        let num = (eta0 * b.0 - c.0, eta0 * b.1 - c.1);
+        let den = (eta0 * b.0 + c.0, eta0 * b.1 + c.1);
+        let dm = den.0 * den.0 + den.1 * den.1;
+        if dm <= 1e-20 {
+            return fresnel_cos(cos_i, n1, n2);
+        }
+        total += (num.0 * num.0 + num.1 * num.1) / dm;
+    }
+    (total * 0.5).clamp(0.0, 1.0)
+}
+
 /// Reflectance of one lens surface: uncoated Fresnel blended toward the
 /// prescription's AR coating by the Coating dial. `layers` is the .lens
-/// coating column: 1 = single-layer MgF₂ quarter-wave at 550 nm; each extra
-/// layer quarters the residual (FlareSim's multicoat approximation).
+/// coating column, resolved to a real multi-layer design by
+/// [`coating_stack`] and evaluated by [`stack_reflectance`] (K-356,
+/// superseding the single-layer-times-a-quarter approximation).
 pub fn surface_reflectance(
     cos_i: f32,
     n1: f32,
@@ -876,14 +1048,7 @@ pub fn surface_reflectance(
     if layers < 0.5 || coating_mix <= 0.0 {
         return plain;
     }
-    const MGF2_N: f32 = 1.38;
-    const DESIGN_NM: f32 = 550.0;
-    let qw = DESIGN_NM / (4.0 * MGF2_N);
-    let mut coated = coating_reflectance(cos_i, n1, n2, MGF2_N, qw, lambda_nm);
-    let extra = (layers - 1.0).clamp(0.0, 8.0).round() as u32;
-    for _ in 0..extra {
-        coated *= 0.25;
-    }
+    let coated = stack_reflectance(cos_i, n1, n2, &coating_stack(layers), lambda_nm);
     (plain + (coated - plain) * coating_mix.clamp(0.0, 1.0)).clamp(0.0, 1.0)
 }
 

--- a/crates/lumit-core/src/fx/resolved.rs
+++ b/crates/lumit-core/src/fx/resolved.rs
@@ -1336,6 +1336,11 @@ fn resolve_one(
             // Transform-anchor convention (K-260: point params are pixels).
             let lx = fl("light_x").unwrap_or(640.0) as f32 * px_scale;
             let ly = fl("light_y").unwrap_or(360.0) as f32 * px_scale;
+            // Source size (K-355): the half-extent of an area light, in the
+            // same px@comp the position uses, so it rides the same preview
+            // factor. Zero is the point source the effect has always had.
+            let sw = (fl("source_width").unwrap_or(0.0) as f32).max(0.0) * px_scale;
+            let sh = (fl("source_height").unwrap_or(0.0) as f32).max(0.0) * px_scale;
             let intensity = (fl("intensity").unwrap_or(1.0) as f32).max(0.0);
             // Library index (K-261; out-of-range clamps inside lens_entry).
             // A pre-K-264 save's index pointed into the old 1299-lens
@@ -1396,6 +1401,7 @@ fn resolve_one(
             Some(Resolved::LensFlare(
                 crate::fx::lens_flare::LensFlareParams {
                     light: [lx, ly],
+                    source_size: [sw, sh],
                     intensity,
                     lens,
                     fstop,

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -5806,6 +5806,8 @@ fn default_flare_params() -> crate::fx::lens_flare::LensFlareParams {
         // Raster pixels (K-260): tests divide by their own raster via
         // manual_light, so any sane point works; this is 0.33/0.30 of 96×54.
         light: [31.7, 16.2],
+        // A point source, as the effect has always defaulted to.
+        source_size: [0.0, 0.0],
         intensity: 1.0,
         lens: 16,
         fstop: 2.8,
@@ -5862,10 +5864,20 @@ fn lens_flare_detects_matte_sources_deterministically() {
         2,
         "the neighbour must be suppressed: {lights:?}"
     );
-    // Brightest first, at the pixel centre.
-    assert!((lights[0].pos[0] - 20.5 / 128.0).abs() < 1e-6);
+    // Brightest first — and since K-355 the light sits at the flux centre of
+    // everything folded into it, not on its brightest pixel. Both pixels are
+    // one lit region here, so the centre is between them weighted by
+    // brightness: (20·4 + 28·3) / 7 = 164/7.
+    let cx = 164.0 / 7.0;
+    assert!(
+        (lights[0].pos[0] - (cx + 0.5) / 128.0).abs() < 1e-6,
+        "x {}",
+        lights[0].pos[0] * 128.0 - 0.5
+    );
     assert!((lights[0].pos[1] - 24.5 / 96.0).abs() < 1e-6);
-    assert_eq!(lights[0].rgb, [4.0, 4.0, 4.0]);
+    // …and its colour is the MEAN of the lit pixels, not the brightest one's:
+    // (4 + 3) / 2. One sparkle can no longer define a source's colour.
+    assert_eq!(lights[0].rgb, [3.5, 3.5, 3.5]);
     // The warm source keeps its colour.
     assert!((lights[1].pos[0] - 100.5 / 128.0).abs() < 1e-6);
     assert_eq!(lights[1].rgb, [1.5, 1.0, 0.5]);
@@ -5900,12 +5912,10 @@ fn lens_flare_detects_matte_sources_deterministically() {
 /// to reach first, so a flare fired from a large soft source came out of its
 /// edge rather than its middle.
 ///
-/// **What this does not fix, stated so nobody assumes it does:** the weight is
-/// flux, and each tile is still represented by its single brightest pixel, so
-/// one very hot pixel still pulls the centroid toward itself. Suppressing that
-/// needs each tile to carry its whole flux and its own centroid rather than one
-/// pixel's — the rework in NEXT-FEATURES entry 1 Phase D, where real source
-/// regions replace tile-max detection altogether.
+/// Since K-355 every tile carries its own flux moments rather than one pixel's,
+/// so the answer is the source's TRUE centre — and no single pixel, however
+/// hot, can move it. That is what stops a flare jumping about inside a
+/// practical as sensor noise shuffles which pixel happens to be brightest.
 #[test]
 fn lens_flare_centres_an_area_source_on_its_light() {
     use crate::fx::lens_flare::*;
@@ -5925,22 +5935,45 @@ fn lens_flare_centres_an_area_source_on_its_light() {
     let lights = detect_lights(&matte, w, h, 1.0, 0.0, true, [1.0; 3]);
     assert_eq!(lights.len(), 1, "one source: {lights:?}");
 
-    // The four tiles each contribute their own top-left covered pixel —
-    // (32,32), (64,32), (32,64), (64,64) — at equal flux, so the centroid is
-    // (48, 48) and the reported position is its pixel centre.
+    // Every lit pixel is weighed, so the answer is the square's exact centre
+    // — (32 + 95) / 2 — rather than a corner of it, which is where this used
+    // to land.
+    let centre = 63.5f32;
     let px = lights[0].pos[0] * w as f32 - 0.5;
     let py = lights[0].pos[1] * h as f32 - 0.5;
-    assert!((px - 48.0).abs() < 1e-3, "x {px}");
-    assert!((py - 48.0).abs() < 1e-3, "y {py}");
+    assert!((px - centre).abs() < 1e-3, "x {px}, want {centre}");
+    assert!((py - centre).abs() < 1e-3, "y {py}, want {centre}");
 
-    // The point of it: closer to the middle of the light than the brightest
-    // pixel of the brightest tile, which is where this used to land.
-    let centre = 63.5f32;
-    let was = 32.0f32;
+    // **The jumping test.** One pixel of the source goes very hot, as sensor
+    // sparkle does frame to frame. That pixel now owns the tile's `luma_max`,
+    // so before K-355 it would have become the light's position outright — a
+    // 30-pixel jump for a source that has not moved. Weighing every pixel
+    // leaves the centre where it was, to well under a pixel.
+    let mut sparkle = matte.clone();
+    let i = ((34 * w + 34) * 4) as usize;
+    for c in 0..3 {
+        sparkle[i + c] = 40.0;
+    }
+    let jumped = detect_lights(&sparkle, w, h, 1.0, 0.0, true, [1.0; 3]);
+    assert_eq!(jumped.len(), 1);
+    let jx = jumped[0].pos[0] * w as f32 - 0.5;
+    let jy = jumped[0].pos[1] * h as f32 - 0.5;
     assert!(
-        (px - centre).abs() < (was - centre).abs(),
-        "the anchor must move toward the centre of the source, not stay at \
-         its corner: {px} vs {was}, centre {centre}"
+        (jx - px).abs() < 1.0 && (jy - py).abs() < 1.0,
+        "one hot pixel moved the light from ({px}, {py}) to ({jx}, {jy})"
+    );
+
+    // And the source knows how big it is, which is what lets it be sampled
+    // across rather than flared as a point (K-355).
+    assert!(
+        lights[0].extent[0] > 0.1,
+        "a source 64 px wide in a 128 px frame must measure a real extent: \
+         {:?}",
+        lights[0].extent
+    );
+    assert!(
+        area_samples(&lights[0], AREA_SAMPLES_MAX).len() > 1,
+        "and must therefore be sampled across, not as one point"
     );
 
     // A one-pixel source has only itself to average, so point lights are

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -5890,6 +5890,73 @@ fn lens_flare_detects_matte_sources_deterministically() {
     assert!((threshold_gate(1.0, 1.0, 0.5) - 0.5).abs() < 1e-6);
 }
 
+/// **A source spanning several tiles is found at the centre of its light, not
+/// at one arbitrary pixel of it** (K-354).
+///
+/// The anchor used to be pinned to the brightest pixel of the brightest tile.
+/// For a point source that is exactly right, and this test pins that it still
+/// is. For a *practical* — a softbox, a window, a lamp with a visible bulb —
+/// it put the light at whichever corner of the source the tile scan happened
+/// to reach first, so a flare fired from a large soft source came out of its
+/// edge rather than its middle.
+///
+/// **What this does not fix, stated so nobody assumes it does:** the weight is
+/// flux, and each tile is still represented by its single brightest pixel, so
+/// one very hot pixel still pulls the centroid toward itself. Suppressing that
+/// needs each tile to carry its whole flux and its own centroid rather than one
+/// pixel's — the rework in NEXT-FEATURES entry 1 Phase D, where real source
+/// regions replace tile-max detection altogether.
+#[test]
+fn lens_flare_centres_an_area_source_on_its_light() {
+    use crate::fx::lens_flare::*;
+    let (w, h) = (128u32, 128u32);
+    let mut matte = vec![0.0f32; (w * h * 4) as usize];
+    // A uniform square filling four whole 32-px tiles: x and y both 32..=95,
+    // so its true centre is (63.5, 63.5).
+    for y in 32..96u32 {
+        for x in 32..96u32 {
+            let i = ((y * w + x) * 4) as usize;
+            matte[i] = 2.0;
+            matte[i + 1] = 2.0;
+            matte[i + 2] = 2.0;
+            matte[i + 3] = 1.0;
+        }
+    }
+    let lights = detect_lights(&matte, w, h, 1.0, 0.0, true, [1.0; 3]);
+    assert_eq!(lights.len(), 1, "one source: {lights:?}");
+
+    // The four tiles each contribute their own top-left covered pixel —
+    // (32,32), (64,32), (32,64), (64,64) — at equal flux, so the centroid is
+    // (48, 48) and the reported position is its pixel centre.
+    let px = lights[0].pos[0] * w as f32 - 0.5;
+    let py = lights[0].pos[1] * h as f32 - 0.5;
+    assert!((px - 48.0).abs() < 1e-3, "x {px}");
+    assert!((py - 48.0).abs() < 1e-3, "y {py}");
+
+    // The point of it: closer to the middle of the light than the brightest
+    // pixel of the brightest tile, which is where this used to land.
+    let centre = 63.5f32;
+    let was = 32.0f32;
+    assert!(
+        (px - centre).abs() < (was - centre).abs(),
+        "the anchor must move toward the centre of the source, not stay at \
+         its corner: {px} vs {was}, centre {centre}"
+    );
+
+    // A one-pixel source has only itself to average, so point lights are
+    // exactly where they always were.
+    let mut dot = vec![0.0f32; (w * h * 4) as usize];
+    let i = ((70 * w + 20) * 4) as usize;
+    dot[i] = 4.0;
+    dot[i + 1] = 4.0;
+    dot[i + 2] = 4.0;
+    dot[i + 3] = 1.0;
+    let point = detect_lights(&dot, w, h, 1.0, 0.0, true, [1.0; 3]);
+    assert_eq!(point.len(), 1);
+    assert!((point[0].pos[0] - 20.5 / w as f32).abs() < 1e-6);
+    assert!((point[0].pos[1] - 70.5 / h as f32).abs() < 1e-6);
+}
+
 #[test]
 fn zz_debug_cells() {
     use crate::fx::lens_flare::*;

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -4811,16 +4811,58 @@ fn lens_flare_optics_match_the_textbook() {
     let expect = ((1.0f32 - 1.5) / (1.0 + 1.5)).powi(2);
     assert!((r - expect).abs() < 1e-4, "{r} vs {expect}");
 
-    // The MgF₂ quarter-wave coating at its design wavelength reflects LESS
-    // than bare glass, and each extra layer quarters the residual again.
-    let plain = fresnel_cos(1.0, 1.0, 1.9);
-    let one = surface_reflectance(1.0, 1.0, 1.9, 1.0, 550.0, 1.0);
-    let two = surface_reflectance(1.0, 1.0, 1.9, 2.0, 550.0, 1.0);
+    // Coatings, on ordinary crown glass (K-356). Note the glass: MgF₂ is
+    // very nearly the IDEAL single layer for n ≈ 1.9, because 1.38² = 1.904,
+    // so a stack comparison there measures a coincidence rather than a
+    // coating. n = 1.5 is the honest case and the common one.
+    let plain = fresnel_cos(1.0, 1.0, 1.5);
+    let one = surface_reflectance(1.0, 1.0, 1.5, 1.0, 550.0, 1.0);
+    let three = surface_reflectance(1.0, 1.0, 1.5, 3.0, 550.0, 1.0);
     assert!(one < plain, "coated {one} should be below bare {plain}");
-    assert!(two < one, "multicoat {two} should be below single {one}");
+    assert!(
+        three < one,
+        "the broadband stack {three} should beat the single layer {one}"
+    );
+
+    // **Reflectance varies across the band, and that is the point.** A real
+    // multicoat has minima rather than a flat floor, which is what gives
+    // ghosts their colour: the stack reflects some wavelengths several times
+    // more than others. The old single-number model could not do this.
+    let across: Vec<f32> = [430.0f32, 500.0, 550.0, 620.0, 680.0]
+        .iter()
+        .map(|&nm| surface_reflectance(1.0, 1.0, 1.5, 3.0, nm, 1.0))
+        .collect();
+    let lo = across.iter().copied().fold(f32::MAX, f32::min);
+    let hi = across.iter().copied().fold(0.0f32, f32::max);
+    assert!(
+        hi > lo * 3.0,
+        "a broadband stack must be wavelength-selective: {across:?}"
+    );
+
+    // **And it shifts with the angle of incidence**, because the phase
+    // thickness carries a cos θ — which is the observed effect that a ghost
+    // changes hue as its source moves off axis. Steeply off-axis, the band
+    // has moved enough that the design wavelength is no longer the minimum.
+    let straight = surface_reflectance(1.0, 1.0, 1.5, 3.0, 550.0, 1.0);
+    let oblique = surface_reflectance(0.6, 1.0, 1.5, 3.0, 550.0, 1.0);
+    assert!(
+        oblique > straight * 1.5,
+        "the coating must vary with angle: {oblique} at 53° vs {straight} \
+         at normal"
+    );
+
     // The Coating dial at 0 is bare glass regardless of the file layers.
-    let off = surface_reflectance(1.0, 1.0, 1.9, 2.0, 550.0, 0.0);
+    let off = surface_reflectance(1.0, 1.0, 1.5, 3.0, 550.0, 0.0);
     assert!((off - plain).abs() < 1e-6);
+
+    // A bare stack (0 layers) is exactly the uncoated interface, and the
+    // transfer matrix agrees with plain Fresnel there — the degenerate case
+    // that proves the chain closes correctly.
+    let empty = stack_reflectance(1.0, 1.0, 1.5, &coating_stack(0.0), 550.0);
+    assert!(
+        (empty - plain).abs() < 1e-5,
+        "an empty stack {empty} must equal bare Fresnel {plain}"
+    );
 }
 
 // §8.4 — the prescription library and pair ranking (K-261, curated to

--- a/crates/lumit-gpu/src/fx/lens_flare.rs
+++ b/crates/lumit-gpu/src/fx/lens_flare.rs
@@ -43,7 +43,15 @@ pub type FlareBake = Arc<dyn Fn() -> FlareBakeData + Send + Sync>;
 pub struct LensFlareOp {
     /// Manual light position as a fraction of the raster (x right, y down)
     /// — the caller divides its raster-pixel parameter by the raster (K-260).
+    /// Still the position the frame-grid probe reasons about, and the centre
+    /// of [`Self::manual_lights`].
     pub light_frac: [f32; 2],
+    /// Manual mode's light list: the position above if the source is a point,
+    /// or the samples across its emitting area if the Source size dial has
+    /// given it one (K-355). Each entry is `[x, y, r, g, b]` with the share of
+    /// the flux already folded into the colour, so the list sums to one light.
+    /// Empty falls back to a single white light at [`Self::light_frac`].
+    pub manual_lights: Vec<[f32; 5]>,
     /// Master gain; 0 short-circuits to the identity.
     pub intensity: f32,
     /// Traced wavelengths with their RGB weights, already multiplied by the
@@ -378,7 +386,10 @@ pub const BLEND_COUNT: u32 = 13;
 
 /// Most flare sources a frame renders — must equal
 /// `lumit_core::fx::lens_flare::MAX_LIGHTS` (pinned by test).
-pub const MAX_LIGHTS: u32 = 16;
+pub const MAX_LIGHTS: u32 = 64;
+/// Distinct sources detection may find — `lumit_core`'s `MAX_SOURCES`. Each
+/// may expand into several light slots when it is an area source (K-355).
+pub const MAX_SOURCES: u32 = 16;
 
 /// Detection tile side — must equal `lens_flare::DETECT_TILE` (pinned by
 /// the same test).
@@ -1384,25 +1395,43 @@ impl FxEngine {
         // zero weight and cost no fill); Manual and the prepared Lights mode
         // run one.
         let matte_mode = op.source == 1;
-        let light_count = if matte_mode { MAX_LIGHTS } else { 1 };
-
-        // The frame's light list. Manual fills slot 0 from the CPU; Matte
-        // mode overwrites the buffer with the detection kernels below.
+        // The frame's light list. Manual fills its slots from the CPU — one
+        // for a point source, several for an area one (K-355); Matte mode
+        // overwrites the buffer with the detection kernels below and may fill
+        // any of them, so it always dispatches the lot.
         let mut light_rows = vec![GpuLight { row: [0.0; 8] }; MAX_LIGHTS as usize];
+        // Matte mode leaves every slot zero here on purpose: the detection
+        // kernels below fill them, and if no matte is bound they never run —
+        // which is what makes an unset matte the labelled no-op rather than a
+        // manual light nobody asked for.
+        let mut manual_count = 1;
         if !matte_mode {
-            light_rows[0] = GpuLight {
-                row: [
-                    op.light_frac[0],
-                    op.light_frac[1],
-                    op.light_tint[0],
-                    op.light_tint[1],
-                    op.light_tint[2],
-                    0.0,
-                    0.0,
-                    0.0,
-                ],
-            };
+            if op.manual_lights.is_empty() {
+                light_rows[0] = GpuLight {
+                    row: [
+                        op.light_frac[0],
+                        op.light_frac[1],
+                        op.light_tint[0],
+                        op.light_tint[1],
+                        op.light_tint[2],
+                        0.0,
+                        0.0,
+                        0.0,
+                    ],
+                };
+            } else {
+                let n = op.manual_lights.len().min(MAX_LIGHTS as usize);
+                for (slot, light) in op.manual_lights.iter().take(n).enumerate() {
+                    light_rows[slot] = GpuLight {
+                        row: [
+                            light[0], light[1], light[2], light[3], light[4], 0.0, 0.0, 0.0,
+                        ],
+                    };
+                }
+                manual_count = n as u32;
+            }
         }
+        let light_count = if matte_mode { MAX_LIGHTS } else { manual_count };
         let lights_buf = ctx
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -1438,7 +1467,10 @@ impl FxEngine {
                 let tiles_y = mh.div_ceil(DETECT_TILE);
                 let tiles_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
                     label: Some("fx-lens-flare-tiles"),
-                    size: u64::from(tiles_x * tiles_y) * 8,
+                    // Ten words per tile since K-355: the brightest pixel's
+                    // luma and index, then the gated coverage, colour and
+                    // flux moments that describe the whole lit area of it.
+                    size: u64::from(tiles_x * tiles_y) * 40,
                     usage: wgpu::BufferUsages::STORAGE,
                     mapped_at_creation: false,
                 });

--- a/crates/lumit-gpu/src/fx/lens_flare.rs
+++ b/crates/lumit-gpu/src/fx/lens_flare.rs
@@ -224,8 +224,6 @@ pub struct LensFlareFx {
     /// case worth holding memory for, so a second render makes its own and
     /// whichever finishes first keeps the slot.
     scratch: Mutex<Option<Scratch>>,
-    /// The pooled multisample target with its size — see [`Self::take_msaa`].
-    msaa: Mutex<Option<(wgpu::Texture, u32, u32)>>,
     /// The off-thread bake (K-350), when this engine is allowed one. `None`
     /// until the first deferred miss, and never built at all on an engine
     /// whose bakes must be exact — the exporter's (see
@@ -481,6 +479,16 @@ fn frame_optics(native_fstop: f32, focal_mm: f32, fstop: f32, focus_m: f32) -> F
     }
 }
 
+/// What the draw's vertex stage needs beyond the cells themselves: the
+/// raster it is drawing into, so a cell can be widened by a known number of
+/// PIXELS rather than a guess in clip space (K-353).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct DrawDims {
+    raster: [f32; 2],
+    _pad: [f32; 2],
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct DetectParams {
@@ -702,7 +710,10 @@ impl LensFlareFx {
         });
         let draw_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("fx-lens-flare-draw-layout"),
-            entries: &[storage_entry(0, true, wgpu::ShaderStages::VERTEX)],
+            entries: &[
+                storage_entry(0, true, wgpu::ShaderStages::VERTEX),
+                uniform_entry(1, wgpu::ShaderStages::VERTEX),
+            ],
         });
         let blur_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("fx-lens-flare-blur-layout"),
@@ -820,15 +831,13 @@ impl LensFlareFx {
                 ..Default::default()
             },
             depth_stencil: None,
-            // 4x multisampled (K-264): the ghost geometry is triangles, and
-            // their silhouettes were one of the three Ultra artefacts —
-            // coverage sampling smooths them at a cost that is a rounding
-            // error next to the trace. The CPU reference models the same
-            // four standard sample positions, so the oracle stays tight.
-            multisample: wgpu::MultisampleState {
-                count: 4,
-                ..Default::default()
-            },
+            // Single-sampled, and antialiased anyway (K-353, superseding
+            // K-264's hardware multisampling): the fragment tests the four
+            // standard sample positions itself from the barycentric
+            // gradients. Hardware 4x MSAA gave the same silhouette smoothing
+            // but blended fp16 into a multisample target, which this GPU does
+            // not do reproducibly — see the note in `fx_lens_flare_draw.wgsl`.
+            multisample: wgpu::MultisampleState::default(),
             fragment: Some(wgpu::FragmentState {
                 module: &draw_mod,
                 entry_point: Some("fs_flare"),
@@ -854,7 +863,6 @@ impl LensFlareFx {
             multiview: None,
             cache: None,
         });
-
         let combine_pl = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("fx-lens-flare-combine-pl"),
             bind_group_layouts: &[&combine_layout],
@@ -889,7 +897,6 @@ impl LensFlareFx {
             combine_layout,
             cache: Mutex::new(BakeCache::new(Self::CACHE_CAP)),
             scratch: Mutex::new(None),
-            msaa: Mutex::new(None),
             baker: OnceLock::new(),
             deferred: std::sync::atomic::AtomicBool::new(false),
             last_drawn: Mutex::new(None),
@@ -1098,46 +1105,6 @@ impl LensFlareFx {
                 area_bytes,
                 vert_bytes,
             },
-        }
-    }
-
-    /// The pooled 4x multisample render target (K-265): the largest
-    /// allocation the effect makes (~66 MB at a 1080p flare buffer), and
-    /// creating it per frame was the K-263 lesson all over again — a
-    /// rolling backlog of dropped allocations the driver reclaims late,
-    /// which the owner felt as renders slowing over minutes and then the
-    /// application dying. Keyed by size; a size change (zoom tier, comp
-    /// resize) rebuilds it once.
-    fn take_msaa(&self, ctx: &GpuContext, fw: u32, fh: u32) -> wgpu::Texture {
-        if let Ok(mut slot) = self.msaa.lock() {
-            if let Some((tex, w, h)) = slot.take() {
-                if w == fw && h == fh {
-                    return tex;
-                }
-            }
-        }
-        ctx.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("fx-lens-flare-msaa"),
-            size: wgpu::Extent3d {
-                width: fw.max(1),
-                height: fh.max(1),
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 4,
-            dimension: wgpu::TextureDimension::D2,
-            format: WORKING_FORMAT,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        })
-    }
-
-    /// Hand the multisample target back for the next frame.
-    fn put_msaa(&self, tex: wgpu::Texture, fw: u32, fh: u32) {
-        if let Ok(mut slot) = self.msaa.lock() {
-            if slot.is_none() {
-                *slot = Some((tex, fw, fh));
-            }
         }
     }
 
@@ -1457,7 +1424,8 @@ impl FxEngine {
         // is centred; the screen transform stays derived from the base.
         let (fpw, fph) = flare_pad_dims_of(fw, fh, op.anamorphic, op.scale);
         let flare_tex = work_texture(ctx, fpw, fph, "fx-lens-flare-buffer");
-        let msaa_tex = live.then(|| lf.take_msaa(ctx, fpw, fph));
+        // No multisample target since K-353 — the raster antialiases itself.
+        let _ = live;
 
         let mut encoder = ctx.encoder("fx-lens-flare-enc");
 
@@ -1545,18 +1513,11 @@ impl FxEngine {
         // flare buffer directly.
         {
             let view = flare_tex.create_view(&Default::default());
-            let msaa_view = msaa_tex
-                .as_ref()
-                .map(|t| t.create_view(&Default::default()));
-            let (target, resolve) = match &msaa_view {
-                Some(m) => (m, Some(&view)),
-                None => (&view, None),
-            };
             let _ = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("fx-lens-flare-clear"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: target,
-                    resolve_target: resolve,
+                    view: &view,
+                    resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                         store: wgpu::StoreOp::Store,
@@ -1646,29 +1607,38 @@ impl FxEngine {
                         (r.max(b.ray_bytes), a.max(b.area_bytes), v.max(b.vert_bytes))
                     });
                 let scratch = lf.take_scratch(ctx, need_rays, need_areas, need_verts);
+                // The raster's own size, so the vertex stage can widen each
+                // cell by a pixel and let the fragment's coverage test see
+                // every pixel the cell touches (K-353).
+                let draw_dims = ctx
+                    .device
+                    .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: Some("fx-lens-flare-draw-dims"),
+                        contents: bytemuck::bytes_of(&DrawDims {
+                            raster: [fpw as f32, fph as f32],
+                            _pad: [0.0; 2],
+                        }),
+                        usage: wgpu::BufferUsages::UNIFORM,
+                    });
                 let draw_bind = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                     label: Some("fx-lens-flare-draw-bind"),
                     layout: &lf.draw_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: scratch.verts.as_entire_binding(),
-                    }],
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: scratch.verts.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: draw_dims.as_entire_binding(),
+                        },
+                    ],
                 });
 
+                // Straight into the flare buffer: since K-353 there is no
+                // multisample target to resolve from, and the raster
+                // antialiases itself in the fragment.
                 let flare_view = flare_tex.create_view(&Default::default());
-                // Draw into the multisample target, resolving into the flare
-                // buffer (K-264). Every batch pass loads the multisample
-                // contents and re-resolves, so the last pass leaves the
-                // complete frame in `flare_tex`. The `None` arm cannot run —
-                // a baked frame is a live frame — but the no-panic rule
-                // (docs/14) prefers a plain raster to an unwrap.
-                let msaa_view = msaa_tex
-                    .as_ref()
-                    .map(|t| t.create_view(&Default::default()));
-                let (draw_view, draw_resolve) = match &msaa_view {
-                    Some(m) => (m, Some(&flare_view)),
-                    None => (&flare_view, None),
-                };
                 // Where the frame breaks its work into separate submissions.
                 let flushes = plan_flushes(&plan, baked.surface_count);
                 for (bi, job) in plan.iter().enumerate() {
@@ -1783,8 +1753,8 @@ impl FxEngine {
                         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                             label: Some("fx-lens-flare-draw-pass"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                view: draw_view,
-                                resolve_target: draw_resolve,
+                                view: &flare_view,
+                                resolve_target: None,
                                 ops: wgpu::Operations {
                                     load: wgpu::LoadOp::Load,
                                     store: wgpu::StoreOp::Store,
@@ -1967,9 +1937,6 @@ impl FxEngine {
             cpass.dispatch_workgroups(w.div_ceil(8), h.div_ceil(8), 1);
         }
         drop(encoder);
-        if let Some(tex) = msaa_tex {
-            lf.put_msaa(tex, fpw, fph);
-        }
         out
     }
 

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -4003,6 +4003,133 @@ fn wgsl_lens_flare_trace_matches_the_cpu_reference() {
     }
 }
 
+/// **The flare is bit-stable across repeated renders, in every shape of
+/// frame** (K-353, docs/14 determinism, impl/lens-flare.md §2.4).
+///
+/// The shipped bit-stability check renders twice with one set of parameters.
+/// That was not enough to catch what was actually wrong: the flare's raster
+/// drew into a 4x multisample target, and additively blending fp16 into one
+/// is not reproducible run to run on this hardware — the same frame came
+/// back a few hundred fp16 ULPs different each time, in different places.
+/// Four runs across configurations that switch each stage off in turn is
+/// what localised it, and it is what would catch a return of it: the frame
+/// varied whatever the ghost blur and the starburst were doing, and varied
+/// down to a single ghost at minimum detail.
+///
+/// `added` is asserted alongside, because a configuration that renders
+/// nothing is trivially stable and would prove nothing — that is exactly how
+/// the first attempt at this measurement fooled itself.
+#[test]
+fn the_flare_renders_the_same_frame_every_time() {
+    let Ok(ctx) = GpuContext::headless() else {
+        crate::no_adapter();
+        return;
+    };
+    let fx = FxEngine::new(&ctx);
+    use lumit_core::fx::lens_flare as lf;
+    let (w, h) = (128u32, 72u32);
+    let img = corpus(w, h);
+    let base = flare_params();
+    let tex = upload_linear_f32(&ctx, &img, w, h);
+
+    // Bisect by stage. Each configuration switches one stage off; the one
+    // whose absence makes the frame stable is the one introducing variance.
+    // `added` proves the flare actually drew — a configuration that renders
+    // nothing is trivially "stable" and says nothing.
+    for (name, p) in [
+        ("all stages", base),
+        (
+            "no ghost blur",
+            lf::LensFlareParams {
+                ghost_softness: 0.0,
+                ..base
+            },
+        ),
+        (
+            "no starburst",
+            lf::LensFlareParams {
+                starburst_intensity: 0.0,
+                ..base
+            },
+        ),
+        (
+            "one ghost only",
+            lf::LensFlareParams {
+                max_ghosts: 1,
+                ..base
+            },
+        ),
+        (
+            "one ghost, no blur, no starburst",
+            lf::LensFlareParams {
+                max_ghosts: 1,
+                ghost_softness: 0.0,
+                starburst_intensity: 0.0,
+                ..base
+            },
+        ),
+        (
+            "minimal: 1 ghost, no dispersion, min detail",
+            lf::LensFlareParams {
+                max_ghosts: 1,
+                ghost_softness: 0.0,
+                starburst_intensity: 0.0,
+                dispersion: 0.0,
+                detail: 0.0,
+                ..base
+            },
+        ),
+    ] {
+        let op = flare_op(&p, w, h);
+        let mut runs: Vec<Vec<f32>> = Vec::new();
+        for _ in 0..4 {
+            let out = fx.lens_flare(
+                &ctx,
+                &tex,
+                w,
+                h,
+                &op,
+                None,
+                &(std::sync::Arc::new(move || flare_bake_data(&p)) as crate::fx::FlareBake),
+                &flare_probe(&p, w, h),
+            );
+            runs.push(readback_linear_f32(&ctx, &out, w, h).unwrap());
+        }
+        let added: f32 = runs[0]
+            .iter()
+            .zip(&img)
+            .map(|(a, b)| (a - b).abs())
+            .sum::<f32>()
+            / (w * h) as f32;
+        assert!(
+            added > 1e-4,
+            "{name}: renders nothing ({added:e}), so stability would be vacuous"
+        );
+        for i in 1..runs.len() {
+            let differing = runs[0].iter().zip(&runs[i]).filter(|(x, y)| x != y).count();
+            assert_eq!(
+                differing,
+                0,
+                "{name}: run {i} differs from run 0 in {differing} floats \
+                 (worst {:e}) — the flare must render the same frame every time",
+                worst_diff(&runs[0], &runs[i])
+            );
+        }
+    }
+
+    // And the trace under it, which is where a variance would be worst: every
+    // stage downstream reads these ray landings.
+    let p = base;
+    let op = flare_op(&p, w, h);
+    let bake = std::sync::Arc::new(move || flare_bake_data(&p)) as crate::fx::FlareBake;
+    let first = fx.lens_flare_trace_debug(&ctx, &op, &bake, 8, w, h);
+    assert!(!first.is_empty(), "the trace oracle hook rendered no rays");
+    for i in 1..3 {
+        let again = fx.lens_flare_trace_debug(&ctx, &op, &bake, 8, w, h);
+        assert_eq!(first, again, "trace run {i} differs from run 0");
+    }
+}
+
 /// Impl note §8.6 + §8.7: the full GPU frame (trace → raster → combine)
 /// stays within the perceptual bound of the CPU scanline reference, the
 /// flare is actually visible (the energy floor that keeps the bound honest),

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -3144,6 +3144,8 @@ fn flare_params() -> lumit_core::fx::lens_flare::LensFlareParams {
     lumit_core::fx::lens_flare::LensFlareParams {
         // Raster pixels of a 192×108 probe framing (K-260).
         light: [63.4, 32.4],
+        // A point source, as the effect has always defaulted to.
+        source_size: [0.0, 0.0],
         intensity: 1.0,
         lens: 16,
         fstop: 2.8,
@@ -3187,6 +3189,12 @@ fn flare_op(p: &lumit_core::fx::lens_flare::LensFlareParams, w: u32, h: u32) -> 
         .collect();
     LensFlareOp {
         light_frac: [p.light[0] / w.max(1) as f32, p.light[1] / h as f32],
+        // The same expansion `fxops` makes for the production path, so the
+        // oracle drives the GPU exactly as the renderer does (K-355).
+        manual_lights: lf::expand_area_lights(&lf::manual_light(p, w, h), lf::AREA_SAMPLES_MAX)
+            .iter()
+            .map(|l| [l.pos[0], l.pos[1], l.rgb[0], l.rgb[1], l.rgb[2]])
+            .collect(),
         intensity: p.intensity,
         lambdas,
         max_ghosts: p.max_ghosts,
@@ -4001,6 +4009,71 @@ fn wgsl_lens_flare_trace_matches_the_cpu_reference() {
             assert!(live > 100, "too few live rays ({live}) to mean anything");
         }
     }
+}
+
+/// **An area light flares like an area, not like a point** (K-355).
+///
+/// Source size gives the light a real emitting area, and the flare of one is
+/// the sum of the point flares across it. So the picture must genuinely change
+/// — a wider source spreads its ghosts — while the total light it adds stays
+/// put, because every sample carries a share of one light's flux rather than a
+/// light of its own. A source that grew brighter as it grew wider would be the
+/// obvious way to get this wrong, and is what the energy bound below catches.
+#[test]
+fn an_area_source_spreads_its_flare_without_gaining_energy() {
+    let Ok(ctx) = GpuContext::headless() else {
+        crate::no_adapter();
+        return;
+    };
+    let fx = FxEngine::new(&ctx);
+    use lumit_core::fx::lens_flare as lf;
+    let (w, h) = (128u32, 72u32);
+    let img = corpus(w, h);
+    let tex = upload_linear_f32(&ctx, &img, w, h);
+
+    let render = |p: lf::LensFlareParams| {
+        let op = flare_op(&p, w, h);
+        let out = fx.lens_flare(
+            &ctx,
+            &tex,
+            w,
+            h,
+            &op,
+            None,
+            &(std::sync::Arc::new(move || flare_bake_data(&p)) as crate::fx::FlareBake),
+            &flare_probe(&p, w, h),
+        );
+        readback_linear_f32(&ctx, &out, w, h).unwrap()
+    };
+
+    let point = flare_params();
+    let area = lf::LensFlareParams {
+        // Half-extents in raster pixels: a wide, short strip, like a tube.
+        source_size: [18.0, 4.0],
+        ..point
+    };
+    assert!(
+        lf::expand_area_lights(&lf::manual_light(&area, w, h), lf::AREA_SAMPLES_MAX).len() > 1,
+        "the test's own source must actually be an area one"
+    );
+
+    let a = render(point);
+    let b = render(area);
+    assert_ne!(a, b, "an area source must not render as a point does");
+
+    // Energy is conserved: the samples share one light's flux.
+    let energy = |v: &[f32]| -> f32 { v.iter().zip(&img).map(|(x, y)| (x - y).abs()).sum::<f32>() };
+    let (ea, eb) = (energy(&a), energy(&b));
+    assert!(ea > 1e-2, "the point flare must be visible: {ea}");
+    let ratio = eb / ea.max(1e-9);
+    assert!(
+        (0.5..=1.5).contains(&ratio),
+        "an area source must spread its light, not multiply it: {ratio} \
+         ({eb} vs {ea})"
+    );
+
+    // And it is still the same picture every time.
+    assert_eq!(b, render(area), "an area source must be bit-stable too");
 }
 
 /// **The flare is bit-stable across repeated renders, in every shape of

--- a/crates/lumit-gpu/src/fx_lens_flare_detect.wgsl
+++ b/crates/lumit-gpu/src/fx_lens_flare_detect.wgsl
@@ -146,6 +146,11 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
     var acc_r: array<f32, 16>;
     var acc_g: array<f32, 16>;
     var acc_b: array<f32, 16>;
+    // The flux-weighted centroid of each anchor's contributing tiles, as
+    // (sum w*x, sum w*y, sum w) — see where it is applied at the bottom.
+    var cen_x: array<f32, 16>;
+    var cen_y: array<f32, 16>;
+    var cen_w: array<f32, 16>;
     var picked_count = 0u;
     // Anchor picks: top-K by luma with Chebyshev suppression.
     for (var k = 0u; k < MAX_LIGHTS; k = k + 1u) {
@@ -183,6 +188,9 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
             acc_r[picked_count] = 0.0;
             acc_g[picked_count] = 0.0;
             acc_b[picked_count] = 0.0;
+            cen_x[picked_count] = 0.0;
+            cen_y[picked_count] = 0.0;
+            cen_w[picked_count] = 0.0;
             picked_count = picked_count + 1u;
         }
     }
@@ -222,6 +230,10 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
             acc_r[nearest] = acc_r[nearest] + src.r * weight;
             acc_g[nearest] = acc_g[nearest] + src.g * weight;
             acc_b[nearest] = acc_b[nearest] + src.b * weight;
+            let flux = tl.luma * weight;
+            cen_x[nearest] = cen_x[nearest] + f32(px) * flux;
+            cen_y[nearest] = cen_y[nearest] + f32(py) * flux;
+            cen_w[nearest] = cen_w[nearest] + flux;
         }
     }
     for (var k = 0u; k < MAX_LIGHTS; k = k + 1u) {
@@ -235,8 +247,19 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
         out._pad1 = 0.0;
         out._pad2 = 0.0;
         if (k < picked_count) {
-            out.pos_x = (f32(anchor_px[k]) + 0.5) / f32(dp.w);
-            out.pos_y = (f32(anchor_py[k]) + 0.5) / f32(dp.h);
+            // Where the light IS, is the centre of its light (K-354) — not
+            // whichever pixel happened to be brightest this frame. On footage
+            // that pixel wanders with sensor noise and specular sparkle, and
+            // the whole flare jitters with it. A one-tile point source has
+            // only its own pixel to average, so point lights are unchanged.
+            var px = f32(anchor_px[k]);
+            var py = f32(anchor_py[k]);
+            if (cen_w[k] > 0.0) {
+                px = cen_x[k] / cen_w[k];
+                py = cen_y[k] / cen_w[k];
+            }
+            out.pos_x = (px + 0.5) / f32(dp.w);
+            out.pos_y = (py + 0.5) / f32(dp.h);
             out.r = acc_r[k] * dp.tint_r;
             out.g = acc_g[k] * dp.tint_g;
             out.b = acc_b[k] * dp.tint_b;

--- a/crates/lumit-gpu/src/fx_lens_flare_detect.wgsl
+++ b/crates/lumit-gpu/src/fx_lens_flare_detect.wgsl
@@ -15,9 +15,28 @@
 //                  tile's flux accumulates onto its nearest anchor
 //                  (K-267 area sources); dead slots zeroed.
 
+// What one tile knows about the light inside it — the WGSL twin of
+// lumit_core's `TileStat` (K-355). Through K-354 this was the brightest pixel
+// alone, which is what made flares JUMP on footage: which pixel is brightest
+// inside a practical changes frame to frame with sensor noise, so the light's
+// position hopped about inside a source that had not moved.
 struct Tile {
+    // Still how anchors are ranked and gated, so a small bright source is
+    // still found.
     luma: f32,
     index: u32,
+    // Sum of gates, and of colour x gate: their ratio is the mean colour of
+    // the light in this tile, which one sparkle cannot define.
+    wsum: f32,
+    csum_r: f32,
+    csum_g: f32,
+    csum_b: f32,
+    // Sum of luma x gate and its first moments: the tile's flux and where in
+    // the tile that flux sits.
+    fsum: f32,
+    fx: f32,
+    fy: f32,
+    _pad: f32,
 };
 
 struct Light {
@@ -55,11 +74,36 @@ struct DetectParams {
 @group(0) @binding(3) var<uniform> dp: DetectParams;
 
 const DETECT_TILE: u32 = 32u;
-const MAX_LIGHTS: u32 = 16u;
+// Light slots the trace carries, and the distinct sources detection may find.
+// A source expands into up to AREA_SAMPLES_MAX² slots when it has real extent
+// (K-355) — mirrors lumit_core's MAX_LIGHTS / MAX_SOURCES / AREA_SAMPLES_MAX.
+const MAX_LIGHTS: u32 = 64u;
+const MAX_SOURCES: u32 = 16u;
+const AREA_SAMPLES_MAX: u32 = 5u;
+const AREA_MIN_EXTENT: f32 = 0.004;
 const SUPPRESS_TILES: i32 = 2;
+
+// The soft gate (== lens_flare::threshold_gate). Declared before its first
+// use, which WGSL requires.
+fn gate(luma: f32) -> f32 {
+    if (dp.softness <= 0.0) {
+        return f32(luma >= dp.threshold);
+    }
+    let t = clamp(
+        (luma - (dp.threshold - dp.softness)) / (2.0 * dp.softness),
+        0.0,
+        1.0,
+    );
+    return t * t * (3.0 - 2.0 * t);
+}
 
 var<workgroup> partial_luma: array<f32, 64>;
 var<workgroup> partial_index: array<u32, 64>;
+var<workgroup> partial_w: array<f32, 64>;
+var<workgroup> partial_c: array<vec3<f32>, 64>;
+var<workgroup> partial_f: array<f32, 64>;
+var<workgroup> partial_fx: array<f32, 64>;
+var<workgroup> partial_fy: array<f32, 64>;
 
 @compute @workgroup_size(8, 8)
 fn detect_tiles(
@@ -71,6 +115,11 @@ fn detect_tiles(
     let tile_y0 = wg.y * DETECT_TILE;
     var best_luma = -1.0;
     var best_index = 0u;
+    var wsum = 0.0;
+    var csum = vec3<f32>(0.0);
+    var fsum = 0.0;
+    var fx = 0.0;
+    var fy = 0.0;
     // Each thread strides the tile 8 apart in both axes: 4×4 pixels each.
     // Row-major visit order per thread keeps its own tie-break at the
     // lowest linear index; the merge below keeps the global one.
@@ -91,14 +140,36 @@ fn detect_tiles(
                 best_luma = luma;
                 best_index = index;
             }
+            // Every lit pixel contributes, not just the brightest (K-355).
+            let g = gate(luma);
+            if (g > 0.0) {
+                let f = luma * g;
+                wsum = wsum + g;
+                csum = csum + max(c.rgb, vec3<f32>(0.0)) * g;
+                fsum = fsum + f;
+                fx = fx + f32(x) * f;
+                fy = fy + f32(y) * f;
+            }
         }
     }
     partial_luma[li] = best_luma;
     partial_index[li] = best_index;
+    partial_w[li] = wsum;
+    partial_c[li] = csum;
+    partial_f[li] = fsum;
+    partial_fx[li] = fx;
+    partial_fy[li] = fy;
     workgroupBarrier();
     if (li == 0u) {
         var luma = -1.0;
         var index = 0u;
+        var w_all = 0.0;
+        var c_all = vec3<f32>(0.0);
+        var f_all = 0.0;
+        var fx_all = 0.0;
+        var fy_all = 0.0;
+        // Thread order, so the sums are the same numbers in the same order
+        // every run — the determinism docs/14 requires.
         for (var i = 0u; i < 64u; i = i + 1u) {
             let pl = partial_luma[i];
             let pi = partial_index[i];
@@ -106,25 +177,25 @@ fn detect_tiles(
                 luma = pl;
                 index = pi;
             }
+            w_all = w_all + partial_w[i];
+            c_all = c_all + partial_c[i];
+            f_all = f_all + partial_f[i];
+            fx_all = fx_all + partial_fx[i];
+            fy_all = fy_all + partial_fy[i];
         }
         var t: Tile;
         t.luma = luma;
         t.index = index;
+        t.wsum = w_all;
+        t.csum_r = c_all.r;
+        t.csum_g = c_all.g;
+        t.csum_b = c_all.b;
+        t.fsum = f_all;
+        t.fx = fx_all;
+        t.fy = fy_all;
+        t._pad = 0.0;
         tiles[wg.y * dp.tiles_x + wg.x] = t;
     }
-}
-
-// The soft gate (== lens_flare::threshold_gate).
-fn gate(luma: f32) -> f32 {
-    if (dp.softness <= 0.0) {
-        return f32(luma >= dp.threshold);
-    }
-    let t = clamp(
-        (luma - (dp.threshold - dp.softness)) / (2.0 * dp.softness),
-        0.0,
-        1.0,
-    );
-    return t * t * (3.0 - 2.0 * t);
 }
 
 @compute @workgroup_size(1)
@@ -146,14 +217,16 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
     var acc_r: array<f32, 16>;
     var acc_g: array<f32, 16>;
     var acc_b: array<f32, 16>;
-    // The flux-weighted centroid of each anchor's contributing tiles, as
-    // (sum w*x, sum w*y, sum w) — see where it is applied at the bottom.
+    // The flux centroid of each source, as (sum f*x, sum f*y, sum f), and the
+    // second moments that give it its EXTENT — see the bottom of this pass.
     var cen_x: array<f32, 16>;
     var cen_y: array<f32, 16>;
     var cen_w: array<f32, 16>;
+    var m2_x: array<f32, 16>;
+    var m2_y: array<f32, 16>;
     var picked_count = 0u;
     // Anchor picks: top-K by luma with Chebyshev suppression.
-    for (var k = 0u; k < MAX_LIGHTS; k = k + 1u) {
+    for (var k = 0u; k < MAX_SOURCES; k = k + 1u) {
         var best_tile = 0u;
         var best_luma = -1.0;
         for (var t = 0u; t < tile_count; t = t + 1u) {
@@ -191,6 +264,8 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
             cen_x[picked_count] = 0.0;
             cen_y[picked_count] = 0.0;
             cen_w[picked_count] = 0.0;
+            m2_x[picked_count] = 0.0;
+            m2_y[picked_count] = 0.0;
             picked_count = picked_count + 1u;
         }
     }
@@ -220,50 +295,120 @@ fn detect_pick(@builtin(global_invocation_id) gid: vec3<u32>) {
                     nearest = p;
                 }
             }
-            let px = tl.index % dp.w;
-            let py = tl.index / dp.w;
-            let c = textureLoad(matte_tex, vec2<i32>(i32(px), i32(py)), 0);
+            // The tile's MEAN colour over its lit pixels, not its brightest
+            // pixel's (K-355): one sparkle among a thousand lit pixels now
+            // shifts the colour by a thousandth instead of defining it.
             var src = vec3<f32>(1.0, 1.0, 1.0);
             if (dp.use_source_colour == 1u) {
-                src = max(c.rgb, vec3<f32>(0.0));
+                if (tl.wsum > 0.0) {
+                    src = vec3<f32>(tl.csum_r, tl.csum_g, tl.csum_b) / tl.wsum;
+                } else {
+                    let px = tl.index % dp.w;
+                    let py = tl.index / dp.w;
+                    let c = textureLoad(matte_tex, vec2<i32>(i32(px), i32(py)), 0);
+                    src = max(c.rgb, vec3<f32>(0.0));
+                }
             }
             acc_r[nearest] = acc_r[nearest] + src.r * weight;
             acc_g[nearest] = acc_g[nearest] + src.g * weight;
             acc_b[nearest] = acc_b[nearest] + src.b * weight;
-            let flux = tl.luma * weight;
-            cen_x[nearest] = cen_x[nearest] + f32(px) * flux;
-            cen_y[nearest] = cen_y[nearest] + f32(py) * flux;
-            cen_w[nearest] = cen_w[nearest] + flux;
+            // The tile's own first moments carry straight over, so no pixel
+            // anywhere can move the source's position on its own.
+            cen_x[nearest] = cen_x[nearest] + tl.fx;
+            cen_y[nearest] = cen_y[nearest] + tl.fy;
+            cen_w[nearest] = cen_w[nearest] + tl.fsum;
+            if (tl.fsum > 0.0) {
+                let mx = tl.fx / tl.fsum;
+                let my = tl.fy / tl.fsum;
+                m2_x[nearest] = m2_x[nearest] + tl.fsum * mx * mx;
+                m2_y[nearest] = m2_y[nearest] + tl.fsum * my * my;
+            }
         }
     }
+    // Zero every slot first: the trace dispatches all MAX_LIGHTS of them and
+    // a dead slot must carry no weight.
     for (var k = 0u; k < MAX_LIGHTS; k = k + 1u) {
-        var out: Light;
-        out.pos_x = 0.0;
-        out.pos_y = 0.0;
-        out.r = 0.0;
-        out.g = 0.0;
-        out.b = 0.0;
-        out._pad0 = 0.0;
-        out._pad1 = 0.0;
-        out._pad2 = 0.0;
-        if (k < picked_count) {
-            // Where the light IS, is the centre of its light (K-354) — not
-            // whichever pixel happened to be brightest this frame. On footage
-            // that pixel wanders with sensor noise and specular sparkle, and
-            // the whole flare jitters with it. A one-tile point source has
-            // only its own pixel to average, so point lights are unchanged.
-            var px = f32(anchor_px[k]);
-            var py = f32(anchor_py[k]);
-            if (cen_w[k] > 0.0) {
-                px = cen_x[k] / cen_w[k];
-                py = cen_y[k] / cen_w[k];
-            }
-            out.pos_x = (px + 0.5) / f32(dp.w);
-            out.pos_y = (py + 0.5) / f32(dp.h);
-            out.r = acc_r[k] * dp.tint_r;
-            out.g = acc_g[k] * dp.tint_g;
-            out.b = acc_b[k] * dp.tint_b;
+        var dead: Light;
+        dead.pos_x = 0.0;
+        dead.pos_y = 0.0;
+        dead.r = 0.0;
+        dead.g = 0.0;
+        dead.b = 0.0;
+        dead._pad0 = 0.0;
+        dead._pad1 = 0.0;
+        dead._pad2 = 0.0;
+        lights[k] = dead;
+    }
+
+    // Each source becomes one light if it is a point, or a GRID of lights
+    // across its emitting area if it is not (K-355). The flare of an area
+    // source is the integral of the point flares over that area, and at this
+    // budget it is evaluated directly rather than approximated: every sample
+    // carries an equal share of the flux, so a source only gets smoother as
+    // it is split, never brighter. This is what gives a bar-shaped practical
+    // bar-shaped ghosts instead of a point's round ones.
+    var slot = 0u;
+    for (var k = 0u; k < picked_count; k = k + 1u) {
+        // Where the light IS, is the centre of its light (K-354, K-355) — not
+        // whichever pixel happened to be brightest this frame. On footage
+        // that pixel wanders with sensor noise and specular sparkle, and the
+        // whole flare jittered with it.
+        var px = f32(anchor_px[k]);
+        var py = f32(anchor_py[k]);
+        var ex = 0.0;
+        var ey = 0.0;
+        if (cen_w[k] > 0.0) {
+            px = cen_x[k] / cen_w[k];
+            py = cen_y[k] / cen_w[k];
+            // Half-extent as the standard deviation of the flux about that
+            // centre: zero for a point, the real width for a practical.
+            ex = sqrt(max(m2_x[k] / cen_w[k] - px * px, 0.0)) / f32(dp.w);
+            ey = sqrt(max(m2_y[k] / cen_w[k] - py * py, 0.0)) / f32(dp.h);
         }
-        lights[k] = out;
+        let cx = (px + 0.5) / f32(dp.w);
+        let cy = (py + 0.5) / f32(dp.h);
+
+        var nx = 1u;
+        var ny = 1u;
+        if (ex >= AREA_MIN_EXTENT) {
+            nx = clamp(u32(round(ex / AREA_MIN_EXTENT)), 1u, AREA_SAMPLES_MAX);
+        }
+        if (ey >= AREA_MIN_EXTENT) {
+            ny = clamp(u32(round(ey / AREA_MIN_EXTENT)), 1u, AREA_SAMPLES_MAX);
+        }
+        // No room to split this source faithfully: carry it as a single point
+        // rather than half an area source, which would lose the rest of its
+        // flux.
+        if (slot + nx * ny > MAX_LIGHTS) {
+            nx = 1u;
+            ny = 1u;
+            if (slot >= MAX_LIGHTS) {
+                break;
+            }
+        }
+        let share = 1.0 / f32(nx * ny);
+        for (var iy = 0u; iy < ny; iy = iy + 1u) {
+            for (var ix = 0u; ix < nx; ix = ix + 1u) {
+                var sx = cx;
+                var sy = cy;
+                if (nx > 1u) {
+                    sx = cx + (f32(ix) / f32(nx - 1u) * 2.0 - 1.0) * ex;
+                }
+                if (ny > 1u) {
+                    sy = cy + (f32(iy) / f32(ny - 1u) * 2.0 - 1.0) * ey;
+                }
+                var out: Light;
+                out.pos_x = sx;
+                out.pos_y = sy;
+                out.r = acc_r[k] * dp.tint_r * share;
+                out.g = acc_g[k] * dp.tint_g * share;
+                out.b = acc_b[k] * dp.tint_b * share;
+                out._pad0 = 0.0;
+                out._pad1 = 0.0;
+                out._pad2 = 0.0;
+                lights[slot] = out;
+                slot = slot + 1u;
+            }
+        }
     }
 }

--- a/crates/lumit-gpu/src/fx_lens_flare_draw.wgsl
+++ b/crates/lumit-gpu/src/fx_lens_flare_draw.wgsl
@@ -14,10 +14,42 @@ struct Vertex {
 
 @group(0) @binding(0) var<storage, read> verts: array<Vertex>;
 
+struct DrawDims {
+    raster: vec2<f32>,
+    pad: vec2<f32>,
+};
+@group(0) @binding(1) var<uniform> dims: DrawDims;
+
+// How far each vertex is pushed outward, in pixels (K-353).
+//
+// At one sample the rasteriser only makes a fragment where the pixel CENTRE
+// falls inside the triangle, but a cell that covers no centre can still
+// cover sample positions — and those are real light. Widening every triangle
+// by more than the furthest sample offset from a centre (0.375 in each axis,
+// so 0.53 diagonally) guarantees a fragment exists wherever coverage might
+// be, and the fragment's own test then throws away the pixels the widening
+// added. The CPU twin does the same thing by widening its bounding box.
+const EXPAND_PX: f32 = 1.0;
+
 struct VsOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) rgb: vec3<f32>,
+    // Barycentric coordinates of this vertex within its own triangle — the
+    // input to the analytic coverage test in the fragment (K-353).
+    @location(1) bary: vec3<f32>,
 };
+
+// The 4x multisample positions inside a pixel, as offsets from the pixel
+// CENTRE — the standard Vulkan/D3D locations at count 4, and the same four
+// `lumit_core::fx::lens_flare::MSAA_SAMPLES` holds as offsets from the pixel
+// origin. The two must stay in step: they are the CPU twin and the GPU of
+// one antialiasing model.
+const SAMPLES: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+    vec2<f32>(-0.125, -0.375),
+    vec2<f32>(0.375, -0.125),
+    vec2<f32>(-0.375, 0.125),
+    vec2<f32>(0.125, 0.375),
+);
 
 // Which of the cell's four stored corners each of its six vertices is
 // (K-263). build_verts stores the corners once, in order round the cell; the
@@ -36,17 +68,161 @@ fn corner_of(k: u32) -> u32 {
     return 0u;
 }
 
+fn cross2(u: vec2<f32>, v: vec2<f32>) -> f32 {
+    return u.x * v.y - u.y * v.x;
+}
+
+// One corner of the triangle, pushed out so that BOTH edges meeting there
+// have moved [`EXPAND_PX`] outward along their own normals.
+//
+// Pushing the corner away from the centroid instead — the obvious thing —
+// is wrong for the shape that matters most here. A caustic-folded cell is a
+// SLIVER: its three corners are nearly collinear, so the centroid sits on
+// that line and "away from the centroid" points ALONG the sliver, leaving
+// its thin axis exactly as thin as it was. Those are precisely the cells
+// whose coverage the pixel centres miss, so the energy they carry went
+// missing with them. Displacing the two edge lines and re-intersecting them
+// widens the thin axis by construction, whatever the shape.
+fn widen_corner(prev: vec2<f32>, here: vec2<f32>, next: vec2<f32>, s: f32) -> vec2<f32> {
+    let d_in = here - prev;
+    let d_out = next - here;
+    let len_in = length(d_in);
+    let len_out = length(d_out);
+    // A collapsed edge has no normal to speak of; fall back to pushing the
+    // corner away from the far one, which is the only direction there is.
+    if (len_in < 1e-6 || len_out < 1e-6) {
+        let away = here - (prev + next) * 0.5;
+        let d = length(away);
+        if (d < 1e-6) {
+            return here;
+        }
+        return here + away / d * EXPAND_PX;
+    }
+    let n_in = vec2<f32>(d_in.y, -d_in.x) / len_in * s;
+    let n_out = vec2<f32>(d_out.y, -d_out.x) / len_out * s;
+    let a1 = prev + n_in * EXPAND_PX;
+    let a2 = here + n_out * EXPAND_PX;
+    let denom = cross2(d_in, d_out);
+    // Near-parallel edges put the miter at infinity; offsetting along one
+    // normal is the bounded answer and still covers what it must.
+    if (abs(denom) < 1e-9) {
+        return here + n_out * EXPAND_PX;
+    }
+    let t = cross2(a2 - a1, d_out) / denom;
+    let widened = a1 + d_in * t;
+    // A very sharp corner mitres a long way out. The coverage test would
+    // still throw the extra away, but the fill it costs is unbounded, so cap
+    // the corner's travel at a few pixels.
+    let travel = widened - here;
+    let dist = length(travel);
+    let cap = EXPAND_PX * 4.0;
+    if (dist > cap) {
+        return here + travel / dist * cap;
+    }
+    return widened;
+}
+
+fn ndc_to_px(ndc: vec2<f32>) -> vec2<f32> {
+    return (ndc * 0.5 + vec2<f32>(0.5, 0.5)) * dims.raster;
+}
+
+fn px_to_ndc(px: vec2<f32>) -> vec2<f32> {
+    return (px / dims.raster - vec2<f32>(0.5, 0.5)) * 2.0;
+}
+
 @vertex
 fn vs_flare(@builtin(vertex_index) vi: u32) -> VsOut {
-    let v = verts[(vi / 6u) * 4u + corner_of(vi % 6u)];
+    let k = vi % 6u;
+    let cell = (vi / 6u) * 4u;
+    let v = verts[cell + corner_of(k)];
+
+    // The two triangles of a cell are vertices 0-2 and 3-5 of its six, so
+    // this vertex's siblings are found by rounding down to its triangle's
+    // first — the whole triangle is needed to widen any one of its corners.
+    let tri0 = (k / 3u) * 3u;
+    let a = verts[cell + corner_of(tri0)];
+    let b = verts[cell + corner_of(tri0 + 1u)];
+    let c = verts[cell + corner_of(tri0 + 2u)];
+    let pa = ndc_to_px(vec2<f32>(a.ndc_x, a.ndc_y));
+    let pb = ndc_to_px(vec2<f32>(b.ndc_x, b.ndc_y));
+    let pc = ndc_to_px(vec2<f32>(c.ndc_x, c.ndc_y));
+    let area = cross2(pb - pa, pc - pa);
+    let s = select(-1.0, 1.0, area >= 0.0);
+    let local = k % 3u;
+    var widened = pa;
+    if (local == 1u) {
+        widened = widen_corner(pa, pb, pc, s);
+    } else if (local == 2u) {
+        widened = widen_corner(pb, pc, pa, s);
+    } else {
+        widened = widen_corner(pc, pa, pb, s);
+    }
+
+    // **Both varyings describe the ORIGINAL triangle, not the widened one.**
+    // Barycentric coordinates and the interpolated colour are both affine in
+    // screen position, and an affine function is reproduced exactly by
+    // interpolating its values at any three points — so evaluating the
+    // original cell's functions at the widened corner and letting the
+    // rasteriser interpolate those gives every fragment the original cell's
+    // barycentric and the original cell's colour. Emitting a unit barycentric
+    // at the widened corner instead would describe the widened triangle, and
+    // the coverage test would happily accept the padding it was supposed to
+    // throw away.
+    var bary = vec3<f32>(1.0, 0.0, 0.0);
+    if (abs(area) > 1e-12) {
+        let w0 = cross2(pb - widened, pc - widened) / area;
+        let w1 = cross2(pc - widened, pa - widened) / area;
+        bary = vec3<f32>(w0, w1, 1.0 - w0 - w1);
+    }
+
     var out: VsOut;
-    out.pos = vec4<f32>(v.ndc_x, v.ndc_y, 0.0, 1.0);
-    out.rgb = vec3<f32>(v.r, v.g, v.b);
+    out.pos = vec4<f32>(px_to_ndc(widened), 0.0, 1.0);
+    out.rgb = bary.x * vec3<f32>(a.r, a.g, a.b)
+        + bary.y * vec3<f32>(b.r, b.g, b.b)
+        + bary.z * vec3<f32>(c.r, c.g, c.b);
+    out.bary = bary;
     return out;
 }
 
+// Coverage the analytic way (K-353), not the hardware's.
+//
+// **Why not 4x MSAA, which is what this used to be.** Additively blending
+// fp16 into a multisample target is not reproducible run to run on this
+// hardware: the same frame came back a few fp16 ULPs different each time,
+// which is what made the flare fail its own bit-stability assertion
+// (docs/14 determinism, impl/lens-flare.md §2.4). Measured, not guessed —
+// the trace is bit-identical run to run, and swapping only the multisample
+// raster for a single-sampled one makes the whole frame bit-identical too.
+//
+// The antialiasing is kept rather than lost. Barycentric coordinates are
+// linear across a triangle, so `dpdx`/`dpdy` of them are exact and constant,
+// and the barycentric at any sub-pixel offset follows without the rasteriser
+// being asked: a fragment tests all four standard sample positions itself
+// and takes `colour x covered/4`. That is precisely the model the CPU twin
+// already spells out in `raster_triangle`, so the oracle now agrees with the
+// GPU by construction instead of by resembling the hardware's resolve.
+//
+// It also gives back the largest allocation the effect made — the 4-sample
+// target was ~66 MB at a 1080p flare buffer — and the resolve with it.
 @fragment
 fn fs_flare(in: VsOut) -> @location(0) vec4<f32> {
-    let luma = 0.2126 * in.rgb.x + 0.7152 * in.rgb.y + 0.0722 * in.rgb.z;
-    return vec4<f32>(in.rgb, luma);
+    let dx = dpdx(in.bary);
+    let dy = dpdy(in.bary);
+    var covered = 0u;
+    for (var i = 0u; i < 4u; i = i + 1u) {
+        let o = SAMPLES[i];
+        let b = in.bary + o.x * dx + o.y * dy;
+        if (b.x >= 0.0 && b.y >= 0.0 && b.z >= 0.0) {
+            covered = covered + 1u;
+        }
+    }
+    if (covered == 0u) {
+        discard;
+    }
+    // The colour stays the one interpolated at the pixel CENTRE, unclamped
+    // and extrapolated where the centre falls outside the triangle — the
+    // non-centroid interpolation the CPU twin models.
+    let rgb = in.rgb * (f32(covered) * 0.25);
+    let luma = 0.2126 * rgb.x + 0.7152 * rgb.y + 0.0722 * rgb.z;
+    return vec4<f32>(rgb, luma);
 }

--- a/crates/lumit-gpu/src/fx_lens_flare_trace.wgsl
+++ b/crates/lumit-gpu/src/fx_lens_flare_trace.wgsl
@@ -178,26 +178,123 @@ fn fresnel_cos(cos_i_in: f32, n1: f32, n2: f32) -> f32 {
     return 0.5 * (rs * rs + rp * rp);
 }
 
-// Single-layer thin-film reflectance (lumit_core `coating_reflectance`).
-fn coating_refl(cos_i_in: f32, n1: f32, n2: f32, coating_n: f32, d_nm: f32, lambda_nm: f32) -> f32 {
-    let cos_i = abs(cos_i_in);
-    let sin2_c = (n1 / coating_n) * (n1 / coating_n) * (1.0 - cos_i * cos_i);
-    if (sin2_c >= 1.0) {
+// The coating library, mirroring lumit_core `coating_stack` (K-356). A lens
+// file publishes a layer COUNT, never the recipe — real designs are
+// manufacturer secrets — so each order takes its textbook design: a MgF2
+// quarter, a V-coat, then the classic broadband quarter/half/quarter W that
+// gives a multicoated lens its two reflectance minima and the green-magenta
+// cast between them.
+const COATING_DESIGN_NM: f32 = 550.0;
+const MGF2_N: f32 = 1.38;
+const AL2O3_N: f32 = 1.63;
+const ZRO2_N: f32 = 2.10;
+const MAX_COATING_LAYERS: u32 = 6u;
+
+// Layer `i` of the stack for `layers`, as (index, quarter waves); a zero
+// index means the slot is empty.
+fn coating_layer(layers: f32, i: u32) -> vec2<f32> {
+    let n = min(u32(max(round(layers), 0.0)), MAX_COATING_LAYERS);
+    if (i >= n) {
+        return vec2<f32>(0.0, 0.0);
+    }
+    if (n == 1u) {
+        return vec2<f32>(MGF2_N, 1.0);
+    }
+    if (n == 2u) {
+        if (i == 0u) { return vec2<f32>(MGF2_N, 1.0); }
+        return vec2<f32>(ZRO2_N, 1.0);
+    }
+    if (i == 0u) { return vec2<f32>(MGF2_N, 1.0); }
+    if (i == 1u) { return vec2<f32>(ZRO2_N, 2.0); }
+    if (i == 2u) { return vec2<f32>(AL2O3_N, 1.0); }
+    if (i % 2u == 0u) { return vec2<f32>(AL2O3_N, 1.0); }
+    return vec2<f32>(ZRO2_N, 1.0);
+}
+
+fn cmul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
+    return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+}
+
+// Multi-layer thin-film reflectance by the characteristic transfer matrix —
+// lumit_core `stack_reflectance`, op for op. Per layer the phase thickness is
+// 2*pi*n*d*cos(theta)/lambda and the admittance n*cos(theta) (s) or
+// n/cos(theta) (p); chaining the layer matrices and closing on the substrate
+// gives Y = C/B and r = (eta0*B - C)/(eta0*B + C). Both polarisations, meaned.
+//
+// The cos(theta) inside the phase is why this matters: the reflectance band
+// shifts BLUE as the angle of incidence rises, which is the observed effect
+// that a ghost changes hue as its source moves off axis. A scalar coating
+// strength cannot express it at all.
+fn stack_refl(cos_i_in: f32, n1: f32, n2: f32, layers: f32, lambda_nm: f32) -> f32 {
+    let cos_i = clamp(abs(cos_i_in), 1e-6, 1.0);
+    let sin_i = n1 * sqrt(max(1.0 - cos_i * cos_i, 0.0));
+    let s_sub = sin_i / max(n2, 1e-6);
+    let c2_sub = 1.0 - s_sub * s_sub;
+    if (c2_sub <= 0.0) {
         return fresnel_cos(cos_i, n1, n2);
     }
-    let cos_c = sqrt(1.0 - sin2_c);
-    let delta = 2.0 * 3.141592653589793 * coating_n * d_nm * cos_c / lambda_nm;
-    let r01 = (n1 * cos_i - coating_n * cos_c) / (n1 * cos_i + coating_n * cos_c);
-    let sin2_2 = (coating_n / n2) * (coating_n / n2) * (1.0 - cos_c * cos_c);
-    if (sin2_2 >= 1.0) {
-        return fresnel_cos(cos_i, n1, n2);
+    let cos_sub = sqrt(c2_sub);
+
+    var total = 0.0;
+    for (var pol = 0u; pol < 2u; pol = pol + 1u) {
+        var eta0 = n1 * cos_i;
+        var eta_sub = n2 * cos_sub;
+        if (pol == 1u) {
+            eta0 = n1 / cos_i;
+            eta_sub = n2 / cos_sub;
+        }
+        var m0 = vec2<f32>(1.0, 0.0);
+        var m1 = vec2<f32>(0.0, 0.0);
+        var m2 = vec2<f32>(0.0, 0.0);
+        var m3 = vec2<f32>(1.0, 0.0);
+        var bad = false;
+        for (var i = 0u; i < MAX_COATING_LAYERS; i = i + 1u) {
+            let l = coating_layer(layers, i);
+            if (l.x <= 0.0 || l.y <= 0.0) {
+                continue;
+            }
+            let s = sin_i / max(l.x, 1e-6);
+            let c2 = 1.0 - s * s;
+            if (c2 <= 0.0) {
+                bad = true;
+                break;
+            }
+            let cos_l = sqrt(c2);
+            let d_nm = l.y * COATING_DESIGN_NM / (4.0 * l.x);
+            let delta = 2.0 * 3.141592653589793 * l.x * d_nm * cos_l / max(lambda_nm, 1e-6);
+            var eta = l.x * cos_l;
+            if (pol == 1u) {
+                eta = l.x / cos_l;
+            }
+            let cd = cos(delta);
+            let sd = sin(delta);
+            let l0 = vec2<f32>(cd, 0.0);
+            let l1 = vec2<f32>(0.0, sd / eta);
+            let l2 = vec2<f32>(0.0, eta * sd);
+            let l3 = vec2<f32>(cd, 0.0);
+            let a0 = cmul(m0, l0) + cmul(m1, l2);
+            let a1 = cmul(m0, l1) + cmul(m1, l3);
+            let a2 = cmul(m2, l0) + cmul(m3, l2);
+            let a3 = cmul(m2, l1) + cmul(m3, l3);
+            m0 = a0;
+            m1 = a1;
+            m2 = a2;
+            m3 = a3;
+        }
+        if (bad) {
+            return fresnel_cos(cos_i, n1, n2);
+        }
+        let b = m0 + m1 * eta_sub;
+        let c = m2 + m3 * eta_sub;
+        let num = eta0 * b - c;
+        let den = eta0 * b + c;
+        let dm = dot(den, den);
+        if (dm <= 1e-20) {
+            return fresnel_cos(cos_i, n1, n2);
+        }
+        total = total + dot(num, num) / dm;
     }
-    let cos_2 = sqrt(1.0 - sin2_2);
-    let r12 = (coating_n * cos_c - n2 * cos_2) / (coating_n * cos_c + n2 * cos_2);
-    let cos_2d = cos(2.0 * delta);
-    let num = r01 * r01 + r12 * r12 + 2.0 * r01 * r12 * cos_2d;
-    let den = 1.0 + r01 * r01 * r12 * r12 + 2.0 * r01 * r12 * cos_2d;
-    return clamp(num / den, 0.0, 1.0);
+    return clamp(total * 0.5, 0.0, 1.0);
 }
 
 // Reflectance of one surface: bare Fresnel blended toward the file's AR
@@ -207,13 +304,7 @@ fn surface_refl(cos_i: f32, n1: f32, n2: f32, layers: f32, lambda_nm: f32) -> f3
     if (layers < 0.5 || tp.coating <= 0.0) {
         return plain;
     }
-    let mgf2_n = 1.38;
-    let qw = 550.0 / (4.0 * mgf2_n);
-    var coated = coating_refl(cos_i, n1, n2, mgf2_n, qw, lambda_nm);
-    let extra = clamp(i32(round(layers - 1.0)), 0, 8);
-    for (var i = 0; i < extra; i = i + 1) {
-        coated = coated * 0.25;
-    }
+    let coated = stack_refl(cos_i, n1, n2, layers, lambda_nm);
     return clamp(plain + (coated - plain) * clamp(tp.coating, 0.0, 1.0), 0.0, 1.0);
 }
 

--- a/crates/lumit-render/src/fxops.rs
+++ b/crates/lumit-render/src/fxops.rs
@@ -955,6 +955,17 @@ pub fn run_ops(
                     // Raster pixels → fraction here, where the raster is
                     // known (K-260: the parameter is px@comp).
                     light_frac: [p.light[0] / w.max(1) as f32, p.light[1] / h.max(1) as f32],
+                    // Manual mode's lights, area-sampled (K-355). One entry
+                    // for a point source — which is what a zero Source size
+                    // gives — and a grid across the emitting area otherwise,
+                    // each carrying its share of the flux.
+                    manual_lights: lf::expand_area_lights(
+                        &lf::manual_light(p, w, h),
+                        lf::AREA_SAMPLES_MAX,
+                    )
+                    .iter()
+                    .map(|l| [l.pos[0], l.pos[1], l.rgb[0], l.rgb[1], l.rgb[2]])
+                    .collect(),
                     intensity: p.intensity,
                     lambdas,
                     max_ghosts: p.max_ghosts,

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -8387,3 +8387,45 @@ Also fixed here, the board's edge: the picture and its board share one rectangle
 board is painted anti-aliased while the platform texture is not, so a fractional rectangle
 bled a soft row of board out under the picture at some zooms. The shared rectangle is now
 snapped to whole device pixels (`snapToDevicePixels`), where the two rasterise identically.
+
+**K-353 · DECIDED · The lens flare antialiases itself, and hardware multisampling is gone
+from it — which is what made the flare bit-stable again.** The flare had been failing its
+own "GPU lens flare must be bit-stable" assertion on a clean main since before 2026-08-08
+(docs/TODO.md carried it as the standing blocker). It is fixed, and the cause was not
+where any of the guesses pointed.
+
+**What was measured, in order.** The ray trace is bit-identical run to run — the trace
+oracle hook reads the ray landings back and they never move. The ghost blur and the
+starburst are innocent: switching either off leaves the variance untouched. The variance
+survives all the way down to a single ghost at one wavelength and minimum detail, so it is
+not an accumulation-depth effect either. Pooling is not the cause; allocating the scratch
+and the multisample target fresh every frame changes nothing. What does change everything
+is the number of samples: rendering the identical frame through a single-sampled pipeline
+is bit-identical across every configuration tried, four runs each. **Additively blending
+fp16 into a 4x multisample target is not reproducible on this hardware** — a few hundred
+of 36864 floats came back one fp16 ULP different each run, in different places each time.
+
+**The fix keeps the antialiasing and drops the hardware.** K-264 added multisampling
+because jagged ghost silhouettes were one of the three Ultra artefacts; that reason still
+stands, so the coverage is now computed rather than sampled. Barycentric coordinates are
+affine in screen position, so `dpdx`/`dpdy` of them are exact, and a fragment can evaluate
+its own barycentric at each of the four standard sample positions and take
+`colour x covered/4`. That is exactly the model `lumit_core`'s `raster_triangle` already
+spelled out as the CPU twin, so the oracle now agrees with the GPU **by construction**
+rather than by resembling a hardware resolve.
+
+Two things that fix demanded and are worth knowing. A single-sampled rasteriser only makes
+a fragment where the pixel CENTRE is covered, so cells that cover sample positions but no
+centre would simply vanish — a third of the flare's energy went missing at the first
+attempt. Every triangle is therefore widened by a pixel before rasterising, and the
+fragment's own coverage test throws the padding away again. The widening displaces the two
+edge lines and re-intersects them rather than pushing corners away from the centroid:
+a caustic-folded cell is a **sliver** whose corners are nearly collinear, so "away from the
+centroid" points along it and leaves its thin axis exactly as thin as it was — which is the
+3% of energy the anamorphic test caught still missing after the first widening.
+
+Also gone with the multisample target: the largest allocation the effect made, ~66 MB at a
+1080p flare buffer (K-265's pool), and the resolve.
+
+Not fixed here, and still open: the flare's raster still draws the cells it culled, which
+remains in TODO.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -8500,3 +8500,39 @@ Not fixed here: ghosts are still *summed* point flares rather than the source's 
 by each ghost's own Jacobian, which is the exact treatment
 ([NEXT-FEATURES.md](NEXT-FEATURES.md) entry 1 Phase D). Sampling converges to it and is what
 the literature uses as the reference; the convolution is the optimisation, not the truth.
+
+**K-356 · DECIDED · Lens coatings are real multi-layer stacks solved by transfer matrix,
+not one layer times a quarter.** The flare's per-surface reflectance was a single-layer MgF₂
+quarter wave, with every additional layer of the prescription's coating column approximated
+as "quarter the residual again". That is the FlareSim shortcut, and it is the reason ghost
+*colour* was the least convincing thing about the effect: a single-layer coating has one
+reflectance minimum, so it can only ever tint ghosts one way, while a real multicoated lens
+has two or more and runs magenta, then green, then amber as a light crosses the frame.
+
+Each surface's coating is now a stack, and its reflectance the standard **characteristic
+transfer matrix**: per layer a phase thickness `δ = 2π n d cos θ / λ` and an optical
+admittance `η = n cos θ` (s) or `n / cos θ` (p), matrices `[[cos δ, i sin δ/η], [i η sin δ,
+cos δ]]` chained and closed on the substrate to give `Y = C/B` and `r = (η₀ − Y)/(η₀ + Y)`,
+with both polarisations averaged for unpolarised light.
+
+**The angle term is the one that earns this.** `δ` carries `cos θ`, so the whole reflectance
+band shifts blue as the angle of incidence rises — and flare rays strike interfaces at large,
+varied angles. That is precisely the observed behaviour a scalar coating strength cannot
+express: a ghost changing hue as its source moves off axis. The test pins it (53° reflects
+over 1.5× what normal incidence does at the design wavelength) alongside wavelength
+selectivity (a broadband stack's reflectance varies more than 3× across the visible).
+
+**What the stacks are, and the honest limit on them.** A `.lens` file publishes a layer
+*count*, never a recipe — real designs are manufacturer secrets, and every serious attempt in
+the literature concludes coatings can only be *measured*, not predicted. So each order takes
+its textbook design: one layer is the MgF₂ quarter wave, two a V-coat, three the classic
+broadband quarter/half/quarter W, and more extends it with alternating quarter-wave pairs.
+The *shape* is what matters here, not the exact recipe. Per-lens calibration against
+photographed flares is what would make the model invertible, and it stays out of scope
+([NEXT-FEATURES.md](NEXT-FEATURES.md) entry 1 Phase E).
+
+One test had to change, and its old assertion was a fossil of the old model: it compared a
+single layer against a "multicoat" on **n = 1.9** glass, where MgF₂ is very nearly the ideal
+single layer (1.38² = 1.904) and any stack is *worse* at exactly 550 nm. That is a
+coincidence of that glass, not a property of coatings; the comparison now runs on ordinary
+n = 1.5 crown, where the broadband stack beats the single layer as it should.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -8450,3 +8450,53 @@ and is folded into the source-region rework
 with recovered flux replace tile-max detection altogether. The earlier plan's "firefly
 suppression by 1/(1+luma) weighting" assumed a per-pixel sum that this detector does not
 have; it is not applicable as written, and Phase D is where it actually belongs.
+
+**K-355 · DECIDED · A flare no longer jumps, because a light is no longer one pixel — and a
+light with an area flares like one.** Two complaints with one root. Every detection tile was
+represented by its single brightest pixel, for the light's position AND its colour, and a
+light was always a point however large the thing emitting it.
+
+**Why flares jumped.** Inside a practical — a lamp with a visible bulb, a window, a
+softbox — *which* pixel is brightest changes frame to frame with sensor noise and specular
+sparkle. The reported position hopped between them, so the whole flare jittered across a
+source that had not moved at all. K-354 centroided the tiles and helped, but the weight was
+still one pixel per tile, so one hot pixel could still drag it. Each tile now carries the
+statistics of its **whole lit area** — Σ gate, Σ colour·gate, and Σ luma·gate with its first
+moments — so a source's position is the flux centroid of every lit pixel in it and its
+colour is their mean. A 40× sparkle moves a 64 px source by under a pixel, which the
+regression test asserts by adding one. Point sources are untouched: a single lit pixel is
+its own centroid and its own mean.
+
+**Why area lights now look right.** The flare of an extended source is the integral of the
+point flares over the emitting area, and at the budget K-353's plan sets out (~2 s a frame)
+that integral is evaluated **directly** rather than approximated. Detection measures each
+source's half-extent as the standard deviation of its flux about its centre; a source wider
+than a fraction of the frame is split into a small centred grid of samples, each carrying an
+equal share of the flux. The sum carries the source's shape: a tube's ghosts come out as
+bars, a window's as rectangles, a bulb's as discs — which a point source structurally cannot
+do. Energy is conserved by construction (the shares sum to one light), so a source only ever
+gets *smoother* as it is split, never brighter, and the GPU test pins exactly that.
+
+The grid is regular, centred and unjittered, so determinism holds (docs/14) and K-353's
+bit-stability still passes. Manual mode gets the same thing as a pair of dials — **Source
+width** and **Source height**, px@comp half-extents (K-260), defaulting to 0, which is the
+point source the effect has always had.
+
+`MAX_LIGHTS` rises 16 → 64 and splits into `MAX_SOURCES` (16, distinct sources detection may
+find) and `MAX_LIGHTS` (64, slots the trace carries), because a source now spends several
+slots when it has extent. Sixteen point sources still cost sixteen slots; a source that
+cannot be split faithfully within the budget is carried as the single point it started as
+rather than as half an area source, which would lose the rest of its flux.
+
+Two consequences worth stating. A source's colour is now the mean of its lit pixels rather
+than its brightest pixel's, so a source with a hot core reads very slightly dimmer than it
+did — that is the firefly suppression working, and it is the more correct answer. And the
+per-tile sums are order-dependent where the old maximum was not: the CPU scans a tile in row
+order and the GPU merges 64 threads' partials in thread order, so the twins agree to the
+matte oracle's perceptual bound rather than op-for-op. Both are internally deterministic,
+which is the property that actually matters.
+
+Not fixed here: ghosts are still *summed* point flares rather than the source's image warped
+by each ghost's own Jacobian, which is the exact treatment
+([NEXT-FEATURES.md](NEXT-FEATURES.md) entry 1 Phase D). Sampling converges to it and is what
+the literature uses as the reference; the convolution is the optimisation, not the truth.

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -8429,3 +8429,24 @@ Also gone with the multisample target: the largest allocation the effect made, ~
 
 Not fixed here, and still open: the flare's raster still draws the cells it culled, which
 remains in TODO.
+
+**K-354 · DECIDED · A detected flare source sits at the centre of its light, not at one
+arbitrary pixel of it.** Matte mode pinned each light to the brightest pixel of its
+brightest tile. For a point source that is exactly right and still is. For a *practical* —
+a softbox, a window, a lamp with a visible bulb — it put the light wherever the tile scan
+happened to reach a maximum first, so a flare fired from a large soft source came out of
+its edge rather than its middle. Each anchor now takes the flux-weighted centroid of the
+tiles that feed it, in the same fixed tile order both twins already used, so the change
+costs nothing and stays deterministic. A one-tile source has only itself to average and is
+untouched.
+
+**What this deliberately does NOT fix, so it is not assumed.** The weight is flux and each
+tile is still represented by its single brightest pixel, so one very hot pixel — a sensor
+sparkle, a specular glint — still pulls the centroid toward itself and still flickers frame
+to frame on real footage. Suppressing that needs each tile to carry its whole flux and its
+own centroid rather than one pixel's, which is a change to the tile reduction in both twins
+and is folded into the source-region rework
+([NEXT-FEATURES.md](NEXT-FEATURES.md) entry 1 Phase D), where real segmented source regions
+with recovered flux replace tile-max detection altogether. The earlier plan's "firefly
+suppression by 1/(1+luma) weighting" assumed a per-pixel sum that this detector does not
+have; it is not applicable as written, and Phase D is where it actually belongs.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -682,9 +682,12 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   one the original research paper used: give the brightness to the CORNERS
   (each corner averages the panels around it) and let the graphics card blend
   smoothly across every panel — the seams simply cease to exist. The jagged
-  outlines got the standard cure, multisampling: the card checks four points
-  per pixel instead of one at the edges of shapes, which is how every game
-  smooths its edges. And the triangular notches in the bright rims turned out to
+  outlines got the standard cure, multisampling: four points checked per pixel
+  instead of one at the edges of shapes, which is how every game smooths its
+  edges. (Lumit later had to stop asking the *card* to do that counting and do
+  it in its own arithmetic instead — same four points, same result, but
+  repeatable. See "the flare that would not draw the same picture twice"
+  below.) And the triangular notches in the bright rims turned out to
   be panels the code was *throwing away* out of caution — an earlier bug made
   long thin panels dangerous to draw, so they were dropped, and every dropped
   one left a bite mark in a rim. They are safe to draw now that brightness is
@@ -814,6 +817,40 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   own black background and hides the layer, which is what "Black" was for —
   the flare as a separate element you Screen back on in another comp — so a
   project saved with Black opens on Normal.
+
+  **The flare that would not draw the same picture twice (K-353).** Lumit
+  holds itself to a rule: the same composition, the same frame, the same
+  settings must produce *the same pixels* — that is what lets a frame be
+  cached, and what makes the preview a promise about the export. The lens
+  flare had quietly stopped keeping it. Render the same flare twice and a few
+  hundred pixels came back a hair different, in different places each time,
+  and the test that says so had been failing for months without anyone knowing
+  which part was to blame.
+
+  The answer came from crossing things off. The ray tracing was innocent —
+  ask it for the same rays twice and every one lands in exactly the same
+  place. The blur was innocent; so was the starburst. It even happened with a
+  single ghost of a single colour, so it was not a matter of adding up too
+  many things. What was left was the *drawing* — and specifically the four-
+  points-per-pixel smoothing described further up. Asking the graphics card to
+  keep four half-precision numbers per pixel and add light into them turns out
+  not to be repeatable on this hardware: the card is free to do that
+  arithmetic in a slightly different order each time, and half-precision
+  numbers are small enough to notice.
+
+  So Lumit stopped asking. The smoothing is still there and still uses the
+  same four points — the flare does the counting itself, in its own
+  arithmetic, which is repeatable by construction. It also happens to be the
+  *exact* calculation the slow reference implementation already did, so the
+  two now agree because they are the same sum rather than because one
+  resembles the other. Two details had to come with it: shapes are grown by a
+  pixel before drawing (otherwise a sliver of light that passes between pixel
+  centres is never asked about at all, and a third of the flare's brightness
+  went missing), and that growing pushes the *edges* outward rather than the
+  corners — a folded sliver's corners lie almost in a line, so pushing them
+  apart lengthens it without ever making it thicker. And the biggest single
+  piece of memory the effect owned, about 66 MB on a large frame, was the
+  card's four-points-per-pixel canvas; it is gone.
 - **RGB split gains a Wavelength mode** (K-090's quality-tier pattern: where the smooth
   look is optional, it hides behind a Bool next to the fast one). Off — the default —
   the split is three tinted samples: the first colour pulled one way, the third the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -883,6 +883,37 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   measured in pixels from the centre outward. Leave them at zero and you have
   the pinpoint star the effect always drew. When the flare is reading a layer
   instead, it measures the size itself from the picture.
+
+  **Why ghosts change colour as a light crosses the frame (K-356).** Every
+  glass surface in a lens is coated to stop it reflecting — that is what the
+  faint purple or green sheen on a lens front element is. Those coatings are
+  the reason lens flare is coloured at all: what little light *does* bounce
+  back off each surface has been filtered by them, so a ghost is tinted by
+  the coating that made it.
+
+  A coating works by interference: light bouncing off the front of a
+  microscopically thin film and light bouncing off its back arrive slightly
+  out of step, and cancel. How far out of step depends on the wavelength —
+  which is why a coating kills some colours better than others — *and* on the
+  angle the light arrives at, because a slanted path through the film is a
+  longer path. So as a light moves toward the edge of frame and its rays hit
+  the glass more steeply, the colour the coating suppresses shifts. That is
+  the real-world effect of a flare going magenta on one side of the frame and
+  green on the other.
+
+  Lumit used to model this with a single film, which can only ever cancel one
+  colour, so ghosts could only be tinted one way. It now solves real
+  multi-layer stacks properly — the standard optics calculation, layer by
+  layer, for both wavelength and angle. Modern lenses use several layers
+  precisely to get two or more cancelled colours, which is where their
+  characteristic look comes from, and that is now what Lumit draws.
+
+  One honest limit: a lens prescription tells you *how many* layers a surface
+  has, never the recipe — those are trade secrets, and the research is
+  unanimous that real coatings can only be measured, not guessed. So Lumit
+  uses the textbook design for each layer count. The behaviour is right; the
+  exact tint of a specific real lens would need that lens photographed and
+  fitted.
 - **RGB split gains a Wavelength mode** (K-090's quality-tier pattern: where the smooth
   look is optional, it hides behind a Bool next to the fast one). Off — the default —
   the split is three tinted samples: the first colour pulled one way, the third the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -851,6 +851,38 @@ Two mechanisms make this safe, and you'll see them by name in the code:
   apart lengthens it without ever making it thicker. And the biggest single
   piece of memory the effect owned, about 66 MB on a large frame, was the
   card's four-points-per-pixel canvas; it is gone.
+
+  **Why flares used to jump, and why lights now have a size (K-355).** Point
+  the flare at footage — at a street lamp, a window, a practical in shot — and
+  it used to twitch. The reason was that Lumit asked a very narrow question of
+  the picture: *which single pixel here is brightest?* That pixel became the
+  light. But inside a real lamp, the brightest pixel is a lottery: sensor
+  noise and the odd sparkle move it from one frame to the next, so the light
+  hopped about inside something that had not moved, and the whole flare
+  hopped with it.
+
+  Lumit now asks a better question: *where is the light, on average?* Every
+  lit pixel is weighed, and the light is placed at the balance point of all of
+  them — its centre of brightness. One pixel going forty times too bright
+  moves that balance point by less than a pixel, so the jitter is simply gone.
+  The same change gives a light its *colour* from the average of what is lit
+  rather than from its hottest speck, so a sparkle can no longer tint a flare.
+
+  And once you are weighing every lit pixel, you also know **how big the light
+  is** — and that turns out to matter enormously. A real flare from a strip
+  light does not look like a flare from a star: its ghosts are little images
+  of the strip, stretched the way the strip is. Lumit gets this right the
+  honest way, by treating a large light as what it actually is: many small
+  lights side by side. It works out the flare for a handful of points spread
+  across the source and adds them up, each carrying its share of the
+  brightness — so a tube gives bar-shaped ghosts, a window rectangular ones,
+  a bulb round ones. Splitting a light this way never makes it brighter, only
+  smoother, because the shares always add back up to one light.
+
+  In Manual mode this is two dials, **Source width** and **Source height**,
+  measured in pixels from the centre outward. Leave them at zero and you have
+  the pinpoint star the effect always drew. When the flare is reading a layer
+  instead, it measures the size itself from the picture.
 - **RGB split gains a Wavelength mode** (K-090's quality-tier pattern: where the smooth
   look is optional, it hides behind a Bool next to the fast one). Off — the default —
   the split is three tinted samples: the first colour pulled one way, the third the

--- a/docs/NEXT-FEATURES.md
+++ b/docs/NEXT-FEATURES.md
@@ -197,6 +197,14 @@ cannot do any of that.
 **Cost:** one flare evaluation per source (unchanged from today) plus G small 2-D
 convolutions — milliseconds, and independent of source area. Far inside the budget.
 
+**Status (K-355):** area sources already work, by **direct sampling** — the source's extent
+is measured from its flux and the flare is evaluated at a small grid of points across it,
+each carrying a share of the flux. That is the reference method (it is what the Monte Carlo
+oracle in D3 does, minus the randomness), so ghosts already take the source's shape. What
+Phase D adds is *efficiency and exactness*: sampling converges to the warped convolution but
+needs enough samples that neighbours land closer than a ghost is wide, and the cap is
+currently 5×5 per source. Build it when a source is wide enough that replication shows.
+
 *Shape:* get `J_g` per ghost by finite-differencing the existing trace at θ₀ ± δ (or read
 it off the ray grid); warp the source's radiance tile; convolve with that ghost's kernel;
 scale by the path's throughput; splat. It runs **inside** the per-wavelength loop, because
@@ -311,20 +319,14 @@ Matte mode already has half of what the literature asks for: the luma gate is so
 summing already weighs an area source by its area rather than one pixel. What still
 flickers on video, and the fixes:
 
-1. ~~**Anchor jumping**~~ — **landed as K-354.** Each anchor now takes the flux-weighted
-   centroid of the tiles feeding it, so a source spanning several tiles is found at the
-   centre of its light rather than at whichever corner the tile scan reached first. Point
-   sources are untouched.
-2. **Fireflies — still open, and the first plan for it was wrong.** A single hot pixel
-   (sensor sparkle, a specular glint) still owns its tile and so still pulls both the flux
-   and the K-354 centroid toward itself, frame to frame. The draft here proposed a Karis
-   `1/(1+luma)` weighting, which assumes a per-pixel *sum* the detector does not have: a
-   tile is represented by its single brightest pixel, for position and for flux. The real
-   fix is to make each tile carry **its whole gated flux and its own centroid** instead of
-   one pixel's — a change to the tile reduction in both twins (the workgroup merge stays a
-   fixed-order sum, so determinism is unaffected). That is the same information Phase D's
-   source regions need, so **do it there rather than twice**: it is listed here only so the
-   gap is not mistaken for a fixed one.
+1. ~~**Anchor jumping**~~ — **landed as K-354, completed by K-355.**
+2. ~~**Fireflies**~~ — **landed as K-355.** Each tile now carries its whole gated flux, its
+   own flux centroid and its mean colour rather than one pixel's, so no single hot pixel can
+   move a light or define its colour. A 40× sparkle shifts a 64 px source by under a pixel.
+
+**What is left of this entry:** nothing. Area sources are handled by direct sampling
+(K-355), which is the reference method; Phase D's per-ghost warped convolution remains the
+*optimisation* of that, not a correction to it.
 
 **Temporal smoothing is a recorded non-option**, not an oversight: a frame must be a
 function of the document and the frame alone (docs/14 determinism; the caches name frames

--- a/docs/NEXT-FEATURES.md
+++ b/docs/NEXT-FEATURES.md
@@ -8,9 +8,15 @@ reverses a decision, that edit and the [02-DECISIONS.md](02-DECISIONS.md) entry 
 the same commit as the code.
 
 In plain terms: this is the "how" file for the work the backlog only names. The two
-biggest entries — the lens flare rework and lights — came out of a research pass
+biggest entries — the lens flare and lights — came out of two research passes
 (2026-08-12) over how the industry actually does this on real footage; the sources are
 cited inline so the reasoning can be checked rather than trusted.
+
+**The flare entries were rewritten the same day**, after the owner set the budget: the
+physically based flare is to be done *properly* at roughly **2 seconds per frame**, not
+approximated down to milliseconds, and a sprite-based flare is welcome as a **separate
+effect** rather than a replacement. Entry 1 is that plan; entry 2 is the sprite one. The
+first draft of this file recommended the opposite trade and was wrong.
 
 Standing obligations every entry inherits (they are why the estimates are not smaller):
 each feature lands with its regression tests, its `app_en.arb` strings (plus
@@ -21,114 +27,308 @@ WGSL kernel, bit-stable draw order, px@comp point parameters — K-260).
 
 ---
 
-## 0. First, the standing blocker: the flare is not bit-stable
+## 0. ~~The bit-stability blocker~~ — LANDED (K-353)
 
-Before any flare work below, the existing regression in TODO's **Now** must be
-understood: `wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals` fails its
-"GPU lens flare must be bit-stable" assertion on clean `main` — two runs of the same
-flare give different pixels. Every flare entry below adds passes to that pipeline, and
-none of them can be validated honestly while the baseline itself wobbles. Find which
-stage varies (bisect by reading back after each pass: bright-pass → trace → blur → draw)
-before changing anything. [impl/lens-flare.md](impl/lens-flare.md) §2.4 explains why the
-additive draw order is the property everything else protects.
+Kept here only as the reading order: everything below builds on a raster that now
+renders the same frame twice. The cause was hardware 4× multisampling (additive fp16
+into a multisample target is not reproducible on this hardware); the flare computes its
+own coverage now. See K-353 and [impl/lens-flare.md](impl/lens-flare.md). Delete this
+heading once the entries under it have landed.
 
 ---
 
-## 1. Lens flare v2 — flares that follow a light, not a threshold
+## 1. The physically based flare, done properly — the ~2 s/frame target
 
-**The problem, precisely.** The shipped flare (docs/08 §3.27) is screen-space: a
-bright-pass finds hot pixels, ghosts are traced from them. On graphics that is fine; on
-*footage* it is the wrong tool, and the research is blunt about why — any bright pixel
-(sky, white shirt, specular glint) spawns ghosts, and pixels crossing the threshold
-frame to frame make the whole flare **flicker**. Even the technique's author recommends
-sprite-based flares for prominent light sources
-([Chapman](https://john-chapman.github.io/2017/11/05/pseudo-lens-flare.html)). What
-Video Copilot's Optical Flares actually is, conceptually: **no bright pass at all** — a
-user-supplied 2D light position drives a designer-authored stack of elements placed
-along the line from the light through frame centre
-([Optical Flares](https://www.videocopilot.net/products/opticalflares)). Deterministic on
-video, zero flicker, art-directable. That is the single biggest "usable with footage"
-win available.
+**The brief changed, and for the better** (owner, 2026-08-12). The earlier plan here
+proposed replacing the physically based path with a cheap sprite stack because the
+literature says the real-time version is not usable on footage. That is the wrong trade
+for Lumit. The owner's position: a sprite-based flare is welcome **as its own separate
+effect** (entry 2), but the physically based one should be done *properly*, and **~2
+seconds per frame is an acceptable budget** — the reference point being an acquaintance's
+own generator, accurate enough to **remove** real flares from footage.
 
-**What already exists to build on** — more than the pitch above implies, so read
-[impl/lens-flare.md](impl/lens-flare.md) first (`crates/lumit-gpu/src/fx/lens_flare.rs`):
+That budget changes everything. The anchor for "interactive physically based" is the
+Hullin-style pipeline as actually implemented: a 27-interface lens → 351 two-bounce
+ghosts, a 32×32 ray grid per ghost, **12 ms total**
+([bitsquid](https://bitsquid.blogspot.com/2017/07/physically-based-lens-flare.html),
+[jpgrenier](https://www.jpgrenier.org/lensflare.html)). 2000 ms is ~167× that. Lumit's
+flare is already in this family — a real prescription, a pupil grid, per-wavelength
+tracing, ranked ghosts, a baked starburst, an iris model, coating and f-stop. So this is
+not a rewrite; it is spending a budget the effect never had on the approximations it was
+forced into.
 
-- **Manual mode is already position-driven** — a px@comp pair (K-260) drives the whole
-  physically-traced flare, so the deterministic-on-footage workflow half-exists today;
-  what it lacks is art-directable *elements* around the physical ghosts.
-- **The starburst already exists and is already baked** per lens/aperture; the owed
-  **image aperture file** parameter (TODO's flare follow-ups) plugs into that bake
-  rather than needing a new mechanism.
-- The source-mode enum already reserves `2 = Lights` "until light layers land (K-257)";
-  `MAX_LIGHTS = 16` and the `GpuLight` layout mean every element below runs per light
-  for free on the existing dispatch axis.
-- The lens designer and `lens_file` (K-264) — where element-stack presets live.
+**A standing rule for this whole entry, from [14-ENGINEERING-RULES.md](14-ENGINEERING-RULES.md):
+every bake belongs on the CPU in Rust.** The coating tables, the starburst FFTs, the
+colour-matching integration — all of them are functions of the lens and the parameters,
+not of the frame. Putting them on the CPU makes them deterministic by construction (the
+property K-353 just had to rescue) and removes them from the per-frame budget in the same
+move. Only the ray grid needs the GPU.
 
-**The build, in two steps:**
+### Phase A — accuracy that costs nothing (do these first)
 
-1. **Element stack in the lens file.** Beside the traced ghosts, a flare gains a list
-   of authored elements, each: `kind` (glow, iris polygon, ring/halo, streak), `offset`
-   (signed position along the light→centre axis: 1.0 = on the light, −1.0 = mirrored
-   across centre — the Optical Flares model), `scale`, `tint`, `opacity`. Data, not
-   shaders: one draw pass of N procedural quads, trivially cheap next to the ray
-   tracer, feeding the same K-289 combine. Keep the additive order fixed (element
-   index, never anything measured) so §2.4's bit-stability holds by construction.
-2. **The one genuinely new kernel: the anamorphic streak** — the Kawase streak filter:
-   downsample ~1/16, then 3–4 passes each sampling 4 taps along the streak direction at
-   distance 4^pass, weight `a^(b·dist)`, attenuation ~0.9–0.95
-   ([Oat, scene postprocessing](https://www.chrisoat.com/papers/Oat-ScenePostprocessing.pdf)).
-   A directional variant of the blur passes already in the file.
+**A1. Multi-layer anti-reflective coatings, by transfer matrix.** The single biggest
+correctness gain per line of code, and the one that fixes *ghost colour*. Today (and in
+every real-time implementation) the coating is an ideal single-layer quarter-wave stack
+with a hand-tuned blend — one reflectance minimum, hence one broad colour cast. Real lens
+coatings are 4–7 layer stacks whose reflectance R(λ) is W- or M-shaped, which is why real
+ghosts run magenta, then green, then amber across a frame. The correct model is the
+standard thin-film **transfer matrix**: per layer, phase thickness `δ = 2π n d cos θ / λ`
+and admittance `η = n cos θ` (s) or `n / cos θ` (p); chain the 2×2 characteristic
+matrices, take `Y = C/B`, then `r = (η₀ − Y)/(η₀ + Y)`, `R = |r|²`; average s and p for
+unpolarised light.
 
-Sources stay as they are: Manual (soon: Lights, entry 3) is the footage workflow;
-Matte keeps the detector for graphics, hardened by entry 2. Full lens-prescription
-ray tracing beyond what the bake already does (Hullin 2011) is ~12 ms/frame class —
-wrong genre; do not chase it.
+Angle dependence is not a small correction: because `δ ∝ cos θ`, the whole reflectance
+band **shifts blue as the angle of incidence rises**, which is exactly the observed effect
+that a ghost changes hue as the source moves off-axis. Flare rays hit interfaces at large
+and varied angles, so this dominates — and a scalar "coating" parameter cannot represent
+any of it.
 
-**Files:** `lens_flare.rs` + its WGSL siblings, `lumit-core/src/fx/lens_flare.rs`
-(params), the lens-file schema (K-264), Effect controls rows (the pair row's dropper on
-px@comp pairs is already owed — K-260). **Spec edits:** docs/08 §3.27 gains the element
-stack; [impl/lens-flare.md](impl/lens-flare.md) gains a §for it (algorithms above, test
-plan below); a K-entry records the design.
+*Shape:* compute `R(λ, cos θ)` on the CPU into a 64×64 (or 128×128) f32 LUT **per
+interface** at lens-load time, upload as a texture array, and have the trace do a bilinear
+fetch. Per-frame cost ≈ zero. Put the layer stack in the lens file as data, and keep a
+per-interface calibration offset — real coatings are measured, not predicted (see Phase E).
+*Refs:* [COMSOL thin-film](https://doc.comsol.com/6.1/doc/com.comsol.help.roptics/roptics_ug_optics.6.73.html),
+[AR coating](https://en.wikipedia.org/wiki/Anti-reflective_coating).
 
-**Test plan:** CPU oracle for each element kind at a known position (docs/08 §2 pattern);
-bit-stability (two renders, identical bytes); a two-frame "video" fixture where a bright
-region moves — assert the element stack's output moves *continuously* (no threshold pop);
-the baked starburst keyed by aperture hash (same aperture → cache hit, no re-FFT).
+**A2. Real spectral radiometry.** Split geometry from radiometry, because they vary at
+different rates. Ray *geometry* varies slowly with λ (dispersion is a smooth perturbation)
+— 8–16 wavelengths, interpolated, is plenty. Ray *radiometry* varies fast, because A1's
+reflectance oscillates several times across the visible — so evaluate it at **81 samples,
+5 nm across 380–780 nm**, which costs LUT fetches rather than rays. Integrate against the
+**CIE 1931 2° colour-matching functions** to XYZ, then one fixed 3×3 into working RGB.
 
-**Size:** the biggest entry here — the element system is real design work. Land it in
-slices: streak element first (pure shader work, immediate visual payoff), then the stack,
-then the baked starburst.
+Do *not* keep three RGB samples: three samples cannot represent a curve with three minima,
+so ghost hues come out systematically wrong. (Hero-wavelength sampling is not applicable —
+that is a Monte Carlo variance-reduction trick, and this is a deterministic quadrature.)
+*Refs:* [CIE CMFs](https://www.fourmilab.ch/documents/specrend/),
+[pbrt colour](https://pbr-book.org/4ed/Radiometry,_Spectra,_and_Color/Color).
 
-## 2. Harden Matte mode's detection on footage (small, do early)
+### Phase B — spend the budget on rays
+
+**B1. A dense, adaptive ray grid with per-ray splatting.** Raise 32² toward **256²** per
+ghost, allocated adaptively: a 16² prepass gives each ghost a bounding box and peak
+irradiance, then resolution is handed out in proportion to on-sensor area. Critically,
+**replace the interpolated-quad rasterisation with per-ray splatting weighted by the exact
+Jacobian**, and clip against every aperture **per ray** rather than per quad. Sparse grid
+plus bilinear interpolation of the transfer is where the current model actually dies:
+caustic folds inside a ghost get averaged away, and per-quad energy is wrong exactly where
+the bundle folds.
+
+This also retires the sliver/fold machinery that K-262 through K-353 kept patching
+(`MIN_QUAD_PX`, sliver drops, the widening K-353 just added) — there are no quads to fold.
+It is the largest single change in this entry and should be its own PR.
+
+**B2. A field-angle-dependent starburst.** The starburst is Fraunhofer diffraction and is
+correctly `|FFT(pupil)|²` — that part is already right. Two things are not. First, **the
+diffracting aperture changes shape across the frame**: off-axis the limiting pupil is no
+longer the iris but the front and rear mechanical stops clipping it into a **cat's-eye**,
+plus a `cos θ` foreshortening. So ray-trace the true exit-pupil outline at 8–16 field
+angles, FFT each at 2048²–4096², and interpolate. Second, the cheap **λ-rescale of one
+FFT is exact only for a real-valued pupil**; the moment the pupil carries phase (dust,
+scratches, coating defects — the things that make real starbursts asymmetric and
+interesting) it needs one FFT per wavelength. At 81 FFTs of 2048² on the CPU with
+`rustfft` that is well under a second, **and it is a bake, not a per-frame cost**.
+
+A free correctness check: blade parity. An even blade count gives that many spikes, an odd
+count twice as many. If the FFT does not reproduce that by itself, something is wrong.
+*Refs:* [Fraunhofer/Fresnel](https://phys.libretexts.org/Bookshelves/Optics/BSc_Optics_(Konijnenberg_Adam_and_Urbach)/06:_Scalar_diffraction_optics/6.07:_Fresnel_and_Fraunhofer_Approximations),
+[Tang's flare report](https://www.cs.toronto.edu/~hxtang/projects/flare_render/lensflare_huixuan.pdf).
+
+### Phase C — the things nobody does in real time
+
+**C1. Energy-ranked four-bounce ghosts.** For N interfaces there are exactly `N(N−1)/2`
+two-bounce paths (351 at N=27) — what everyone traces. Four-bounce paths number ~10⁵ at
+the same N. With a modern coating (R ≈ 0.3%) a four-bounce path carries ~10⁻⁵ of a
+two-bounce one, so the vast majority are invisible; but the sun is ~10⁵× a normal
+highlight, and a few four-bounce paths land as *tight, well-focused* spots rather than
+broad discs. Those are exactly the small hard artefacts a removal model would otherwise
+leave as residual. With uncoated or vintage glass (R ≈ 4%) they are plainly visible.
+
+*Shape:* enumerate all of them on the CPU, run a 16² energy prepass, keep the top few
+hundred by peak sensor irradiance, render survivors at full grid. This is the
+ranked-path method stray-light analysis already uses (Zemax's Ghost Focus Generator does
+the same), and against a 2 s budget it is nearly free.
+
+**C2. Fresnel ringing on ghost edges, by fractional Fourier transform.** The starburst is
+Fraunhofer; **the ghosts are Fresnel**, because each ghost image is defocused by its own
+amount. The operator that interpolates between "identity" (in contact) and "Fourier" (far
+field) as a function of defocus is the **fractional Fourier transform** — one parameter
+gives both the hard aperture polygon and the diffraction pattern, and everything
+real-time drops it, which is why real-time ghosts have hard edges. Budget: applying it to
+all 351 ghosts × 12 λ at 256² is ~2 s on its own, so apply it to the **top ~32 ghosts by
+energy** (~100 ms). Hardest item here; do it last. *Ref:* Joo et al. 2016,
+[CGF 35(4)](https://onlinelibrary.wiley.com/doi/abs/10.1111/cgf.12953).
+
+### Phase D — area and extended sources (the part that makes footage work)
+
+This is the answer to "make it work with area lights", and the research is unambiguous
+about the shape of it.
+
+**The wrong model first, so it is not re-proposed.** Flare from an extended source is
+**not** the convolution of the source with a single point-source flare PSF. Talvala et al.
+measured this directly and their figure caption says it plainly — the glare patterns are
+not shift-invariant ([Stanford, SIGGRAPH 2007](https://graphics.stanford.edu/papers/glare_removal/glare_removal.pdf)).
+A ghost 400 px from the source moves and changes shape at a different rate than the source
+does, so one global convolution cannot be right. (Hullin's own limitations section offers
+exactly that approximation for area lights, unvalidated — it is the gap this fills.)
+
+**The right model: convolution *per ghost*, in that ghost's own frame.** Each ghost path
+is an imaging system, and its map from incident direction to sensor position is locally
+affine — this is the classical paraxial ghost-imaging result, that each ghost sub-system
+has its own cardinal points and its own **ghost magnification**, so a ghost is a
+magnified, generally defocused *image of the source*. Linearising at the source centre
+gives a 2×2 Jacobian `J_g` per ghost, and then
+
+```
+Ghost_g(x)  =  [ PointGhost_g  ⊛  (S ∘ J_g⁻¹) ] (x)
+```
+
+— the point-source ghost kernel convolved with the source's radiance map, affinely warped
+by that ghost's Jacobian (flip, anisotropic scale and rotation included; ghosts on the far
+side of frame are inverted images of the source). Shift-invariance holds *within* a ghost
+over the source's angular support, and fails *between* ghosts — which is precisely why the
+per-ghost decomposition is the correct treatment of a shift-variant system.
+
+**What this buys, concretely:** a neon tube's ghosts become elongated bars, a window's
+become rectangles, a headlight's become discs — and a near-focused ghost shows the *shape
+of the source* while a defocused one takes the aperture polygon. Point sprites structurally
+cannot do any of that.
+
+**Cost:** one flare evaluation per source (unchanged from today) plus G small 2-D
+convolutions — milliseconds, and independent of source area. Far inside the budget.
+
+*Shape:* get `J_g` per ghost by finite-differencing the existing trace at θ₀ ± δ (or read
+it off the ray grid); warp the source's radiance tile; convolve with that ghost's kernel;
+scale by the path's throughput; splat. It runs **inside** the per-wavelength loop, because
+`J_g` and the kernel are both λ-dependent.
+
+**D1. Guard the linearisation with adaptive subdivision.** Evaluate `J_g` at the source's
+corners; if it varies across the source by more than a kernel width, quadtree-split the
+source region and repeat per patch, blending with a windowed partition of unity (the
+Efficient Filter Flow structure). This is the correctness dial, it degrades gracefully, and
+2 s buys dozens of patches per source.
+
+**D2. The starburst half *is* shift-invariant, so take the free win.** Veiling glare and
+the starburst are centred on the source and vary only slowly with field angle, which is why
+every eye-glare paper convolves the whole HDR frame with one PSF (Ritschel's *Temporal
+Glare*, Kakimoto, Spencer). So convolve the source region's radiance map with the
+diffraction kernel directly, per wavelength — one FFT pair per band, and softboxes and
+windows get correct soft glare for nothing.
+
+**D3. A brute-force Monte Carlo mode, as the oracle rather than the default.** The
+production reference is Animal Logic's *Lego Movie 2* renderer: connect a random sample on
+the light source to a random sample on the front lens, importance-sampled jointly over
+paths and pupil cells (which lifted their sensor hit rate from ~15% to ~90%), and splat.
+Use it in tests to assert the fast path matches within tolerance, and for the case where
+linearity genuinely fails — **occlusion**, where a lens hood or foreground object clips
+part of the source, which is not linear in the source and must be sampled.
+*Ref:* [DigiPro 2019](https://animallogic.com/wp-content/uploads/2023/06/Physical-Based-Lens-Flare-Rendering.pdf).
+
+**D4. Where the source region comes from, on real footage.** Log-luminance threshold →
+connected components → morphological close and a small dilation → drop components below an
+area/flux floor → cap at 16 by total flux → **track components frame to frame** so a
+flickering practical does not pop. Keep the region's **radiance map**, not just a centroid
+and a total — that map is the `S` above.
+
+**Flux matters more than shape, and clipping destroys it.** Flare amplitude is linear in
+source flux, so clipping a 1000:1 source at 1.0 under-drives the entire flare by orders of
+magnitude. In descending order of trustworthiness: use raw/HDR footage; else standard
+single-channel highlight reconstruction; else — and this is the production answer — an
+explicit **per-region intensity multiplier** in the UI (Animal Logic flag lights for the
+flare pass and give them separate intensity multipliers). A single-image HDR CNN may
+provide an initial *guess* only; the literature is blunt that saturated content is
+hallucinated. Never let a hallucinated highlight silently set flare amplitude — surface the
+number and let the artist tune it. This is the calibration knob the physical world always
+needs.
+
+### Phase E — only if flare *removal* is genuinely a goal
+
+Every serious attempt in the literature converges on the same conclusion: **coatings and
+manufacturing deviations cannot be predicted, only measured.** Walch et al. built their
+model by measuring real captured flares and fitting, precisely because the internal
+parameters — especially the AR coatings — can only be approximated. The 2026
+*Precomputed Lens Transport Maps* work identifies the gap that matters for invertibility:
+prior polynomial and neural lens models **omit Fresnel intensity throughput**, which
+precludes accurate simulation of internal reflections.
+
+So if removal is the goal, what matters is not more wavelengths but: (1) differentiability
+of the forward model in its parameters, because removal is *fitting*, not simulating;
+(2) correct handling of the aperture occlusion discontinuity, which is the dominant fitting
+error when a smooth model smears across it; (3) Fresnel throughput, not just ray geometry;
+(4) sub-pixel ghost positions, controlled by the element spacings you are least likely to
+know — so make them fitted, not fixed; (5) strict scene-referred linearity with exposure
+modelled explicitly; (6) a **per-lens calibration workflow** — photograph a point source
+across a grid of field angles and f-stops, fit spacings and coating stacks to the observed
+ghosts.
+
+**Read on the acquaintance's generator:** almost certainly a physically based forward model
+*plus* per-lens calibration, then fit-and-subtract. The physics gets the right parametric
+family; the calibration picks the right member of it. A simulator without a calibration
+path will not reach that bar however many wavelengths it samples.
+
+### What not to build
+
+Lee & Eisemann 2013's paraxial matrix model and the polynomial-optics line (Hullin 2012,
+Bodonyi 2025) are **speed devices**: they trade bounded fit error for evaluation cost. At
+2 s/frame they cost accuracy and buy nothing. Keep polynomial optics only as a
+ground-truth-comparison harness if it is ever worth quantifying how far the interactive
+path was off. Also skip precomputed *flare-field* interpolation across source positions —
+Hullin's team tried warping precomputed flares and reported it failed, flares being too
+sensitive to subtle changes.
+
+### Suggested build order within entry 1
+
+A1 → A2 (free accuracy, no budget spent) → B2 (a bake, big visual payoff) → D4 + D2
+(source regions and the free shift-invariant half) → D (per-ghost warped convolution, the
+headline for footage) → B1 (dense grid + splatting, the big one) → C1 → C2 → E.
+
+---
+
+## 2. A sprite-based flare, as its own effect
+
+Blessed explicitly by the owner alongside entry 1: an **Optical Flares-style** effect that
+is not physically derived at all. No bright pass and no ray tracing — a light **position**
+(px@comp, animatable and trackable) drives a designer-authored stack of elements, each
+placed along the line from the light through frame centre at its own offset, scale, tint
+and opacity: glow, iris ghosts, halo ring, streak, starburst. Deterministic on video, zero
+flicker, art-directable, and cheap (one pass of N procedural quads).
+
+This is a **new effect** in [08-EFFECTS.md](08-EFFECTS.md) §3, not a mode of the physical
+one — the two answer different questions and mixing them is what made the plan muddled the
+first time. Its element stack is data (a preset file), not shaders. The one genuinely new
+kernel it wants is the **anamorphic streak**: a Kawase streak filter — downsample ~1/16,
+then 3–4 passes each sampling 4 taps along the streak direction at distance 4^pass, weight
+`a^(b·dist)`, attenuation ~0.9–0.95
+([Oat](https://www.chrisoat.com/papers/Oat-ScenePostprocessing.pdf)) — a directional
+variant of blur passes the engine already has, and useful to the physical flare too.
+
+---
+
+## 3. Harden Matte detection on footage (small, do early)
 
 Matte mode already has half of what the literature asks for: the luma gate is soft
-(`threshold` + `threshold_softness`, `lens_flare::threshold_gate`), and K-267's tile
-flux summing already weighs an area source as its area rather than one pixel. What
-still flickers on video, and the fixes
-([Froyok's UE writeup](https://www.froyok.fr/blog/2021-09-ue4-custom-lens-flare/),
-[LearnOpenGL PBB](https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom)):
+(`threshold` + `threshold_softness`, `lens_flare::threshold_gate`), and K-267's tile flux
+summing already weighs an area source by its area rather than one pixel. What still
+flickers on video, and the fixes:
 
-1. **Fireflies** — a single hot pixel (sensor sparkle, specular glint) rides the tile
-   sum and pops a source for one frame. The Karis-average idea, adapted to the
-   detector: weight each pixel's contribution to its tile's flux by `1/(1+luma)`, so
-   one outlier cannot own the anchor. Same formula in `detect_lights` (the CPU twin)
-   and the WGSL reduction, or the matte-mode frame oracle fails — which is the test.
-2. **Anchor jumping** — a source's anchor position quantises to its brightest pixel,
-   which wanders inside the practical frame to frame. A flux-weighted centroid over
-   the anchor's tiles (still deterministic, still index-ordered summation per §2.4)
-   steadies the position without any cross-frame state.
+1. **Fireflies** — a single hot pixel (sensor sparkle, a specular glint) rides the tile sum
+   and pops a source for one frame. Adapt the Karis-average idea to the detector: weight
+   each pixel's contribution to its tile's flux by `1/(1+luma)`, so one outlier cannot own
+   the anchor. The same formula must land in `detect_lights` (the CPU twin) and the WGSL
+   reduction, or the matte-mode frame oracle fails — which is the test.
+2. **Anchor jumping** — a source's anchor quantises to its brightest pixel, which wanders
+   inside the practical frame to frame. A flux-weighted centroid over the anchor's tiles
+   (still deterministic, still index-ordered summation per §2.4) steadies it without any
+   cross-frame state.
 
 **Temporal smoothing is a recorded non-option**, not an oversight: a frame must be a
-function of the document and the frame alone (docs/14 determinism; the caches name
-frames on exactly that promise), and a detector that remembers the previous frame
-breaks random access, export/preview identity and the frame oracle in one move. The
-footage answer to "the threshold pops" is the Manual/Lights element path (entries 1
-and 3), not history buffers.
+function of the document and the frame alone (docs/14 determinism; the caches name frames
+on exactly that promise), and a detector that remembers the previous frame breaks random
+access, preview/export identity and the frame oracle in one move. The footage answer to
+"the threshold pops" is entry 1's Phase D — real source regions with real flux — not
+history buffers.
 
-This entry must not land before the bit-stability blocker (entry 0) is understood —
-it edits the passes under suspicion, and would muddy the bisect.
-
-## 3. Light layers, and area lights via LTC
+## 4. Light layers, and area lights via LTC
 
 **What exists:** nothing in the model — `LayerKind` has no Light; the flare reserves
 Lights mode "until light layers land (K-257)"; the roadmap parks lights in Phase 5.
@@ -190,7 +390,7 @@ one lit quad and asserting the gradient's monotonic falloff and its peak under t
 light's centre; determinism (two renders, identical bytes); a no-lights comp renders
 byte-identical to today (the pass must be a true no-op when absent).
 
-## 4. Light wrap — the cheapest "light meets footage" feature that exists
+## 5. Light wrap — the cheapest "light meets footage" feature that exists
 
 The compositing classic for keyed foregrounds: blur the *background*, mask it by the
 inverted-and-blurred alpha edge of the foreground, screen it back over the edges — the
@@ -207,7 +407,7 @@ footage layers" entry describes the same below-stack plumbing; whichever lands f
 digs the tunnel the other reuses). CPU oracle + WGSL kernel + arb/engine-label strings
 + an 08-EFFECTS §3 entry.
 
-## 5. Viewer bar completion — the two owed halves of what just landed
+## 6. Viewer bar completion — the two owed halves of what just landed
 
 Natural follow-ups to K-352 and the resolution dropdown, both small and both already
 specified in docs/07 §2.2:
@@ -222,7 +422,7 @@ specified in docs/07 §2.2:
   undoable, unlike the looks) plus quick black/white/checker. The checker option is
   K-352's flag; the swatch is the first UI for `comp.background` at all.
 
-## 6. Region of interest (docs/07 §2.2 item 7)
+## 7. Region of interest (docs/07 §2.2 item 7)
 
 Drag a rectangle; the engine composites only that region. The realiser already
 composites at a scaled raster (K-186 / the preview-scale work), so the mechanism is a
@@ -238,17 +438,28 @@ while a region is set; folding is better, scrubbing inside a region is the use c
 
 | # | Entry | Why this position |
 |---|-------|-------------------|
-| 1 | 0 — flare bit-stability | Blocks honest validation of 1 and 2 |
-| 2 | 2 — bright-pass hardening | Small, immediate payoff on footage, de-risks 1 |
-| 3 | 5 — viewer bar completion | Small, finishes surfaces this week opened |
-| 4 | 1 — flare element stack | The headline; slice it (streak → stack → starburst) |
-| 5 | 3a/3b — Light layer + flare wiring | Model decision first, wiring is cheap |
-| 6 | 4 — light wrap | Anytime after its below-stack plumbing exists |
-| 7 | 3c — LTC area lights | The deep cut; lands on a model already proven by 3b |
-| 8 | 6 — region of interest | Independent; whenever the Viewer is next open |
+| — | 0 — flare bit-stability | **Landed** (K-353). Everything else assumes it |
+| 1 | 3 — harden Matte detection | Small, immediate payoff on footage, touches the passes while they are fresh |
+| 2 | 6 — viewer bar completion | Small, finishes the surfaces the Viewer work just opened |
+| 3 | 1·A1 + 1·A2 — coatings and spectral radiometry | Free accuracy: CPU bakes, no per-frame budget, fixes ghost colour |
+| 4 | 4a/4b — Light layer + flare Lights mode | Model decision first (a `03-DATA-MODEL` change), wiring is cheap after |
+| 5 | 1·B2 — field-angle starburst | A bake with a big visual payoff; independent of the ray work |
+| 6 | 1·D4 + 1·D2 — source regions, shift-invariant glare | Real flux from footage, plus the free half of area sources |
+| 7 | 1·D — per-ghost warped convolution | **The headline for footage**: ghosts become images of the source |
+| 8 | 5 — light wrap | Anytime after its below-stack plumbing exists |
+| 9 | 1·B1 — dense grid + per-ray splatting | The big one; retires the quad/sliver machinery. Its own PR |
+| 10 | 4c — LTC area lights | Lands on a Light model already proven by 4b |
+| 11 | 2 — sprite-based flare effect | Independent of all of it; a separate effect entirely |
+| 12 | 7 — region of interest | Independent; whenever the Viewer is next open |
+| 13 | 1·C1, 1·C2 — four-bounce, Fresnel ringing | The last accuracy percent; C2 is the hardest item here |
+| 14 | 1·E — calibration and invertibility | Only if flare *removal* is genuinely a goal |
 
-Skipped deliberately, so they are not re-proposed: per-frame FFT diffraction and full
-lens simulation (offline-class cost), temporal history buffers for flare smoothing
-(tracked positions make them unnecessary), ML relighting (non-deterministic, wrong
-weight class), representative-point sphere/tube lights (LTC covers the rect case a
-compositor actually needs; add spheres only if a use case shows up).
+Skipped deliberately, so they are not re-proposed: **paraxial and polynomial-optics lens
+models** (Lee & Eisemann 2013, Hullin 2012, Bodonyi 2025 — speed devices that cost accuracy
+and buy nothing at 2 s/frame); **precomputed flare-field interpolation across source
+positions** (Hullin's team tried warping precomputed flares and reported failure); **a
+global source ⊛ PSF convolution for ghosts** (measurably wrong — flare is shift-variant,
+Talvala 2007); **temporal history buffers** for flare smoothing (they break the determinism
+the caches are named on); **ML relighting** (non-deterministic, wrong weight class);
+**representative-point sphere/tube lights** (LTC covers the rect case a compositor needs;
+add spheres only if a use case shows up).

--- a/docs/NEXT-FEATURES.md
+++ b/docs/NEXT-FEATURES.md
@@ -311,15 +311,20 @@ Matte mode already has half of what the literature asks for: the luma gate is so
 summing already weighs an area source by its area rather than one pixel. What still
 flickers on video, and the fixes:
 
-1. **Fireflies** — a single hot pixel (sensor sparkle, a specular glint) rides the tile sum
-   and pops a source for one frame. Adapt the Karis-average idea to the detector: weight
-   each pixel's contribution to its tile's flux by `1/(1+luma)`, so one outlier cannot own
-   the anchor. The same formula must land in `detect_lights` (the CPU twin) and the WGSL
-   reduction, or the matte-mode frame oracle fails — which is the test.
-2. **Anchor jumping** — a source's anchor quantises to its brightest pixel, which wanders
-   inside the practical frame to frame. A flux-weighted centroid over the anchor's tiles
-   (still deterministic, still index-ordered summation per §2.4) steadies it without any
-   cross-frame state.
+1. ~~**Anchor jumping**~~ — **landed as K-354.** Each anchor now takes the flux-weighted
+   centroid of the tiles feeding it, so a source spanning several tiles is found at the
+   centre of its light rather than at whichever corner the tile scan reached first. Point
+   sources are untouched.
+2. **Fireflies — still open, and the first plan for it was wrong.** A single hot pixel
+   (sensor sparkle, a specular glint) still owns its tile and so still pulls both the flux
+   and the K-354 centroid toward itself, frame to frame. The draft here proposed a Karis
+   `1/(1+luma)` weighting, which assumes a per-pixel *sum* the detector does not have: a
+   tile is represented by its single brightest pixel, for position and for flux. The real
+   fix is to make each tile carry **its whole gated flux and its own centroid** instead of
+   one pixel's — a change to the tile reduction in both twins (the workgroup merge stays a
+   fixed-order sum, so determinism is unaffected). That is the same information Phase D's
+   source regions need, so **do it there rather than twice**: it is listed here only so the
+   gap is not mistaken for a fixed one.
 
 **Temporal smoothing is a recorded non-option**, not an oversight: a frame must be a
 function of the document and the frame alone (docs/14 determinism; the caches name frames

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,16 +17,6 @@ this file is the concrete backlog underneath it.
 
 These sit above everything else: they are what the editor feels like in the hand.
 
-- **The lens flare is not bit-stable on this machine, today.**
-    `lumit-gpu`'s `fx::tests::wgsl_lens_flare_matches_the_cpu_frame_reference_and_neutrals`
-    fails its own "GPU lens flare must be bit-stable" assertion on a clean `main`
-    (checked 2026-08-08 by stashing every local change and running it alone): two
-    runs of the same flare give different pixels. Bit-stability is the property
-    the whole additive-blend draw order exists to protect
-    ([impl/lens-flare.md](impl/lens-flare.md) §2.4), so this is a real
-    regression and not a flaky test - and it means the two flare performance
-    items below cannot be measured honestly until it is understood. Find which
-    stage varies before changing anything.
 - **The flare's raster still draws the cells it culled.** After K-263 a batch
     draws exactly its own cells, but a cell the guards kill is still stored and
     still submitted as a degenerate off-screen triangle. Compacting to just the

--- a/docs/impl/lens-flare.md
+++ b/docs/impl/lens-flare.md
@@ -63,10 +63,31 @@ n(λ) = A + B/λ²
 This reproduces n_d and the Abbe number exactly, which is all the flare can see.
 
 **Reflectance.** Bare glass is unpolarised Fresnel by incidence cosine. A coated surface
-is the Airy two-interface summation for a single MgF₂ (n 1.38) quarter-wave layer tuned
-at 550 nm; each extra layer quarters the residual (the FlareSim multicoat
-approximation). The Coating dial blends bare → coated per surface, so 0 is a vintage
-uncoated look and 1 the prescription's own character.
+is a real multi-layer stack solved by the **characteristic transfer matrix** (K-356,
+superseding the single-layer-times-a-quarter approximation): per layer
+`δ = 2π n d cos θ / λ` and `η = n cos θ` (s) or `n / cos θ` (p), matrices
+`[[cos δ, i sin δ/η], [i η sin δ, cos δ]]` chained and closed on the substrate for
+`Y = C/B`, `r = (η₀ − Y)/(η₀ + Y)`, both polarisations meaned. The Coating dial blends
+bare → coated per surface, so 0 is a vintage uncoated look and 1 the prescription's own
+character.
+
+**Why it is worth the matrix.** `δ` carries a `cos θ`, so the reflectance band shifts blue
+as the angle of incidence rises — and flare rays strike interfaces at large, varied angles.
+That is the observed effect a scalar cannot express: **a ghost changes hue as its source
+crosses the frame.** A single-layer coating has one reflectance minimum and can only tint
+ghosts one way; a real multicoat has two or more, which is where the magenta/green/amber
+character of a modern lens comes from.
+
+A `.lens` file gives a layer *count*, never the recipe (real designs are trade secrets, and
+the literature is unanimous that coatings can only be measured), so `coating_stack` maps the
+count to that order's textbook design: MgF₂ quarter, V-coat, the classic broadband
+quarter/half/quarter W, then alternating quarter-wave pairs. The shape is the point, not the
+recipe; per-lens calibration is Phase E of NEXT-FEATURES entry 1 and out of scope here.
+
+One trap worth recording: **do not benchmark coatings on n ≈ 1.9 glass.** MgF₂ is very
+nearly the ideal single layer there (1.38² = 1.904), so a single layer beats any stack at
+the design wavelength — a coincidence of that glass, not a property of coatings. The oracle
+compares on ordinary n = 1.5 crown.
 
 ## 2. Ghost pairs: enumeration, filter, ranking
 
@@ -528,8 +549,12 @@ the other cannot silently clamp to Divide.
 
 1. **FFT**: round trip, 8-point DFT match, Parseval (ortho).
 2. **Optics units**: Cauchy reproduces (n_d, V); Snell at 45°; TIR returns None;
-   normal-incidence Fresnel = ((n1−n2)/(n1+n2))²; the MgF₂ quarter-wave cuts bare-glass
-   reflectance and each extra layer cuts it further; Coating 0 is bare glass exactly.
+   normal-incidence Fresnel = ((n1−n2)/(n1+n2))². Coatings on n = 1.5 crown (K-356): a
+   single layer beats bare glass and the broadband stack beats the single layer; the stack
+   is wavelength-selective (>3× across the visible, which is what colours ghosts) and
+   angle-dependent (53° reflects >1.5× normal incidence, which is what makes a ghost change
+   hue off axis); an empty stack equals bare Fresnel, so the matrix chain closes; Coating 0
+   is bare glass exactly.
 3. **Library**: all 1299 files parse with sane focal lengths (2..2000 mm), surface
    counts (3..64) and positive semi-apertures; the bake is deterministic (pairs, sprite,
    gain bit-equal across runs); every ranked pair indexes real surfaces.

--- a/docs/impl/lens-flare.md
+++ b/docs/impl/lens-flare.md
@@ -237,12 +237,31 @@ boundary to be visible. **A cell stores four corners at 20 bytes, once** (K-263)
 through K-262 it wrote the two triangles' six vertices at 32 bytes each — and the
 raster's vertex shader maps its six vertex indices onto them (`corner_of`, the index
 buffer spelled in the shader). Same triangles, same winding, same primitive order, 2.4×
-less vertex memory written and read. **The raster is 4× multisampled (K-264)**, with a
-resolve into the flare buffer: triangle silhouettes were the jagged edges in the
-owner's Ultra report, and coverage sampling smooths them for a cost that is a rounding
-error beside the trace. The CPU reference models the SAME four standard sample
-positions (coverage × centre-interpolated colour, `MSAA_SAMPLES`), which is what keeps
-the frame oracle tight rather than merely close.
+less vertex memory written and read. **The raster is single-sampled and computes its own
+coverage (K-353, superseding K-264's hardware multisampling)**. Triangle silhouettes were
+the jagged edges in the owner's Ultra report and are still smoothed at the same four
+standard sample positions — but the fragment evaluates them itself rather than asking the
+rasteriser. Barycentric coordinates are affine in screen position, so `dpdx`/`dpdy` of
+them are exact; a fragment reconstructs its barycentric at each sample offset and takes
+`colour × covered/4`, which is *precisely* what the CPU reference's `raster_triangle`
+already did with `MSAA_SAMPLES`. The oracle therefore agrees with the GPU by construction.
+
+**Why the hardware path had to go:** additively blending fp16 into a 4× multisample target
+is not reproducible run to run on this hardware, and that — not the draw order, not the
+bake, not the pools — is what failed the §2.4 bit-stability assertion for months (K-353
+has the full measurement). Two consequences of doing coverage this way are load-bearing:
+
+- **Every triangle is widened by a pixel before rasterising**, because a single-sampled
+  rasteriser only makes a fragment where the pixel *centre* is covered, and a cell can
+  cover sample positions without covering any centre. The fragment's coverage test then
+  discards the padding. Without this a third of the flare's energy simply vanished.
+- **The widening displaces the two edge lines and re-intersects them**, rather than pushing
+  each corner away from the centroid. A fold cell is a *sliver* whose corners are nearly
+  collinear, so "away from the centroid" points along it and never widens the thin axis —
+  the last 3% of missing energy, which the padded-anamorphic test caught.
+
+Gone with the multisample target: the ~66 MB pooled 4-sample texture (K-265) and the
+resolve.
 
 The combine's flare tap is ZERO outside the buffer (K-266): squeeze or scale
 below 1 asks for coordinates past it, and clamp-addressing repeated the edge

--- a/docs/impl/lens-flare.md
+++ b/docs/impl/lens-flare.md
@@ -387,10 +387,40 @@ eye) — deviation D5, kept from K-256.
 
 Shipped in the K-257 pass as the **Matte** source mode (docs/08 §3.27): the flare
 sources itself from a referenced layer's picture. A compute reduction tiles the matte
-into a 32 px grid (max Rec. 709 luma + argmax per tile; ties to the lowest linear index;
-fixed-order partial merges, so it is deterministic), then a single-thread pass picks the
-top-16 ANCHOR tiles by luma (`MAX_LIGHTS`, 8 → 16 in K-267) with a 2-tile Chebyshev
-non-max suppression, each gated by the soft Threshold. **Area sources (K-267): every
+into a 32 px grid, then a single-thread pass picks the top-16 ANCHOR tiles by luma
+(`MAX_SOURCES`, 8 → 16 in K-267) with a 2-tile Chebyshev non-max suppression, each gated
+by the soft Threshold.
+
+**Each tile carries the statistics of its whole lit area, not one pixel (K-355)** — the
+maximum luma and its argmax (still how anchors are *ranked*, so a small bright source is
+still found), plus `Σ gate`, `Σ colour·gate`, and `Σ luma·gate` with its first moments
+`Σ x·luma·gate` / `Σ y·luma·gate`. This is what stopped flares **jumping** on footage:
+representing a tile by its brightest pixel meant the light's position was decided by a
+lottery that sensor noise and specular sparkle re-ran every frame, so a flare twitched
+across a practical that had not moved. A source's position is now the flux centroid of
+every lit pixel feeding it and its colour their mean, neither of which one pixel can
+move; a 40× sparkle shifts a 64 px source by under a pixel (pinned by
+`lens_flare_centres_an_area_source_on_its_light`). Point sources are untouched — a single
+lit pixel is its own centroid and its own mean.
+
+The per-tile sums are order-dependent where the old maximum was not, so the CPU (row order
+within a tile) and the GPU (64 partials merged in thread order) agree to the matte oracle's
+perceptual bound rather than op-for-op. Each is internally deterministic in fixed order,
+which is the §2.4 property that matters.
+
+**Area sources are sampled, not approximated (K-355).** Each anchor's second moments give
+its half-extent — the standard deviation of its flux about its centre — and a source wider
+than `AREA_MIN_EXTENT` of the frame is split into a centred regular grid of up to
+`AREA_SAMPLES_MAX²` samples, each carrying an equal share of the flux. The flare of an
+extended source *is* the integral of the point flares across it, and the ~2 s/frame budget
+(docs/NEXT-FEATURES.md entry 1) affords evaluating that directly: the sum carries the
+source's shape, so a tube's ghosts are bars and a window's rectangles. Energy is conserved
+by construction — the shares sum to one light — so splitting only smooths. The grid is
+regular and unjittered, so K-353's bit-stability survives. `MAX_LIGHTS` is therefore 64
+slots against `MAX_SOURCES` 16 distinct sources; a source that cannot be split within the
+remaining slots is carried as the single point it started as rather than as a fraction of
+itself. Manual mode gets the same by dial (**Source width** / **Source height**, px@comp
+half-extents, default 0). **Area sources (K-267): every
 gated tile's flux then accumulates onto its nearest anchor** — per tile, `(use source ?
 the tile's brightest pixel's RGB : white) × the gate`, nearest by Chebyshev with ties to
 the lowest anchor index, tiles visited in index order so the float sum matches the CPU

--- a/flutter_ui/lib/l10n/app_en.arb
+++ b/flutter_ui/lib/l10n/app_en.arb
@@ -1449,6 +1449,14 @@
   "@fxSource": {
     "description": "Effect controls — a control on Matte key."
   },
+  "fxSourceHeight": "Source height",
+  "@fxSourceHeight": {
+    "description": "Effect controls — a control on Lens flare. Half the height of the light itself, in pixels: 0 is a point of light, larger makes it a panel or a strip whose flare takes that shape."
+  },
+  "fxSourceWidth": "Source width",
+  "@fxSourceWidth": {
+    "description": "Effect controls — a control on Lens flare. Half the width of the light itself, in pixels: 0 is a point of light, larger makes it a panel or a strip whose flare takes that shape."
+  },
   "fxSpin": "Spin",
   "@fxSpin": {
     "description": "Effect controls — a control on Radial blur."

--- a/flutter_ui/lib/l10n/engine_labels.dart
+++ b/flutter_ui/lib/l10n/engine_labels.dart
@@ -221,6 +221,8 @@ Map<String, String> get _table => {
       "Soft light": l10n.fxSoftLight,
       "Softness": l10n.fxSoftness,
       "Source": l10n.fxSource,
+      "Source height": l10n.fxSourceHeight,
+      "Source width": l10n.fxSourceWidth,
       "Spin": l10n.fxSpin,
       "Starburst intensity": l10n.fxStarburstIntensity,
       "Status": l10n.fxStatus,


### PR DESCRIPTION
Stacked on #93 — GitHub will retarget this to `main` once that merges. The diff shown is this branch's own work.

## The bit-stability blocker is fixed (K-353)

`docs/TODO.md` carried this as the standing blocker in **Now**: the lens flare failed its own "GPU lens flare must be bit-stable" assertion on a clean `main`, and the entry said to *find which stage varies before changing anything*. So that is what happened, and the cause was in none of the suspected places.

What was measured, in order:

| Suspect | Result |
|---|---|
| The ray trace | **Innocent** — the trace oracle hook reads the ray landings back; bit-identical every run |
| Ghost blur | Innocent — switching it off leaves the variance untouched |
| Starburst | Innocent — same |
| Accumulation depth | Not it — survives down to a single ghost, one wavelength, minimum detail |
| Scratch / MSAA pooling | Not it — fresh allocations every frame change nothing |
| **Sample count** | **This.** The identical frame through a single-sampled pipeline is bit-identical across six configurations, four runs each |

**Additively blending fp16 into a 4× multisample target is not reproducible on this hardware.** A few hundred of 36864 floats came back one fp16 ULP different each run, in different places each time.

### The fix keeps the antialiasing and drops the hardware

K-264 added multisampling because jagged ghost silhouettes were one of the three Ultra artefacts, so that reason still stands — the coverage is now *computed* rather than sampled. Barycentric coordinates are affine in screen position, so `dpdx`/`dpdy` of them are exact; a fragment reconstructs its own barycentric at each of the four standard sample positions and takes `colour × covered/4`. That is precisely the model `lumit_core`'s `raster_triangle` already spelled out as the CPU twin, so **the oracle now agrees with the GPU by construction** rather than by resembling a hardware resolve.

Two details are load-bearing, and both cost real energy when I got them wrong first:

- A single-sampled rasteriser only makes a fragment where the pixel **centre** is covered, but a cell can cover sample positions without covering any centre. Triangles are therefore widened by a pixel before rasterising and the fragment's own test discards the padding. Without it **a third of the flare's energy vanished**.
- The widening displaces the two **edge lines** and re-intersects them, rather than pushing corners away from the centroid. A fold cell is a *sliver* whose corners are nearly collinear, so "away from the centroid" runs along it and never widens the thin axis — that was the last 3% of missing energy, which the padded-anamorphic test caught.

Also gone: the ~66 MB pooled 4-sample texture (K-265) and the resolve.

### Tests

`the_flare_renders_the_same_frame_every_time` renders four times across six configurations that switch each stage off in turn, asserting both bit-identity **and** that the frame is not empty — a configuration that renders nothing is trivially stable, which is exactly how my first attempt at this measurement fooled itself into a wrong conclusion. All 12 flare tests pass on a real adapter; `cargo fmt` and `clippy` clean.

## The plan for entry 1 was rewritten

After the owner set the budget: the physically based flare is to be done **properly at roughly 2 s/frame**, not approximated down to milliseconds, and a sprite-based flare is welcome as a **separate effect** rather than a replacement. The first draft of `docs/NEXT-FEATURES.md` recommended the opposite trade and was wrong.

Entry 1 is now a phased programme with the numbers to judge each phase: multi-layer AR coatings by transfer matrix (the biggest correctness gain per line of code — it is what fixes ghost hue shifting across the field), 81-sample spectral radiometry against the CIE curves, a dense adaptive ray grid with per-ray splatting replacing interpolated quads, a field-angle-dependent starburst accounting for cat's-eye pupil clipping, energy-ranked four-bounce paths, and fractional-Fourier ghost propagation for the Fresnel ringing every real-time implementation drops.

**Phase D is the area-source answer** and the part worth reading twice. Flare from an extended source is *not* the convolution of the source with a point PSF — that was measured and published as false (Talvala et al., SIGGRAPH 2007), because a ghost moves at a different rate than its source. But each ghost path is an imaging system whose map is locally affine, so **per ghost it is an exact convolution**: the point-ghost kernel against the source's radiance map warped by that ghost's Jacobian. A neon tube's ghosts become elongated bars, a window's become rectangles. Cost is milliseconds and independent of source area. Monte Carlo (the *Lego Movie 2* estimator) becomes the test oracle rather than the default, and stays the answer for occlusion, which genuinely is not linear in the source.

The doc also records **what not to build**, with reasons — paraxial and polynomial-optics models, precomputed flare-field interpolation, global source-convolution for ghosts, and temporal history buffers (which would break the determinism the frame caches are named on).

## Note on the PR grouping

We agreed to group PRs by theme, with the flare group covering entries 0, 2 and 1. Entry 1 has since become a multi-phase programme rather than a single change, so this PR carries the blocker fix and the plan; the phases will come as their own PRs against the ordering in `NEXT-FEATURES.md`.

No new strings.
