### PR TITLE
Add middle-mouse panning to the timeline and the viewer.

### DIFF
--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -367,6 +367,12 @@ Every control on either strip keeps the behaviour its item below defines. The it
 1. **Magnification** dropdown: Fit, Fit up to 100%, then 25 / 33.3 / 50 / 100 / 200 / 400 /
    800 %. Magnification is display scaling only; it MUST NOT change render resolution.
    `Ctrl+scroll` zooms about the pointer; `Shift+/` fits.
+   **A middle-button drag MUST pan the picture**, whatever tool is armed, which is what
+   After Effects, Blender and Resolve all do with it. It MUST be read off the pointer's
+   held buttons rather than won in the gesture arena, so it reaches the picture through
+   whatever the tool has laid over it, and the Hand tool stays what it is: the way to pan
+   without a middle button. The one exception is an armed picker, which owns the picture
+   as it already does (§6.1) and holds it still while pixels are read off it.
    **Every magnification change is anchored**: the comp point the gesture names —
    under the pointer for a wheel notch or a click, the middle of the box for a sweep — MUST
    still be under that point afterwards. A magnification MUST be clamped to a sane range
@@ -1745,6 +1751,13 @@ arithmetic is the one shared pure module (`panels/timeline_snap.dart`).
 
 - Plain wheel scrolls vertically. `Shift+wheel` scrolls horizontally. `Ctrl+wheel` zooms
   time about the pointer. The wheel MUST never zoom without a modifier (no scroll hijack).
+- **A middle-button drag MUST pan the lanes, both ways at once**, which is what After
+  Effects, Blender and Resolve all do with it. The view moves against the drag, so the
+  lanes follow the pointer, and the outline comes with them because the two halves share
+  one vertical scroll. It MUST be read off the pointer's held buttons rather than won in
+  the gesture arena: the marquee is a pan recogniser over the whole ground, and a drag
+  that had to beat it would be a drag the marquee sometimes ate. The primary button is
+  untouched, so a drag on empty lane space still draws the box.
 - **Zoom flies rather than cutting**: magnification is a place changing, not a value
   being nudged, so it animates — geometrically, because zoom is a ratio and equal time should
   buy equal ratio. Notches arriving quickly are worth more, so a rolled wheel covers ground
@@ -1826,8 +1839,9 @@ half, outside the horizontal scroller so it stays pinned to the viewport edge, a
 outline reserves the same gutter with an undraggable block level with its toolbar and
 column header — so the columns never shift as the view changes. The lane bottom bar
 carries the time-zoom slider, the magnet, and the horizontal scrollbar. **The wheel
-scrolls, dragging never does**: a plain wheel moves the rows, `Shift+wheel` scrolls
-sideways, `Ctrl+wheel` zooms time about the pointer, and a drag on empty lane space is the
+scrolls, and so does the middle button**: a plain wheel moves the rows, `Shift+wheel`
+scrolls sideways, `Ctrl+wheel` zooms time about the pointer, a middle-button drag pans
+both ways at once, and a drag on empty lane space with the primary button is the
 keyframe marquee. A zoom with no pointer to zoom about — the slider — holds the playhead
 still instead (§4.6), so what is being worked on stays on screen. **Edge-follow is
 built as a page flip** (TI-9): while the transport runs, a playhead that leaves the viewport

--- a/flutter_ui/lib/panels/timeline_lane_area_frb.dart
+++ b/flutter_ui/lib/panels/timeline_lane_area_frb.dart
@@ -297,6 +297,9 @@ class LayerArea extends StatelessWidget {
   /// are left alone, so they still reach the scrollable.
   final void Function(PointerScrollEvent event, double contentX) onWheel;
 
+  /// A middle-button drag over the lanes, in screen pixels.
+  final void Function(Offset delta) onPan;
+
   /// Settings ▸ Interface ▸ Panels ▸ *Layer names on lane bars*, off
   /// by default. Read once by the panel and handed down, never looked up in a
   /// bar's own build.
@@ -349,6 +352,7 @@ class LayerArea extends StatelessWidget {
     required this.fpsDen,
     required this.magnet,
     required this.onWheel,
+    required this.onPan,
     required this.selectionMove,
   });
 
@@ -625,6 +629,13 @@ class LayerArea extends StatelessWidget {
                       // wheel zooms or pans instead of scrolling, and a
                       // plain one is left alone.
                       child: Listener(
+                        // The middle button drags the view about, as it does in
+                        // After Effects, Blender and Resolve.
+                        onPointerMove: (event) {
+                          if (event.buttons == kMiddleMouseButton) {
+                            onPan(event.delta);
+                          }
+                        },
                         // A *modified* wheel is claimed through the resolver, so the
                         // scroll views around this one cannot act on the same event
                         // as well — a Ctrl+wheel zoom that also scrolled the lanes

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -2755,10 +2755,21 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
       );
       return;
     }
