### PR TITLE
Rotational properties appear in the graph view, and full revolution counter increments

### DIFF
--- a/crates/lumit-bridge/src/api/worker_thread.rs
+++ b/crates/lumit-bridge/src/api/worker_thread.rs
@@ -1562,6 +1562,16 @@ fn idle_fill(state: &mut WorkerState, stream: &mut WorkerResponseStream) {
                 continue;
             }
         }
+        // A render onto a full card pushes a frame out, and with every
+        // read-back slot taken that frame is dropped rather than read back.
+        // The next turn then finds it missing and makes it again, which on a
+        // device with slow read-backs is a fill that never ends. So the fill
+        // waits for a slot instead: not exhausted, nothing made this turn, and
+        // the worker comes back in a couple of milliseconds.
+        let (used, budget, _) = state.renderer.frame_texture_stats();
+        if used + frame_bytes > budget && state.renderer.demotions_saturated() {
+            return;
+        }
         match prepare_frame(state, &document, comp_ref.id, frame, quality, bgra, true) {
             // Tell the frontend, or the fill is invisible: the cache bar only
             // redraws when it hears something, and a fill shows no frame.
@@ -4998,13 +5008,18 @@ mod tests {
         state.last_shown = Some((CompositionReference::new(state.project.id, comp), 7, 1.0));
         state.fill_exhausted = false;
         // Idle turns until the fill has nothing left; each turn also collects
-        // what the card handed back, as the worker loop does.
-        for _ in 0..2_000 {
-            if state.fill_exhausted {
-                break;
-            }
+        // what the card handed back, as the worker loop does. With every
+        // read-back slot taken the fill makes nothing and waits, so the loop
+        // gives the card its clock rather than spinning through its turns
+        // before a single read-back has landed, which is what the macOS
+        // runner's software device did with a fixed count of turns.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while !state.fill_exhausted && std::time::Instant::now() < deadline {
             super::idle_fill(&mut state, &mut stream);
             super::drain_demotions(&mut state);
+            if state.renderer.demotions_saturated() {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
         }
         assert!(state.fill_exhausted, "the fill terminates");
         // Read-backs still in flight land over the next few turns — of the

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -1912,6 +1912,14 @@ impl HeadlessRenderer {
         self.demotions.len()
     }
 
+    /// Whether every read-back slot is taken, so the next eviction would be
+    /// dropped rather than read back. The fill waits on this rather than
+    /// rendering a frame the card would then let go.
+    #[must_use]
+    pub fn demotions_saturated(&self) -> bool {
+        self.demotions.len() >= MAX_DEMOTIONS_IN_FLIGHT
+    }
+
     /// How many demotion read-backs the card has refused so far. Each is a
     /// frame that left VRAM and reached no lower tier, by design (a miss costs
     /// a render); a test counting held frames subtracts these.

--- a/flutter_ui/lib/panels/graph_channels.dart
+++ b/flutter_ui/lib/panels/graph_channels.dart
@@ -270,13 +270,10 @@ List<GraphChannel> graphChannels({
         if (fx.id.toString() != effectId) continue;
         for (final param in cachedListParameters(fx.name)) {
           if (param.id != paramId) continue;
-          // A Slider is a Float inside a closed range: the kind is the
-          // control, not the storage, so it keeps every float affordance —
-          // docs/08 §1.2 names the graph editor among them.
-          if (param.kind is! BridgeParamKind_Float &&
-              param.kind is! BridgeParamKind_Slider) {
-            continue;
-          }
+          // The kind is the control, not the storage: a Slider, an Int and an
+          // Angle all cross the bridge as one Float scalar, and any of them
+          // keyed is a curve (docs/08 §1.2). So the test is on the value, not
+          // the kind. Naming kinds here dropped Slider once and Angle after it.
           BridgeScalar? scalar;
           for (final v in fx.values) {
             if (v.id == param.id && v.value is BridgeEffectValue_Float) {

--- a/flutter_ui/lib/widgets/angle_dial.dart
+++ b/flutter_ui/lib/widgets/angle_dial.dart
@@ -212,7 +212,7 @@ class _DialPainter extends CustomPainter {
 /// independently keyed halves could disagree about where the rotation is.
 /// Typing 400 into the degrees box therefore rolls over of its own accord — the
 /// value becomes 400 and redraws as `1x +40°`.
-class TurnsAndDegreesField extends StatelessWidget {
+class TurnsAndDegreesField extends StatefulWidget {
   /// The whole angle, turns included.
   final double degrees;
 
@@ -244,9 +244,23 @@ class TurnsAndDegreesField extends StatelessWidget {
   static double degreesOf(double value) => value - turnsOf(value) * 360;
 
   @override
+  State<TurnsAndDegreesField> createState() => _TurnsAndDegreesFieldState();
+}
+
+class _TurnsAndDegreesFieldState extends State<TurnsAndDegreesField> {
+  /// The turns when a drag on the degrees box began. The box runs on from its
+  /// own last tick, so past 360 it reports 361, 362 and so on, and adding the
+  /// turns of the moment put the turn it had just gained on top again every
+  /// tick. Null when the box is not being dragged.
+  double? _dragTurns;
+
+  @override
   Widget build(BuildContext context) {
-    final turns = turnsOf(degrees);
-    final rest = degreesOf(degrees);
+    final degrees = widget.degrees;
+    final onChanged = widget.onChanged;
+    final onCommit = widget.onCommit;
+    final turns = TurnsAndDegreesField.turnsOf(degrees);
+    final rest = TurnsAndDegreesField.degreesOf(degrees);
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -254,7 +268,7 @@ class TurnsAndDegreesField extends StatelessWidget {
         SizedBox(
           width: 30,
           child: DragValueField(
-            key: ValueKey<String>('angle-turns-$keyName'),
+            key: ValueKey<String>('angle-turns-${widget.keyName}'),
             value: turns,
             min: -10000,
             max: 10000,
@@ -264,7 +278,7 @@ class TurnsAndDegreesField extends StatelessWidget {
             onChanged: (v) => onCommit(v.toDouble() * 360 + rest),
             onChangeLive: onChanged == null
                 ? null
-                : (v) => onChanged!(v.toDouble() * 360 + rest),
+                : (v) => onChanged(v.toDouble() * 360 + rest),
             onChangeEnd: (v) => onCommit(v.toDouble() * 360 + rest),
           ),
         ),
@@ -272,7 +286,7 @@ class TurnsAndDegreesField extends StatelessWidget {
         SizedBox(
           width: 54,
           child: DragValueField(
-            key: ValueKey<String>('angle-degrees-$keyName'),
+            key: ValueKey<String>('angle-degrees-${widget.keyName}'),
             value: rest,
             // Open, not clamped to ±360: typing 400 here is a legitimate way to
             // say "one turn and forty", and it redraws as that.
@@ -282,10 +296,15 @@ class TurnsAndDegreesField extends StatelessWidget {
             decimals: 1,
             suffix: '°',
             onChanged: (v) => onCommit(turns * 360 + v.toDouble()),
+            onChangeStart: () => _dragTurns = turns,
             onChangeLive: onChanged == null
                 ? null
-                : (v) => onChanged!(turns * 360 + v.toDouble()),
-            onChangeEnd: (v) => onCommit(turns * 360 + v.toDouble()),
+                : (v) => onChanged((_dragTurns ?? turns) * 360 + v.toDouble()),
+            onChangeEnd: (v) {
+              onCommit((_dragTurns ?? turns) * 360 + v.toDouble());
+              _dragTurns = null;
+            },
+            onDragCancel: () => _dragTurns = null,
           ),
         ),
       ],

--- a/flutter_ui/lib/widgets/angle_dial.dart
+++ b/flutter_ui/lib/widgets/angle_dial.dart
@@ -61,12 +61,14 @@ class AngleDial extends StatefulWidget {
 }
 
 class _AngleDialState extends State<AngleDial> {
-  /// The angle the drag started from, and the pointer angle it started at —
-  /// the drag applies the *difference* rather than jumping the hand to wherever
-  /// the pointer went down. Grabbing the hand a little off-centre should not
-  /// snap it.
-  double _startValue = 0;
-  double _startPointer = 0;
+  /// The value as the drag has wound it so far, and the pointer angle of the
+  /// last move. Each move adds the short way round from the last one, so the
+  /// hand follows the pointer rather than jumping to wherever it went down,
+  /// and a drag that keeps going round keeps counting turns in either
+  /// direction. Measuring against the start instead folded every move to
+  /// within half a turn, so one drag could never add a whole one.
+  double _value = 0;
+  double _lastPointer = 0;
   bool _shift = false;
 
   /// Degrees clockwise from twelve o'clock for a point in the dial's box.
@@ -79,19 +81,21 @@ class _AngleDialState extends State<AngleDial> {
   }
 
   void _begin(Offset local) {
-    _startValue = widget.degrees;
-    _startPointer = _pointerDegrees(local);
+    _value = widget.degrees;
+    _lastPointer = _pointerDegrees(local);
   }
 
   double _valueFor(Offset local) {
-    // The shortest way round from where the drag started, so crossing twelve
-    // o'clock counts as a small move rather than a 360° jump.
-    var delta = _pointerDegrees(local) - _startPointer;
+    // The shortest way round from the last move, so crossing twelve o'clock
+    // counts as a small move rather than a 360° jump.
+    final pointer = _pointerDegrees(local);
+    var delta = pointer - _lastPointer;
     if (delta > 180) delta -= 360;
     if (delta < -180) delta += 360;
-    final raw = _startValue + delta;
-    if (!_shift || widget.step <= 0) return raw;
-    return (raw / widget.step).roundToDouble() * widget.step;
+    _lastPointer = pointer;
+    _value += delta;
+    if (!_shift || widget.step <= 0) return _value;
+    return (_value / widget.step).roundToDouble() * widget.step;
   }
 
   @override

--- a/flutter_ui/test/angle_turns_test.dart
+++ b/flutter_ui/test/angle_turns_test.dart
@@ -9,8 +9,13 @@
 // split and the recombination ever disagree, a rotation drifts by whole turns
 // every time someone touches its row.
 
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/theme/theme.dart';
 import 'package:lumit_flutter/widgets/angle_dial.dart';
+import 'package:lumit_flutter/widgets/controls.dart';
 
 void main() {
   group('turns and degrees', () {
@@ -72,6 +77,83 @@ void main() {
         final v = i * 0.37;
         expect(TurnsAndDegreesField.degreesOf(v).abs(), lessThan(360));
       }
+    });
+  });
+
+  group('the dial winds through full turns', () {
+    const size = 100.0;
+
+    /// A dial at [degrees] in a box at the origin, reporting every value the
+    /// drag hands back.
+    Future<List<double>> mount(WidgetTester tester, double degrees) async {
+      final seen = <double>[];
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThemeScope(
+          theme: LumitTheme.dark(),
+          animationLevel: AnimationLevel.none,
+          showTooltips: false,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: AngleDial(
+              size: size,
+              degrees: degrees,
+              onChanged: seen.add,
+              onChangeEnd: seen.add,
+            ),
+          ),
+        ),
+      ));
+      return seen;
+    }
+
+    /// The point on the dial's rim [clockwise] degrees from twelve o'clock.
+    Offset rim(double clockwise) {
+      final a = clockwise * math.pi / 180;
+      return Offset(size / 2 + math.sin(a) * 40, size / 2 - math.cos(a) * 40);
+    }
+
+    /// One drag from twelve o'clock through [turns] whole turns in 45° steps,
+    /// clockwise for a positive count and anticlockwise for a negative one.
+    Future<void> wind(WidgetTester tester, double turns) async {
+      final gesture = await tester.startGesture(rim(0));
+      final steps = (turns.abs() * 8).round();
+      for (var i = 1; i <= steps; i++) {
+        await gesture.moveTo(rim(turns.sign * i * 45));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pump();
+    }
+
+    /// Dragging the hand round once used to hand back the angle it started
+    /// from: every move was measured against the start and folded to within
+    /// half a turn, so the turns box never moved off 0x.
+    testWidgets('a clockwise drag past twelve adds a turn', (tester) async {
+      final seen = await mount(tester, 30);
+      await wind(tester, 1);
+      expect(seen.last, closeTo(390, 1e-6));
+      expect(TurnsAndDegreesField.turnsOf(seen.last), 1);
+    });
+
+    testWidgets('an anticlockwise drag takes turns away', (tester) async {
+      final seen = await mount(tester, 30);
+      await wind(tester, -2);
+      expect(seen.last, closeTo(-690, 1e-6));
+      expect(TurnsAndDegreesField.turnsOf(seen.last), -1);
+    });
+
+    testWidgets('the hand still follows the pointer inside a turn',
+        (tester) async {
+      final seen = await mount(tester, 0);
+      final gesture = await tester.startGesture(rim(0));
+      await gesture.moveTo(rim(90));
+      await tester.pump();
+      await gesture.moveTo(rim(45));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+      expect(seen.last, closeTo(45, 1e-6));
     });
   });
 }

--- a/flutter_ui/test/angle_turns_test.dart
+++ b/flutter_ui/test/angle_turns_test.dart
@@ -156,4 +156,84 @@ void main() {
       expect(seen.last, closeTo(45, 1e-6));
     });
   });
+
+  group('the degrees box crossing 360', () {
+    /// The pair at [degrees], reporting every value a drag hands back. Each
+    /// value is fed straight back in as the new angle, the way the row does
+    /// with a live tick, since that rebuild is what the bug lived in.
+    Future<List<double>> mount(WidgetTester tester, double degrees) async {
+      final seen = <double>[];
+      var shown = degrees;
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: ThemeScope(
+          theme: LumitTheme.dark(),
+          animationLevel: AnimationLevel.none,
+          showTooltips: false,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: StatefulBuilder(
+              builder: (context, setState) => TurnsAndDegreesField(
+                keyName: 't',
+                degrees: shown,
+                onChanged: (v) => setState(() => seen.add(shown = v)),
+                onCommit: (v) => setState(() => seen.add(shown = v)),
+              ),
+            ),
+          ),
+        ),
+      ));
+      return seen;
+    }
+
+    /// Scrubbing the degrees box from 350 up through 360 used to send the
+    /// turns box racing: the box runs on from its own last tick, so it
+    /// reported 361, 362, and the row added the turn it had just gained on
+    /// top of each one. One turn is gained once, at 360, and no more.
+    testWidgets('scrubbing past 360 gains exactly one turn', (tester) async {
+      final seen = await mount(tester, 350);
+      final box = find.byKey(const ValueKey<String>('angle-degrees-t'));
+      final gesture = await tester.startGesture(tester.getCenter(box));
+      // Past the drag slop first, then the scrub proper in small steps.
+      await gesture.moveBy(const Offset(20, 0));
+      await tester.pump();
+      for (var i = 0; i < 10; i++) {
+        await gesture.moveBy(const Offset(2, 0));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pump();
+
+      expect(seen, isNotEmpty);
+      for (var i = 1; i < seen.length; i++) {
+        expect(seen[i] - seen[i - 1], inInclusiveRange(0, 30),
+            reason: 'tick $i jumped from ${seen[i - 1]} to ${seen[i]}');
+      }
+      expect(seen.last, inInclusiveRange(360, 400));
+      expect(TurnsAndDegreesField.turnsOf(seen.last), 1);
+    });
+
+    testWidgets('scrubbing down through 0 loses exactly one turn',
+        (tester) async {
+      final seen = await mount(tester, 370);
+      final box = find.byKey(const ValueKey<String>('angle-degrees-t'));
+      final gesture = await tester.startGesture(tester.getCenter(box));
+      await gesture.moveBy(const Offset(-20, 0));
+      await tester.pump();
+      for (var i = 0; i < 10; i++) {
+        await gesture.moveBy(const Offset(-2, 0));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pump();
+
+      expect(seen, isNotEmpty);
+      for (var i = 1; i < seen.length; i++) {
+        expect(seen[i - 1] - seen[i], inInclusiveRange(0, 30),
+            reason: 'tick $i jumped from ${seen[i - 1]} to ${seen[i]}');
+      }
+      expect(seen.last, inInclusiveRange(320, 360));
+      expect(TurnsAndDegreesField.turnsOf(seen.last), 0);
+    });
+  });
 }

--- a/flutter_ui/test/frb/cache_bar_frb_test.dart
+++ b/flutter_ui/test/frb/cache_bar_frb_test.dart
@@ -311,6 +311,18 @@ void main() {
       final p = freshProject();
       final comp = p.state.project!.newComposition(name: 'Scene');
       comp.addSolidLayer();
+      // A one-frame work area, so the worker's idle fill has nothing to make
+      // while this test is looking. The entry count below is the whole
+      // memory tier's, and a fill frame the card pushed out landed in it
+      // between the two readings on the Linux runner, reading as a second
+      // composite that never happened.
+      comp.setWorkArea(
+        span: BridgeSpan(
+          inPoint: comp.timeOfFrame(frame: 0),
+          outPoint: comp.timeOfFrame(frame: 1),
+          startOffset: const BridgeRational(num: 0, den: 1),
+        ),
+      );
       p.uiState.setSelectedComp(comp);
 
       await tester.pumpWidget(hostPanel(
@@ -321,6 +333,7 @@ void main() {
       ));
       await tester.pump();
 
+      final base = cacheStats().entries;
       comp.renderScope(
         frame: BigInt.zero,
         scale: p.uiState.viewerScale,
@@ -331,15 +344,19 @@ void main() {
       // count to be non-zero — earlier tests in this file leave residue in the
       // shared cache, and a `before` snapshotted on their entries races the
       // first trace (two queued traces collapse to the newest, so the first
-      // can vanish entirely).
+      // can vanish entirely). And for the memory tier to have gained an entry
+      // since the trace was asked for: the Viewer puts the frame on the card
+      // first, which the strip reports as held, and a `before` read then saw
+      // the first trace's own filing land as though the second had composited.
       await settleFrb(
         tester,
         minRounds: 15,
         maxRounds: 400,
         until: () =>
             cacheStorageOf(comp.cachedFrames(
-                frames: BigInt.one, scale: p.uiState.viewerScale)[0]) !=
-            0,
+                    frames: BigInt.one, scale: p.uiState.viewerScale)[0]) !=
+                0 &&
+            cacheStats().entries > base,
       );
 
       final before = cacheStats();

--- a/flutter_ui/test/frb/graph_editor_frb_test.dart
+++ b/flutter_ui/test/frb/graph_editor_frb_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lumit_flutter/main.dart';
+import 'package:lumit_flutter/panels/effect_param_row_frb.dart'
+    show cachedListParameters;
 import 'package:lumit_flutter/panels/graph_editor_frb.dart';
 import 'package:uuid/uuid.dart';
 import 'package:lumit_flutter/panels/graph_maths.dart';
@@ -1206,6 +1208,47 @@ void main() {
               .map((t) => channels.single.drawnValueAt(bulging, t))
               .reduce(math.max),
           100);
+    });
+
+    /// An Angle is a Float scalar drawn as a dial, so a keyed one is a curve
+    /// like any other. The resolver above was still naming the kinds it took,
+    /// so Twirl's Angle opened to an empty graph.
+    testWidgets('graphChannels resolves an angle parameter', (tester) async {
+      final p = withLayer();
+      p.layer.addEffect(name: 'twirl');
+      final staged = p.layer.getEffects();
+      final fxId = staged.single.id();
+      final angle = cachedListParameters('twirl').firstWhere(
+          (param) => param.id == 'angle',
+          orElse: () => fail('twirl has no angle parameter'));
+      expect(angle.kind, isA<BridgeParamKind_Angle>());
+      for (final instance in staged) {
+        instance.setValue(
+          id: 'angle',
+          value: BridgeEffectValue.float(BridgeScalar.keyframed([
+            for (final (f, v) in [(0, -30.0), (100, 90.0)])
+              BridgeKeyframe(
+                time: p.comp.timeOfFrame(frame: f),
+                value: v,
+                interpIn: const BridgeSideInterp.linear(),
+                interpOut: const BridgeSideInterp.linear(),
+              ),
+          ])),
+        );
+      }
+      p.layer.setEffects(effects: staged);
+      final id = p.layer.internallayerId.toString();
+      p.uiState.model.refresh();
+
+      final channels = graphChannels(
+        layers: p.uiState.model.layers,
+        selected: ['$id/effects/$fxId/angle'],
+      );
+      expect(channels, hasLength(1),
+          reason: 'an Angle kind is a float and belongs in the graph');
+      expect(channels.single.keys, hasLength(2));
+      expect(channels.single.hardBounds, (null, null),
+          reason: 'a dial winds through full turns');
     });
 
     /// A transform has no parameter range to be held inside, so its curve is


### PR DESCRIPTION
Rotational properties now appear in the graph view and can be altered like other float properties. Additionally when dragging the revolution value past 360/0 it increments the full revolution counter.