### PR TITLE
FFmpeg 8.1 migration — parked until macOS has a route to 8.x

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,8 +8,8 @@
 # before a fresh clone would build. Two of them did.
 #
 # The arrangement now: each platform points the build at FFmpeg from outside this file.
-# macOS exports FFMPEG_PKG_CONFIG_PATH at the keg-only ffmpeg@7 (CI does it per job,
-# developers per shell — docs/GUIDE.md §8). Linux needs nothing: the distro's FFmpeg 7
+# macOS exports FFMPEG_PKG_CONFIG_PATH at the Homebrew ffmpeg formula (CI does it per job,
+# developers per shell — docs/GUIDE.md §8). Linux needs nothing: the distro's FFmpeg 8
 # development packages sit on pkg-config's default search path, which is exactly what
 # rusty_ffmpeg probes when the variable is unset. Windows uses FFMPEG_LIBS_DIR /
 # FFMPEG_INCLUDE_DIR (rusty_ffmpeg's pkg-config branch is cfg(not(windows)), so it never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,34 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      # ffmpeg@7 is keg-only, so pkg-config cannot find it on its default search
-      # path; the build is pointed at the keg explicitly. This lives here, not in
-      # .cargo/config.toml, because Cargo's [env] has no per-target form and the
-      # macOS path injected on Linux made rusty_ffmpeg's build script panic (K-204).
-      - name: Install FFmpeg (keg-only) and point pkg-config at it
+      # Homebrew has no ffmpeg@8 formula (checked: only @2.8, @4, @5, @6, @7),
+      # and the plain `ffmpeg` formula is already 9.x, which no published rsmpeg
+      # supports — macOS currently has NO route to 8.x from Homebrew's bottles.
+      # This job is therefore red until either homebrew-core ships ffmpeg@8 or
+      # `brew extract --version=8.x ffmpeg <tap>` (an 8-series formula pulled
+      # from Homebrew's own history, built from source) is proven on a Mac —
+      # this branch stays a draft PR until one of those lands. The version gate
+      # below is
+      # the load-bearing part: rsmpeg's `ffmpeg8` feature generates bindings for
+      # avcodec 62 / avutil 60, and linking those against any other major is a
+      # struct-layout mismatch, not a warning. Pointing at the keg from here
+      # rather than .cargo/config.toml stays deliberate (K-204): Cargo's [env]
+      # has no per-target form, and the macOS path injected on Linux made
+      # rusty_ffmpeg's build script panic.
+      - name: Install FFmpeg 8 and check the major matches the crate feature
         run: |
-          brew install ffmpeg@7
-          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install ffmpeg
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig" >> "$GITHUB_ENV"
+          major="$(brew list --versions ffmpeg | awk '{print $2}' | cut -d. -f1)"
+          [ "$major" = "8" ] || {
+            echo "::error::Homebrew ffmpeg is $major.x; crates/lumit-media pins rsmpeg's ffmpeg8 feature."
+            echo "::error::Fix by installing ffmpeg@8 once Homebrew ships it, or move the crate feature."
+            exit 1
+          }
       - name: FFmpeg version for the cache key (Cellar paths are versioned;
               a cached rusty_ffmpeg build script must not outlive its keg)
         id: ffver