-    if (keys.isShiftPressed && _hLane.hasClients) {
-      _hLane.jumpTo((_hLane.offset + event.scrollDelta.dy)
-          .clamp(0.0, _hLane.position.maxScrollExtent));
-    }
+    if (keys.isShiftPressed) _scrollBy(_hLane, event.scrollDelta.dy);
+  }
+
+  /// Scroll a controller by [by], stopping at either end. A controller with no
+  /// viewport has nothing to scroll.
+  void _scrollBy(ScrollController c, double by) {
+    if (!c.hasClients || by == 0) return;
+    c.jumpTo((c.offset + by).clamp(0.0, c.position.maxScrollExtent));
+  }
+
+  /// A middle-button drag over the lanes, the way it does in After Effects,
+  /// Blender and Resolve.
+  void _panLanes(Offset delta) {
+    _scrollBy(_hLane, -delta.dx);
+    _scrollBy(_vLane, -delta.dy);
   }
 
   /// Zoom from somewhere other than the pointer — the bottom bar's slider —
@@ -3313,12 +3324,6 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                   // again every time. Only two things actually care where the
                   // playhead is: the line itself, and the razor (which reads it
                   // when clicked). Both listen for themselves now.
-                  //
-                  // Dragging never scrolls the timeline — the wheel, the
-                  // trackpad and the scrollbars do (docs/07 §4.6). A drag on
-                  // empty lane space is the keyframe marquee, and a scrollable
-                  // competing for it in the gesture arena would win and eat the
-                  // box.
                   //
                   // **The trackpad is the exception, and it has to be**: a
                   // two-finger scroll on a Mac arrives as a pan *gesture*, not
@@ -3984,6 +3989,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                       onKeysSelected: _onLaneKeysSelected,
                       onKeyMenu: _laneKeyMenu,
                       onWheel: (e, x) => _wheel(e, x, axis),
+                      onPan: _panLanes,
                       onSeek: (f) =>
                           ui.scrubTo(f.clamp(0, frames == 0 ? 0 : frames - 1)),
                       onSelect: (l) => _selectLayer(ui, l, among: layers),

--- a/flutter_ui/lib/panels/viewer_panel_frb.dart
+++ b/flutter_ui/lib/panels/viewer_panel_frb.dart
@@ -591,6 +591,13 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
             );
 
         return Listener(
+          // The middle button pans, like in other software.
+          onPointerMove: (event) {
+            if (event.buttons == kMiddleMouseButton &&
+                ui.dropper.value == null) {
+              _panBy(event.delta);
+            }
+          },
           // The wheel zooms about the cursor (docs/07 §2.2): the comp point
           // under the pointer stays under the pointer, which is what makes
           // zooming feel like leaning in rather than teleporting.
@@ -622,13 +629,7 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
               channel: _channel,
               compSize: size,
               footage: footage,
-              onPan: (delta) => setState(() {
-                // A pan during a zoom flight would be fighting it, so the
-                // flight ends where it is and the drag takes over.
-                _zoomFrom = null;
-                _zoomMotion.value = 1;
-                _pan += delta;
-              }),
+              onPan: _panBy,
               // The model is *told* an edit landed, rather than the boxes
               // checking for themselves as they draw: the Viewer
               // commits its own edits, and the drawing path reads the held
@@ -786,6 +787,16 @@ class _ViewerPanelFrbState extends State<ViewerPanelFrb>
       _pan = next.pan;
     });
   }
+
+  /// Move the picture by a drag's worth, whether that drag came from the Hand
+  /// tool, a press on empty space or the middle button.
+  void _panBy(Offset delta) => setState(() {
+        // A pan during a zoom flight would be fighting it, so the flight ends
+        // where it is and the drag takes over.
+        _zoomFrom = null;
+        _zoomMotion.value = 1;
+        _pan += delta;
+      });
 
   /// The magnification "Fit" means here: the whole picture in the panel.
   double _fitScale(BoxConstraints constraints, BridgeCompSize size) {

--- a/flutter_ui/test/frb/timeline_scroll_frb_test.dart
+++ b/flutter_ui/test/frb/timeline_scroll_frb_test.dart
@@ -1,5 +1,5 @@
-// Scrolling the Timeline: the gesture a Mac trackpad makes, and the two halves
-// staying level.
+// Scrolling the Timeline: the gesture a Mac trackpad makes, the two halves
+// staying level, and the middle button dragging the view about.
 //
 // **Both of these were reported from a real Mac and neither shows on a mouse.**
 // A two-finger trackpad scroll arrives as a *pan gesture*, not as the wheel's
@@ -10,6 +10,7 @@
 // long stack.
 
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/main.dart';
@@ -91,6 +92,88 @@ void main() {
       expect(extents, hasLength(1),
           reason: 'the outline reserves the lane bottom bar\'s height, so one '
               'half cannot run past the other: $extents');
+    });
+
+    /// The lanes' one horizontal position, once there is somewhere to scroll to.
+    ScrollPosition horizontalPosition(WidgetTester tester) => tester
+        .stateList<ScrollableState>(find.byType(Scrollable))
+        .map((s) => s.position)
+        .firstWhere(
+            (p) => p.axis == Axis.horizontal && p.maxScrollExtent > 0);
+
+    /// Zoom time in far enough that the lanes are wider than the panel, so a
+    /// horizontal pan has room to move.
+    Future<void> zoomIn(WidgetTester tester, Offset at) async {
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendEventToBinding(pointer.hover(at));
+      for (var i = 0; i < 6; i++) {
+        await tester.sendEventToBinding(pointer.scroll(const Offset(0, -1)));
+        await tester.pump();
+      }
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pumpAndSettle();
+    }
+
+    /// A drag over the lanes, on whichever button is asked for.
+    Future<void> drag(WidgetTester tester, Offset from, Offset by,
+        {required int buttons}) async {
+      final pointer = TestPointer(2, PointerDeviceKind.mouse, null, buttons);
+      await tester.sendEventToBinding(pointer.down(from));
+      await tester.pump();
+      // In steps, because a drag arrives as a stream of small moves and the
+      // pan adds each one up.
+      for (var i = 1; i <= 4; i++) {
+        await tester.sendEventToBinding(pointer.move(from + by * (i / 4)));
+        await tester.pump();
+      }
+      await tester.sendEventToBinding(pointer.up());
+      await tester.pump();
+    }
+
+    /// **The middle button drags the view about** (docs/07 §4.6), the way it
+    /// does in After Effects, Blender and Resolve. Both ways at once, and the
+    /// view moves against the drag so the lanes follow the pointer.
+    testWidgets('a middle-button drag pans the lanes both ways',
+        (tester) async {
+      final p = withManyLayers();
+      await mount(tester, p);
+
+      final lanes = tester.getCenter(find.byType(LayerArea));
+      await zoomIn(tester, lanes);
+
+      final acrossBefore = horizontalPosition(tester).pixels;
+      expect(acrossBefore, greaterThan(0),
+          reason: 'the zoom left the lanes somewhere to scroll from');
+      expect(verticalPositions(tester).every((p) => p.pixels == 0), isTrue,
+          reason: 'and the rows start at the top');
+
+      // Right and up, so the lanes go left and down under the pointer.
+      await drag(tester, lanes, const Offset(60, -80),
+          buttons: kMiddleMouseButton);
+
+      expect(horizontalPosition(tester).pixels, lessThan(acrossBefore),
+          reason: 'dragging right takes the view back in time');
+      expect(verticalPositions(tester).any((p) => p.pixels > 0), isTrue,
+          reason: 'and dragging up takes it down the stack');
+    });
+
+    /// The primary button still belongs to the keyframe marquee, which is what
+    /// a drag on empty lane space has always drawn.
+    testWidgets('a primary drag still leaves the view where it was',
+        (tester) async {
+      final p = withManyLayers();
+      await mount(tester, p);
+
+      final lanes = tester.getCenter(find.byType(LayerArea));
+      await zoomIn(tester, lanes);
+
+      final acrossBefore = horizontalPosition(tester).pixels;
+      await drag(tester, lanes, const Offset(60, -80), buttons: kPrimaryButton);
+
+      expect(horizontalPosition(tester).pixels, acrossBefore);
+      expect(verticalPositions(tester).every((p) => p.pixels == 0), isTrue,
+          reason: 'the marquee has the drag, not the scroll');
     });
   });
 }

--- a/flutter_ui/test/frb/viewer_panel_frb_test.dart
+++ b/flutter_ui/test/frb/viewer_panel_frb_test.dart
@@ -253,6 +253,65 @@ void main() {
           reason: 'and it is still following the pointer');
     });
 