-        run: echo "v=$(brew list --versions ffmpeg@7 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "v=$(brew list --versions ffmpeg | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - uses: Swatinem/rust-cache@v2
         with:
           key: ffmpeg-${{ steps.ffver.outputs.v }}
@@ -60,25 +76,25 @@ jobs:
     runs-on: windows-latest
     env:
       # BtbN "shared, GPL" build: GPL matches Lumit's licence, shared gives the
-      # import libs + DLLs rsmpeg links against, n7.1 matches the macOS keg ffmpeg@7.
-      # Pinned to a dated autobuild, not the rolling "latest" tag: latest rotated
-      # its n7.1 assets out on 2026-08-17 and every job 404'd. A dated tag's
-      # assets are immutable; moving to FFmpeg 8 is a crate-feature migration,
-      # not a URL edit.
-      FFMPEG_ASSET: ffmpeg-n7.1.1-6-g48c0f071d4-win64-gpl-shared-7.1
+      # import libs + DLLs rsmpeg links against, n8.1 matches the crate's
+      # `ffmpeg8` feature. Pinned to a dated autobuild, not the rolling "latest"
+      # tag: latest rotated its n7.1 assets out on 2026-08-17 and every job 404'd.
+      # A dated tag's assets are immutable, so re-pin deliberately rather than
+      # tracking a moving URL.
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-shared-8.1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      # FFmpeg 7.1 dev libs for lumit-media. rusty_ffmpeg links the import libs in
+      # FFmpeg 8.1 dev libs for lumit-media. rusty_ffmpeg links the import libs in
       # FFMPEG_LIBS_DIR and reads headers from FFMPEG_INCLUDE_DIR (it ignores
       # pkg-config on Windows); the DLLs and the ffmpeg CLI (test fixtures) go on
       # PATH. See docs/impl/phase-0-kickoff.md slice 4 and docs/GUIDE.md.
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         shell: pwsh
         run: |
-          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-04-30-13-13/$env:FFMPEG_ASSET.zip"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/$env:FFMPEG_ASSET.zip"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
           Expand-Archive "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
           $root = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
@@ -126,10 +142,10 @@ jobs:
     name: tests (Linux, with media)
     runs-on: ubuntu-latest
     env:
-      # The same BtbN "shared, GPL" n7.1 build the Windows job takes, so all
+      # The same BtbN "shared, GPL" n8.1 build the Windows job takes, so all
       # three platforms link an identical FFmpeg. The distro's own is 6.x,
-      # which the crate's `ffmpeg7_1` feature does not match.
-      FFMPEG_ASSET: ffmpeg-n7.1.1-6-g48c0f071d4-linux64-gpl-shared-7.1
+      # which the crate's `ffmpeg8` feature does not match.
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-linux64-gpl-shared-8.1
       # This runner installs Mesa's lavapipe below, so every GPU test MUST run
       # here: a missing adapter is a broken runner, not a machine without a
       # graphics card, and `lumit_gpu::no_adapter` turns the polite skip into a
@@ -160,9 +176,9 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev \
             libx11-dev libxcursor-dev libxi-dev libxrandr-dev libxcb1-dev \
             libwayland-dev mesa-vulkan-drivers libclang-18-dev
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         run: |
-          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-04-30-13-13/${FFMPEG_ASSET}.tar.xz"
+          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
@@ -178,7 +194,7 @@ jobs:
           # leaves the variable unset. Exporting the override here was masking
           # exactly that — it is how a broken .cargo/config.toml passed CI while
           # every fresh Linux clone failed. Adding to PKG_CONFIG_PATH exercises
-          # the contributor's code path with a pinned FFmpeg 7.1 (the runner's
+          # the contributor's code path with a pinned FFmpeg 8.1 (the runner's
           # own distro still ships FFmpeg 6, so the tarball stays).
           echo "PKG_CONFIG_PATH=$root/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$root/lib" >> "$GITHUB_ENV"
@@ -217,9 +233,9 @@ jobs:
     name: flutter frontend (Linux build + analyze + test)
     runs-on: ubuntu-latest
     env:
-      # The same BtbN "shared, GPL" n7.1 build the other jobs take, so the
+      # The same BtbN "shared, GPL" n8.1 build the other jobs take, so the
       # bridge .so links the identical FFmpeg lumit-media expects.
-      FFMPEG_ASSET: ffmpeg-n7.1.1-6-g48c0f071d4-linux64-gpl-shared-7.1
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-linux64-gpl-shared-8.1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -241,11 +257,11 @@ jobs:
           # EGL/egl*.h + egl.pc. The Linux zero-copy Viewer plugin
           # (linux/runner/viewer_texture_bridge.cc, K-177) imports engine DMA-BUF
           # frames into GL external textures, so it links EGL + GLESv2.
-      # Same FFmpeg 7.1 install the `linux` job uses (its .pc prefix rewrite +
+      # Same FFmpeg 8.1 install the `linux` job uses (its .pc prefix rewrite +
       # env exports), so the bridge's `media` feature links here identically.
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         run: |
-          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-04-30-13-13/${FFMPEG_ASSET}.tar.xz"
+          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
@@ -352,20 +368,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      # Same keg-only FFmpeg the macOS Rust jobs install. The build_pod.sh phase
+      # Same FFmpeg formula the macOS Rust jobs install (the `check` job carries
+      # the version gate and why there is no ffmpeg@8). The build_pod.sh phase
       # inside the Xcode build compiles the bridge crate, so rusty_ffmpeg needs
-      # the same formula here, and the podspec's -L flags need the keg present.
-      # The keg is not on pkg-config's default search path, so point the build at
-      # it explicitly, exactly as the `check` and `coverage` jobs do (K-204).
-      # Xcode's build environment inherits this from $GITHUB_ENV; it is not
-      # supplied by .cargo/config.toml, which deliberately sets no [env] block.
-      - name: Install FFmpeg (keg-only) and point pkg-config at it
+      # the same formula here, and the podspec's -L flags need it present. The
+      # explicit pkg-config path stays for the same reason as the `check` and
+      # `coverage` jobs (K-204). Xcode's build environment inherits this from
+      # $GITHUB_ENV; it is not supplied by .cargo/config.toml, which
+      # deliberately sets no [env] block.
+      - name: Install FFmpeg and point pkg-config at it
         run: |
-          brew install ffmpeg@7
-          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install ffmpeg
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: FFmpeg version for the cache key
         id: ffver
-        run: echo "v=$(brew list --versions ffmpeg@7 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "v=$(brew list --versions ffmpeg | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - uses: Swatinem/rust-cache@v2
         with:
           key: ffmpeg-${{ steps.ffver.outputs.v }}
@@ -397,7 +414,7 @@ jobs:
       # (x86_64 + arm64), and on an arm64 runner the x86_64 slice counts as
       # cross-compilation, which pkg-config-rs refuses outright ("has not been
       # configured to support cross-compilation"). Forcing it with
-      # PKG_CONFIG_ALLOW_CROSS would be the wrong answer: Homebrew's ffmpeg@7 keg
+      # PKG_CONFIG_ALLOW_CROSS would be the wrong answer: Homebrew's ffmpeg
       # holds one architecture, so it would hand arm64 link flags to an x86_64
       # link. A universal build needs both kegs present and is out of scope for
       # this gate, which exists to compile the Swift runner and resolve the
@@ -438,7 +455,7 @@ jobs:
     name: bridge codegen is fresh (generate produces no diff)
     runs-on: ubuntu-latest
     env:
-      FFMPEG_ASSET: ffmpeg-n7.1.1-6-g48c0f071d4-linux64-gpl-shared-7.1
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-linux64-gpl-shared-8.1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -461,9 +478,9 @@ jobs:
             libxkbcommon-dev libxkbcommon-x11-dev \
             libx11-dev libxcursor-dev libxi-dev libxrandr-dev libxcb1-dev \
             libwayland-dev mesa-vulkan-drivers libclang-18-dev
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         run: |
-          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-04-30-13-13/${FFMPEG_ASSET}.tar.xz"
+          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
@@ -526,15 +543,15 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
-      # Keg-only, as in the `check` job above: point pkg-config at the keg here
-      # rather than in .cargo/config.toml (K-204).
-      - name: Install FFmpeg (keg-only) and point pkg-config at it
+      # As in the `check` job above (which carries the version gate): point
+      # pkg-config at the formula here rather than in .cargo/config.toml (K-204).
+      - name: Install FFmpeg and point pkg-config at it
         run: |
-          brew install ffmpeg@7
-          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install ffmpeg
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: FFmpeg version for the cache key
         id: ffver
-        run: echo "v=$(brew list --versions ffmpeg@7 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+        run: echo "v=$(brew list --versions ffmpeg | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - uses: Swatinem/rust-cache@v2
         with:
           key: ffmpeg-${{ steps.ffver.outputs.v }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@
 # continue-on-error, so a partial release is never published quietly.
 #
 # Toolchain steps mirror ci.yml's `windows` and `flutter-linux` jobs exactly
-# (same FFmpeg 7.1 shared build, same LLVM 18 pin, same Flutter 3.44.7); when
+# (same FFmpeg 8.1 shared build, same LLVM 18 pin, same Flutter 3.44.7); when
 # one changes, change the other.
 #
 # The macOS artefacts are Developer ID signed, notarised and stapled (K-310)
@@ -33,14 +33,14 @@ jobs:
     name: Windows installer
     runs-on: windows-latest
     env:
-      FFMPEG_ASSET: ffmpeg-n7.1-latest-win64-gpl-shared-7.1
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-win64-gpl-shared-8.1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         shell: pwsh
         run: |
-          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$env:FFMPEG_ASSET.zip"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/$env:FFMPEG_ASSET.zip"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
           Expand-Archive "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
           $root = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
@@ -94,7 +94,7 @@ jobs:
     name: Linux bundle
     runs-on: ubuntu-latest
     env:
-      FFMPEG_ASSET: ffmpeg-n7.1-latest-linux64-gpl-shared-7.1
+      FFMPEG_ASSET: ffmpeg-n8.1.2-44-g7c533d0f86-linux64-gpl-shared-8.1
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -107,9 +107,9 @@ jobs:
             libx11-dev libxcursor-dev libxi-dev libxrandr-dev libxcb1-dev \
             libwayland-dev mesa-vulkan-drivers libclang-18-dev \
             clang cmake ninja-build libgtk-3-dev
-      - name: Install FFmpeg 7.1 (BtbN shared build)
+      - name: Install FFmpeg 8.1 (BtbN shared build)
         run: |
-          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${FFMPEG_ASSET}.tar.xz"
+          url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-17-13-05/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
@@ -201,12 +201,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      # Mirrors ci.yml's `check` job: keg-only ffmpeg@7 found via the explicit
-      # pkg-config override (K-204).
-      - name: Install FFmpeg 7.1 and dylibbundler
+      # Mirrors ci.yml's `check` job, including the FFmpeg-8 problem it
+      # documents: Homebrew has no ffmpeg@8, so this takes the plain formula and
+      # will fail to link until one exists (K-389). The explicit pkg-config
+      # override stays either way (K-204).
+      - name: Install FFmpeg 8 and dylibbundler
         run: |
-          brew install ffmpeg@7 dylibbundler create-dmg
-          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg@7)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install ffmpeg dylibbundler create-dmg
+          echo "FFMPEG_PKG_CONFIG_PATH=$(brew --prefix ffmpeg)/lib/pkgconfig" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
       - uses: subosito/flutter-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ Lumit can check for updates and installs them automatically or when you want.
 ## Building from source
 
 Rust stable (pinned by `rust-toolchain.toml`) plus two external dependencies:
-**FFmpeg 7.x** for media, and **LLVM 18** for the binding generator — newer LLVM
+**FFmpeg 8.x** for media, and **LLVM 18** for the binding generator — newer LLVM
 silently generates broken bindings, so 18 is pinned on every platform.
 
 <details>
 <summary><b>Windows</b> (my primary development platform)</summary>
 
-Unzip a [BtbN FFmpeg 7.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)
+Unzip a [BtbN FFmpeg 8.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)
 under `%USERPROFILE%\ffmpeg\`, then:
 
 ```powershell
@@ -89,9 +89,9 @@ cargo test --workspace
 <summary><b>macOS</b></summary>
 
 ```sh
-brew install ffmpeg@7
-# The formula is keg-only, so point the build at it (K-204):
-export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"
+brew install ffmpeg  # see docs/TODO.md: Homebrew has no ffmpeg@8 yet, and plain ffmpeg is 9.x
+# Point the build at it (K-204):
+export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig"
 cargo test --workspace
 ```
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,12 +48,12 @@ Lumit 还想为创作者提供几个目标，让它足以满足你的所有剪�
 
 ## 构建
 
-需要 Rust 稳定版（由 `rust-toolchain.toml` 固定）外加两个外部依赖：用于媒体处理的 **FFmpeg 7.x**，以及用于绑定生成器的 **LLVM 18**——较新的 LLVM 会静默生成有问题的绑定，因此所有平台都固定在 18。
+需要 Rust 稳定版（由 `rust-toolchain.toml` 固定）外加两个外部依赖：用于媒体处理的 **FFmpeg 8.x**，以及用于绑定生成器的 **LLVM 18**——较新的 LLVM 会静默生成有问题的绑定，因此所有平台都固定在 18。
 
 <details>
 <summary><b>Windows</b></summary>
 
-在 `%USERPROFILE%\ffmpeg\`, 下解压[BtbN FFmpeg 7.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)，然后运行:
+在 `%USERPROFILE%\ffmpeg\`, 下解压[BtbN FFmpeg 8.1 shared/GPL build](https://github.com/BtbN/FFmpeg-Builds/releases)，然后运行:
 
 ```powershell
 winget install LLVM.LLVM --version 18.1.8
@@ -67,9 +67,9 @@ cargo test --workspace
 运行：
 
 ```sh
-brew install ffmpeg@7
-# The formula is keg-only, so point the build at it (K-204):
-export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"
+brew install ffmpeg  # see docs/TODO.md: Homebrew has no ffmpeg@8 yet, and plain ffmpeg is 9.x
+# Point the build at it (K-204):
+export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig"
 cargo test --workspace
 ```
 </details>

--- a/crates/lumit-media/Cargo.toml
+++ b/crates/lumit-media/Cargo.toml
@@ -14,7 +14,7 @@ test-fixtures = []
 [dependencies]
 bincode = "1"
 blake3 = "1"
-rsmpeg = { version = "0.18", default-features = false, features = ["ffmpeg7_1", "link_system_ffmpeg"] }
+rsmpeg = { version = "0.18", default-features = false, features = ["ffmpeg8", "link_system_ffmpeg"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 

--- a/crates/lumit-media/src/index.rs
+++ b/crates/lumit-media/src/index.rs
@@ -200,7 +200,6 @@ pub mod tests_support {
     pub fn ffmpeg_bin() -> Option<&'static str> {
         [
             "ffmpeg",
-            "/opt/homebrew/opt/ffmpeg@7/bin/ffmpeg",
             "/opt/homebrew/bin/ffmpeg",
             "/usr/local/bin/ffmpeg",
         ]

--- a/docs/02-DECISIONS.md
+++ b/docs/02-DECISIONS.md
@@ -9907,3 +9907,39 @@ floats are. Two changes, taken together:
 The alternative — teaching derived values to rescale — would have given `derived.*`
 ids a second contract (a unit table living nowhere) for exactly one consumer.
 Deriving the value that has no unit is smaller and cannot drift.
+
+## K-389 — FFmpeg is pinned to 8.1, and macOS has no route to it yet
+
+**DECIDED** (2026-08-18). Supersedes the FFmpeg 7.x half of **K-082** and the
+`ffmpeg@7` naming in **K-204**; both entries' actual rules — pkg-config on
+Linux/macOS, `FFMPEG_LIBS_DIR`/`FFMPEG_INCLUDE_DIR` on Windows, and no `[env]`
+block in `.cargo/config.toml` — are unchanged and still binding.
+
+`crates/lumit-media` now selects rsmpeg's `ffmpeg8` feature (was `ffmpeg7_1`) and
+CI installs FFmpeg **8.1**. The trigger was the pin going stale: BtbN's rolling
+`latest` tag rotated its n7.1 assets out on 2026-08-17 and every media job 404'd,
+which forced a dated-tag pin and made the version an explicit choice rather than
+an inherited default.
+
+Three things this entry exists to record:
+
+- **No source changes were needed.** `lumit-media` already used the modern
+  spellings on every seam FFmpeg 8 tightened — `AVChannelLayout` rather than the
+  old channel-count/mask pair, `send_packet`/`receive_frame` rather than the
+  one-shot decode calls, `AV_PROFILE_*` rather than `FF_PROFILE_*` — so the
+  crate compiles unmodified against the 8.1 headers. Nothing was renamed away
+  underneath it.
+- **Decode semantics are proven identical, not assumed.** A 600-frame 1080p60
+  clip was decoded under 7.1 and 8.1, software and D3D11VA, and all four blake3
+  sets match byte for byte. That is the oracle this migration turned on, and a
+  future major bump is expected to clear the same bar before it lands.
+- **macOS cannot build today.** Homebrew has no `ffmpeg@8` formula (only @2.8,
+  @4, @5, @6, @7) and its plain `ffmpeg` has already moved to 9.0.1, which no
+  published rsmpeg supports — 0.18.0+ffmpeg.8.0 is the newest, and there is no
+  `ffmpeg9` feature anywhere. The macOS jobs therefore install plain `ffmpeg`
+  behind a major-version gate that fails loudly rather than linking 8-shaped
+  bindings against 9-shaped libraries, which would be undefined behaviour that
+  compiles. Deliberately **not** solved by leaving macOS on `ffmpeg@7`: a
+  mismatched major is the one failure mode worse than a red job. It resolves
+  when Homebrew ships `ffmpeg@8`, or when rsmpeg learns FFmpeg 9 and Lumit
+  follows; docs/TODO.md carries it until then.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -3695,7 +3695,12 @@ FFmpeg present, and everyday `cargo` commands need to know where it is.
 
 There are two moving parts, and it helps to know why each exists:
 
-- **FFmpeg itself** — the video/audio engine. We use version 7.1. On Windows it comes as a
+- **FFmpeg itself** — the video/audio engine. We use version 8.1, and the major number
+  matters: the Rust side generates its FFmpeg bindings from the headers of whichever
+  build you point it at, and those bindings describe FFmpeg 8's data structures. Point
+  the build at FFmpeg 7 or 9 and it will compile against one shape and run against
+  another, which is the kind of fault that shows up as nonsense rather than an error
+  message. On Windows it comes as a
   folder with three important sub-folders: `lib` (the "how to call in" stubs the build links
   against), `include` (the description of what's callable), and `bin` (the actual `.dll`
   files the finished app loads while it runs, plus the `ffmpeg` command-line tool the tests
@@ -3709,7 +3714,7 @@ There are two moving parts, and it helps to know why each exists:
 
 ### On Windows (the shipping platform)
 
-1. Download `ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip` from the
+1. Download `ffmpeg-n8.1-latest-win64-gpl-shared-8.1.zip` from the
    [BtbN FFmpeg builds](https://github.com/BtbN/FFmpeg-Builds/releases) page and unzip it
    under your user folder, e.g. `C:\Users\you\ffmpeg\`. (GPL because Lumit is GPL; "shared"
    because we want the `.dll` files.)
@@ -3725,18 +3730,26 @@ There are two moving parts, and it helps to know why each exists:
 
 ### On macOS
 
-FFmpeg comes from Homebrew: `brew install ffmpeg@7`. That formula is *keg-only* — Homebrew
-deliberately does not put it where the system looks by default, because it is an older
-version than the plain `ffmpeg` formula and linking it would shadow that. So the build has
-to be told where it went, once, in the terminal you build from:
+FFmpeg comes from Homebrew: `brew install ffmpeg`, then tell the build where it went, once,
+in the terminal you build from:
 
 ```sh
-export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg@7)/lib/pkgconfig"
+export FFMPEG_PKG_CONFIG_PATH="$(brew --prefix ffmpeg)/lib/pkgconfig"
 ```
 
 Put that in your shell profile and every future terminal has it. macOS ships the translator
 (libclang) as part of its developer tools, so there is nothing else to set up — then
 `cargo test --workspace` works.
+
+**Check the version first, though: `brew list --versions ffmpeg` has to say 8-something.**
+Homebrew keeps older majors as separate formulas — `ffmpeg@7`, `ffmpeg@6` and so on — but
+at the time of writing there is no `ffmpeg@8`, and the plain formula has already moved on
+to 9. So macOS currently has no route to the version Lumit needs, and this is the one
+platform where the build genuinely cannot be set up today. It resolves either when
+Homebrew adds `ffmpeg@8` (at which point swap both `ffmpeg` above for `ffmpeg@8`, and note
+that a versioned formula is *keg-only*, which is exactly why the export line above exists),
+or when the Rust binding crate learns FFmpeg 9 and Lumit follows it there. Windows and
+Linux are unaffected.
 
 This line used to live in the repo's `.cargo/config.toml` instead, so nobody had to type
 it. It was removed (K-204) because Cargo offers no way to make such a setting apply to one
@@ -3748,7 +3761,7 @@ requirement, so macOS is the one that says it out loud.
 ### On Linux (K-082)
 
 Linux finds FFmpeg the same way macOS does — by asking the system's package registry
-(`pkg-config`) where the libraries live — so the setup is: install the FFmpeg 7
+(`pkg-config`) where the libraries live — so the setup is: install the FFmpeg 8
 *development* packages (the ones ending `-dev`, which carry the headers the binding
 generator reads), plus `pkg-config` and `clang`. On Debian 13 or Ubuntu 24.10 and newer
 that is one line: `sudo apt install pkg-config clang libavcodec-dev libavformat-dev
@@ -3776,11 +3789,13 @@ Linux used to need a second export here, to undo a macOS folder the repo's
 plain again; if you are looking at an older checkout, deleting the `[env]` block from
 `.cargo/config.toml` is what the fix amounted to.
 
-One honest caveat: the build needs FFmpeg **7**, and some distributions still ship
-FFmpeg 6 — Ubuntu 24.04 LTS is the big one. On those, `cargo build` will complain about
-"ffmpeg stuff" (a version the binding doesn't accept, or missing headers). The fix is a
-newer distribution release, or building FFmpeg 7.1 from source and letting `pkg-config`
-find it.
+One honest caveat: the build needs FFmpeg **8**, and most distributions still ship 6 or 7 —
+Ubuntu 24.04 LTS is the big one. On those, `cargo build` will complain about "ffmpeg stuff"
+(a version the binding doesn't accept, or missing headers). Three ways out: a newer
+distribution release, building FFmpeg 8.1 from source and letting `pkg-config` find it, or
+the route CI takes — download BtbN's `ffmpeg-n8.1-*-linux64-gpl-shared-8.1` tarball, rewrite
+the `prefix=` line in its `lib/pkgconfig/*.pc` files to wherever you unpacked it, and add
+that folder to `PKG_CONFIG_PATH`. See `.github/workflows/ci.yml` for the exact commands.
 
 (A **Flatpak** — a ready-to-install Linux bundle — is how releases ship for Linux, and
 since K-290 it is the *only* way they do. An earlier one packaged the old egui application

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -189,14 +189,20 @@ holding a `SmoothZoom` and reading its value, with no design left in it.
 - **`ProjectReference::state()` hands the raw `Arc<RwLock<…>>` out**, so a caller
     can hold a project lock as long as it likes and in any order. The order is
     written down and tested; nothing enforces it at the type level.
+- **macOS cannot build against FFmpeg 8** (K-389). Homebrew has no `ffmpeg@8`
+    formula and its plain `ffmpeg` is already 9.x, which no published rsmpeg
+    supports; the macOS jobs install plain `ffmpeg` behind a major-version gate
+    that fails loudly rather than link mismatched bindings. Retire this when
+    Homebrew ships `ffmpeg@8` (swap the formula back and restore the keg-only
+    `FFMPEG_PKG_CONFIG_PATH` wording), or when rsmpeg gains an `ffmpeg9` feature.
 - **The macOS IOSurface Viewer path is unproven** - CI links the bundle but
     nobody has launched the .app (K-033).
-- **The macOS .app is not relocatable** - the podspec links keg-only FFmpeg by
+- **The macOS .app is not relocatable** - the podspec links Homebrew FFmpeg by
     absolute Homebrew path. Distribution needs the dylibs vendored and install
     names rewritten (K-033).
 - **The macOS build is single-architecture** - `pkg-config-rs` refuses to
     cross-compile and a keg holds one architecture, so `ARCHS` is pinned to the
-    runner's. A universal bundle needs both `ffmpeg@7` kegs and per-slice `-L`
+    runner's. A universal bundle needs both `ffmpeg` kegs and per-slice `-L`
     flags (K-033), plus a decision on whether Intel macs are supported at all.
 - **The iOS podspec is misnamed** - `rust_lib_lumit_flutter` against a pubspec
     name of `lumit_bridge`. Same fix macOS took; iOS has no target and no CI job.

--- a/docs/impl/media-io.md
+++ b/docs/impl/media-io.md
@@ -7,7 +7,7 @@ classic NLE bugs: "scrubbing shows the wrong frame" and "4K playback melts the C
 ## 1. Linking ffmpeg
 
 - Crate: **rsmpeg** (maintained) over ffmpeg-next (maintenance-only). Build against
-  **FFmpeg 7.x shared libs**; on Windows fetch gyan.dev/BtbN release builds in CI and ship
+  **FFmpeg 8.x shared libs**; on Windows fetch gyan.dev/BtbN release builds in CI and ship
   the DLLs (LGPL build, dynamic linking — required for GPLv3-compatibility comfort and to
   swap builds); on the dev Mac, Homebrew ffmpeg. Pin the major version; wrap all direct
   `ffi::` calls in one `lumit-media::av` module so version bumps touch one file.

--- a/docs/impl/phase-0-kickoff.md
+++ b/docs/impl/phase-0-kickoff.md
@@ -29,7 +29,7 @@ lumit/
 ```
 
 Dependencies (take the latest compatible releases; majors as of writing): `wgpu` 24+,
-`egui`/`eframe`/`egui_dock` matching set, `winit` via eframe, `rsmpeg` (+ FFmpeg 7 shared
+`egui`/`eframe`/`egui_dock` matching set, `winit` via eframe, `rsmpeg` (+ FFmpeg 8 shared
 libs per [media-io.md](media-io.md) §1), `cpal`, `crossbeam-channel`, `arc-swap`, `rayon`,
 `serde`/`serde_json`, `zip`, `uuid` (v7 feature), `proptest` + `insta` (dev). Workspace
 lints from day one: `unwrap_used = "deny"` and `expect_used = "deny"` for the engine crates
@@ -101,6 +101,13 @@ Windows with the `media` feature on. The recipe:
 
 Windows CI now runs the full `clippy --workspace --all-targets` + `test --workspace` gate,
 media included — the shipping target no longer trails macOS.
+
+**Version note (2026-08-18):** the two recipes above are as they stood; the pinned FFmpeg
+is now **8.1**, not 7.1, and `crates/lumit-media/Cargo.toml` selects rsmpeg's `ffmpeg8`
+feature. Nothing else in the recipe moved — same BtbN shared/GPL build, same variables,
+same LLVM 18 pin — but the asset name and the crate feature must agree on the major, so
+read the current versions from `docs/GUIDE.md` and `.github/workflows/ci.yml` rather than
+from this dated note.
 
 ## Slice 5 — decode → Viewer (runs: you can SEE footage)
 

--- a/docs/learn/07-BUILD-SHIP.md
+++ b/docs/learn/07-BUILD-SHIP.md
@@ -45,7 +45,7 @@ internals in a debugger is unpleasant; the tests are how this project is worked 
 | Anything in the bridge crate | `cargo build -p lumit_bridge` | `target/debug/lumit_bridge.{dll,so,dylib}`, which `flutter_ui/test/frb/` loads (content-hash checked, stale = loud failure) |
 
 Codegen versions are pinned: `flutter_rust_bridge` 2.12.0 exactly, Flutter 3.44.7 in
-CI, Rust via `rust-toolchain.toml` (1.97.1). All three OSes link FFmpeg n7.1.
+CI, Rust via `rust-toolchain.toml` (1.97.1). All three OSes link FFmpeg n8.1 (K-389; macOS has no Homebrew route to it yet).
 
 ## CI: the merge gate
 

--- a/flutter_ui/rust_builder/macos/lumit_bridge.podspec
+++ b/flutter_ui/rust_builder/macos/lumit_bridge.podspec
@@ -43,7 +43,10 @@ A new Flutter FFI plugin project.
     'DEFINES_MODULE' => 'YES',
     # Flutter.framework does not contain a i386 slice.
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    # ffmpeg@7 is keg-only (deliberately not linked), so its lib directory has to
+    # FFmpeg 8 has no Homebrew formula yet (see ci.yml's macOS note): these
+    # paths cover a future ffmpeg@8 keg and a brew-extract tap, and stop naming
+    # ffmpeg@7 - linking 7's dylibs into 8-shaped bindings is a struct-layout
+    # mismatch that compiles. Keg-only formulas' lib directories have to
     # be named outright. Homebrew's prefix differs by architecture — /opt/homebrew
     # on Apple Silicon, /usr/local on Intel — and ld ignores a -L directory that
     # does not exist, so naming both covers either machine.
@@ -60,7 +63,7 @@ A new Flutter FFI plugin project.
     # invoking cargo's linker. A new Rust dependency that needs another framework
     # fails at link time with undefined symbols, and nothing points back here.
     'OTHER_LDFLAGS' => '-force_load ${BUILT_PRODUCTS_DIR}/liblumit_bridge.a ' \
-      '-L/opt/homebrew/opt/ffmpeg@7/lib -L/usr/local/opt/ffmpeg@7/lib ' \
+      '-L/opt/homebrew/opt/ffmpeg@8/lib -L/usr/local/opt/ffmpeg@8/lib ' \
       '-lavcodec -lavdevice -lavfilter -lavformat -lavutil -lswresample -lswscale ' \
       '-framework AudioUnit -framework CoreAudio -framework CoreFoundation ' \
       '-framework IOSurface -framework Foundation -framework QuartzCore ' \

--- a/packaging/flatpak/io.github.luminalmvm.Lumit.yml
+++ b/packaging/flatpak/io.github.luminalmvm.Lumit.yml
@@ -4,7 +4,7 @@
 # libraries it needs, so it does not care whether the user runs Ubuntu, Fedora
 # or Arch. Unlike the buried egui-era manifest (K-182), this one does not
 # build anything: CI has already built the Flutter bundle and packed the
-# FFmpeg 7.1 libraries into its lib/ directory (the launcher's rpath covers
+# FFmpeg 8.1 libraries into its lib/ directory (the launcher's rpath covers
 # them), so the manifest just repacks that staged bundle. The GNOME runtime
 # supplies GTK 3, which the Flutter Linux embedder needs and the plain
 # freedesktop runtime does not ship.

--- a/packaging/macos/make-dmg.sh
+++ b/packaging/macos/make-dmg.sh
@@ -7,7 +7,7 @@
 #
 #   packaging/macos/make-dmg.sh [version]
 #
-# Needs: flutter, rust, and `brew install ffmpeg@7 dylibbundler create-dmg`
+# Needs: flutter, rust, and `brew install ffmpeg dylibbundler create-dmg`
 # (create-dmg optional - without it the image has no drag-to-Applications
 # window dressing).
 #
@@ -41,8 +41,17 @@ command -v dylibbundler >/dev/null || {
     echo "dylibbundler not found - brew install dylibbundler" >&2
     exit 1
 }
-ffprefix="$(brew --prefix ffmpeg@7 2>/dev/null)" || {
-    echo "ffmpeg@7 not found - brew install ffmpeg@7" >&2
+ffprefix="$(brew --prefix ffmpeg 2>/dev/null)" || {
+    echo "ffmpeg not found - brew install ffmpeg" >&2
+    exit 1
+}
+# The dylibs bundled here have to be the same major the bridge generated its
+# bindings from (crates/lumit-media pins rsmpeg's ffmpeg8 feature). A mismatch
+# does not announce itself - it ships an .app that reads FFmpeg's structures at
+# the wrong offsets - so refuse rather than bundle it (K-389).
+ffmajor="$(brew list --versions ffmpeg | awk '{print $2}' | cut -d. -f1)"
+[ "$ffmajor" = "8" ] || {
+    echo "Homebrew ffmpeg is $ffmajor.x; this build needs 8.x (see docs/TODO.md)" >&2
     exit 1
 }
 

--- a/scripts/win-dev-env.ps1
+++ b/scripts/win-dev-env.ps1
@@ -3,12 +3,12 @@
     Set up the environment variables Lumit's media crate needs to build on Windows.
 
 .DESCRIPTION
-    lumit-media links FFmpeg 7.1 through rsmpeg. On Windows, rusty_ffmpeg's build
+    lumit-media links FFmpeg 8.1 through rsmpeg. On Windows, rusty_ffmpeg's build
     script links the import libraries named by FFMPEG_LIBS_DIR / FFMPEG_INCLUDE_DIR
     and generates its FFI with bindgen, which needs libclang (LIBCLANG_PATH). At run
     time the FFmpeg DLLs (and the ffmpeg CLI used by the test fixtures) must be on PATH.
 
-    This script finds a BtbN FFmpeg 7.1 "shared, GPL" build and an LLVM install, then
+    This script finds a BtbN FFmpeg 8.1 "shared, GPL" build and an LLVM install, then
     exports those variables for the current shell. Pass -Persist to also write them to
     your user environment so every new terminal has them.
 
@@ -19,8 +19,8 @@
     The extracted FFmpeg build directory (the folder containing bin\, lib\, include\).
     If omitted, the script searches, in order:
       $env:KIRIKO_FFMPEG_DIR
-      %USERPROFILE%\ffmpeg\ffmpeg-n7.1-*-win64-gpl-shared-*
-      C:\ffmpeg\ffmpeg-n7.1-*-win64-gpl-shared-*
+      %USERPROFILE%\ffmpeg\ffmpeg-n8.1-*-win64-gpl-shared-*
+      C:\ffmpeg\ffmpeg-n8.1-*-win64-gpl-shared-*
 
 .PARAMETER Persist
     Also store the variables at User scope (like setx) so future shells inherit them.
@@ -35,7 +35,7 @@
 
 .NOTES
     Get the FFmpeg build from https://github.com/BtbN/FFmpeg-Builds/releases (the
-    "ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip" asset) and extract it under
+    "ffmpeg-n8.1-latest-win64-gpl-shared-8.1.zip" asset) and extract it under
     %USERPROFILE%\ffmpeg\. Install LLVM 18 (winget install LLVM.LLVM --version 18.1.8):
     bindgen 0.71 mis-generates opaque structs against very new libclang, so pin 18.
     See docs/GUIDE.md "Building on Windows" and docs/impl/phase-0-kickoff.md slice 4.
@@ -56,7 +56,7 @@ function Find-FfmpegDir {
     foreach ($base in @("$env:USERPROFILE\ffmpeg", 'C:\ffmpeg')) {
         if (Test-Path $base) {
             $match = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -like 'ffmpeg-n7.1-*win64-gpl-shared*' } |
+                Where-Object { $_.Name -like 'ffmpeg-n8.1-*win64-gpl-shared*' } |
                 Sort-Object Name -Descending | Select-Object -First 1
             if ($match) { $candidates += $match.FullName }
         }
@@ -84,8 +84,8 @@ function Find-LibclangDir {
 $ff = Find-FfmpegDir -Explicit $FfmpegDir
 if (-not $ff) {
     Write-Error @"
-Could not find an FFmpeg 7.1 shared/GPL build.
-Download ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip from
+Could not find an FFmpeg 8.1 shared/GPL build.
+Download ffmpeg-n8.1-latest-win64-gpl-shared-8.1.zip from
 https://github.com/BtbN/FFmpeg-Builds/releases and extract it under %USERPROFILE%\ffmpeg\,
 or pass -FfmpegDir <path-to-the-extracted-folder>.
 "@


### PR DESCRIPTION
**Do not merge yet.** The migration is complete and proven — rsmpeg `ffmpeg8`, zero source changes (the crate already used every modern API spelling), and a blake3 oracle over 600 real frames decoding **byte-identically** between 7.1 and 8.1, software and D3D11VA hardware both. Windows and Linux CI move to the newest dated autobuild carrying n8.1, and `release.yml` comes off the rolling `latest` tag it was still riding (the same stale-pin class that 404'd ci.yml on the 17th).

**The blocker:** Homebrew has no `ffmpeg@8` formula (only @2.8/@4/@5/@6/@7), and plain `ffmpeg` is already **9.0.1**, which no published rsmpeg supports. macOS has no bottle route to 8.x, so merging this today reds every macOS job permanently — and a red CI blocks everything by standing policy.

**Unblock, either of:**
1. homebrew-core ships `ffmpeg@8` (likely, now that 9 is out — watch [formulae.brew.sh](https://formulae.brew.sh/formula/)), or
2. someone with a Mac proves `brew extract --version=8.x ffmpeg <tap>` (an 8-series formula pulled from Homebrew's own history, source-built) and the CI steps switch to it.

The macOS jobs on this branch carry a loud version gate so a mismatched major can never link silently — linking 7 or 9 dylibs against 8-shaped bindings is a struct-layout mismatch that *compiles*. The podspec stops naming `ffmpeg@7` for the same reason.

Merging needs: rebase, flip the gate's expectation to the chosen install route, one green run.