+    /// Where the picture is drawn, as the panel hands it to the stage.
+    Rect drawnPicture(WidgetTester tester) =>
+        tester.widget<ViewerStage>(find.byType(ViewerStage)).fitted;
+
+    /// A drag across the stage on whichever button is asked for.
+    Future<void> dragStage(WidgetTester tester, Offset by,
+        {required int buttons}) async {
+      final from =
+          tester.getCenter(find.byKey(const ValueKey('viewer-stage')));
+      final pointer = TestPointer(3, PointerDeviceKind.mouse, null, buttons);
+      await tester.sendEventToBinding(pointer.down(from));
+      await tester.pump();
+      for (var i = 1; i <= 4; i++) {
+        await tester.sendEventToBinding(pointer.move(from + by * (i / 4)));
+        await tester.pump();
+      }
+      await tester.sendEventToBinding(pointer.up());
+      await tester.pump();
+    }
+
+    /// **The middle button pans the picture** (docs/07 §2.2), as it does in
+    /// After Effects, Blender and Resolve. Whatever tool is armed, because it
+    /// is read off the pointer rather than won in the gesture arena.
+    testWidgets('a middle-button drag pans the picture', (tester) async {
+      final p = withLayer();
+      await mount(tester, p);
+
+      final before = drawnPicture(tester);
+      await dragStage(tester, const Offset(40, -30),
+          buttons: kMiddleMouseButton);
+      final after = drawnPicture(tester);
+
+      expect(after.left, closeTo(before.left + 40, 1));
+      expect(after.top, closeTo(before.top - 30, 1));
+      expect(after.size, before.size,
+          reason: 'a pan moves the picture, it does not resize it');
+    });
+
+    /// An armed picker owns the picture: it holds still while pixels are being
+    /// read off it, so the pan stands down until the tool is put away.
+    testWidgets('a middle-button drag does not pan under an armed picker',
+        (tester) async {
+      final p = withLayer();
+      await mount(tester, p);
+
+      p.uiState.armDropper(DropperArm(
+        id: 'test',
+        reads: DropperReads.colour,
+        label: 'Key colour',
+        onPick: (_) {},
+      ));
+      await tester.pump();
+
+      final before = drawnPicture(tester);
+      await dragStage(tester, const Offset(40, -30),
+          buttons: kMiddleMouseButton);
+      expect(drawnPicture(tester), before);
+    });
+
     /// **The magnifier is on screen for the whole pick, and it shows what the
     /// release will commit** (docs/07 §6.1). The owner reported it missing
     /// after the redesign; nothing had been taken out of it, but a pick drag

--- a/web-docs/src/content/docs/panels/timeline.mdx
+++ b/web-docs/src/content/docs/panels/timeline.mdx
@@ -82,6 +82,13 @@ contents appear beneath it, each on a lane of its own.
 
 A [Sequence layer](/use/sequence-layers/) draws its clips on one row.
 
+## Moving about
+
+- **The wheel** scrolls the rows.
+- **Shift+wheel** scrolls sideways.
+- **Ctrl+wheel** zooms time, anchored on the pointer.
+- **A middle-button drag** pans both ways at once. The outline moves with the lanes.
+
 ## Editing keyframes in bulk
 
 <Shot file="layers-selected.png" caption="A block of keyframes selected: the box, its stretch handles, and the count of what is inside." />

--- a/web-docs/src/content/docs/panels/viewer.mdx
+++ b/web-docs/src/content/docs/panels/viewer.mdx
@@ -56,6 +56,14 @@ Select a layer and the Viewer draws its wireframe with a transform gizmo. The ha
 scale and rotate it. See [Transforming layers](/use/transform/). The tag at the top left
 names what is selected.
 
+### Moving about
+
+- **The wheel** zooms, anchored on the pointer.
+- **A middle-button drag** pans the picture, whatever tool is armed.
+- **The Hand tool** pans on an ordinary drag.
+
+A middle-button drag does not pan while a dropper is armed.
+
 ### At an effect
 
 Select one effect — its heading in [Effect controls](/panels/effect-controls/), or its box


### PR DESCRIPTION
The middle button now drags the view about, the way it does in After Effects,
Blender and Resolve. In the timeline it pans both ways at once and the outline
comes with it, in the viewer it pans the picture whatever tool is armed. The
primary button is untouched, so a drag on empty lane space is still the keyframe
marquee.

To test, zoom the timeline in with ctrl+wheel and drag the lanes about with the
middle button, then do the same over the picture in the viewer with the
Selection tool and again with the Hand tool. An armed dropper should hold the
picture still.

No new translation keys. docs/07 sections 2.2 and 4.6 and the timeline and
viewer manual pages are updated in the same commit.