### PR TITLE
Stop plugin ring files piling up in the temp folder

### DIFF
--- a/crates/lumit-aplug/src/ipc/ring.rs
+++ b/crates/lumit-aplug/src/ipc/ring.rs
@@ -141,6 +141,11 @@ pub struct Ring {
     map: MmapMut,
     /// Set on the side that made the file, so that side deletes it.
     owned: Option<PathBuf>,
+    /// The maker's own handle, kept open for the life of the ring. On Windows
+    /// it carries delete-on-close, so the file goes when this process ends
+    /// whether or not anything dropped the ring. The host keeps its brokers
+    /// in a static, and a static is never dropped.
+    file: Option<File>,
 }
 
 impl Drop for Ring {
@@ -149,10 +154,13 @@ impl Drop for Ring {
             return;
         };
         // Windows will not delete a file that is still mapped, so the mapping
-        // goes first, swapped for a one-byte anonymous one.
+        // goes first, swapped for a one-byte anonymous one, then the handle,
+        // which on Windows is the delete. The remove is for the other
+        // platforms.
         if let Ok(empty) = MmapMut::map_anon(1) {
             drop(std::mem::replace(&mut self.map, empty));
         }
+        drop(self.file.take());
         let _ = std::fs::remove_file(path);
     }
 }
@@ -169,18 +177,23 @@ impl Ring {
             slots: RING_SLOTS,
             slot_bytes: SLOT_BYTES,
         };
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)?;
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(true);
+        // FILE_FLAG_DELETE_ON_CLOSE. The broker still opens the file by name
+        // while this handle is open; std's default share mode allows that.
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            options.custom_flags(0x0400_0000);
+        }
+        let file = options.open(path)?;
         file.set_len(SLOT_BYTES.saturating_mul(u64::from(RING_SLOTS)))?;
         let map = map_file(&file)?;
         Ok(Self {
             spec,
             map,
             owned: Some(path.to_path_buf()),
+            file: Some(file),
         })
     }
 
@@ -196,6 +209,7 @@ impl Ring {
             spec: spec.clone(),
             map,
             owned: None,
+            file: None,
         })
     }
 

--- a/crates/lumit-aplug/src/tests.rs
+++ b/crates/lumit-aplug/src/tests.rs
@@ -712,3 +712,37 @@ fn the_broker_is_spawned_without_a_console_window() {
         "no_console must be CREATE_NO_WINDOW and nothing else"
     );
 }
+
+/// The host keeps its brokers in a static, and a static is never dropped, so
+/// a ring file only ever went away by luck. The maker's handle now carries
+/// delete-on-close: the file must be gone once the process that made it has
+/// ended, dropped or not. The probe is a child copy of this test binary that
+/// makes a ring, forgets it, and exits.
+#[cfg(windows)]
+#[test]
+fn a_forgotten_ring_goes_with_its_process() {
+    const PROBE: &str = "LUMIT_APLUG_RING_PROBE";
+    if let Ok(path) = std::env::var(PROBE) {
+        let ring = crate::ipc::ring::Ring::create(Path::new(&path)).expect("a ring");
+        std::mem::forget(ring);
+        std::process::exit(0);
+    }
+    let path = std::env::temp_dir().join(format!("lumit-aplug-probe-{}.ring", std::process::id()));
+    let status = std::process::Command::new(std::env::current_exe().expect("this test binary"))
+        .args([
+            "a_forgotten_ring_goes_with_its_process",
+            "--exact",
+            "--test-threads=1",
+        ])
+        .env(PROBE, &path)
+        .status()
+        .expect("the probe runs");
+    assert!(status.success(), "the probe made its ring and exited");
+    let leaked = path.exists();
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !leaked,
+        "the ring file outlived the process that made it: {}",
+        path.display()
+    );
+}

--- a/crates/lumit-ofx/src/ipc/shm.rs
+++ b/crates/lumit-ofx/src/ipc/shm.rs
@@ -194,6 +194,12 @@ pub struct Ring {
     map: MmapMut,
     /// Set on the side that made the file, so that side deletes it.
     owned: Option<PathBuf>,
+    /// The maker's own handle, kept open for the life of the ring. On Windows
+    /// it carries delete-on-close, so the file goes when this process ends
+    /// whether or not anything dropped the ring. The host keeps its brokers
+    /// in a static, and a static is never dropped, which is how half a
+    /// gigabyte a broker used to pile up in the temp directory.
+    file: Option<File>,
 }
 
 impl Drop for Ring {
@@ -202,12 +208,13 @@ impl Drop for Ring {
             return;
         };
         // Windows will not delete a file that is still mapped, and the file is
-        // as big as the ring — a session's worth of undeleted ones would be
-        // real disk. So the mapping goes first, swapped for a one-byte
-        // anonymous one, which costs a page and nothing else.
+        // as big as the ring. So the mapping goes first, swapped for a
+        // one-byte anonymous one, then the handle, which on Windows is the
+        // delete. The remove is for the other platforms.
         if let Ok(empty) = MmapMut::map_anon(1) {
             drop(std::mem::replace(&mut self.map, empty));
         }
+        drop(self.file.take());
         let _ = std::fs::remove_file(path);
     }
 }
@@ -229,18 +236,23 @@ impl Ring {
             slots,
             slot_bytes,
         };
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(path)?;
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true).truncate(true);
+        // FILE_FLAG_DELETE_ON_CLOSE. The broker still opens the file by name
+        // while this handle is open; std's default share mode allows that.
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            options.custom_flags(0x0400_0000);
+        }
+        let file = options.open(path)?;
         file.set_len(slot_bytes.saturating_mul(u64::from(slots)))?;
         let map = map_file(&file)?;
         Ok(Self {
             spec,
             map,
             owned: Some(path.to_path_buf()),
+            file: Some(file),
         })
     }
 
@@ -256,6 +268,7 @@ impl Ring {
             spec: spec.clone(),
             map,
             owned: None,
+            file: None,
         })
     }
 

--- a/crates/lumit-ofx/src/tests.rs
+++ b/crates/lumit-ofx/src/tests.rs
@@ -2767,3 +2767,37 @@ fn the_broker_is_spawned_without_a_console_window() {
         "no_console must be CREATE_NO_WINDOW and nothing else"
     );
 }
+
+/// The host keeps its brokers in a static, and a static is never dropped, so
+/// a ring file only ever went away by luck. The maker's handle now carries
+/// delete-on-close: the file must be gone once the process that made it has
+/// ended, dropped or not. The probe is a child copy of this test binary that
+/// makes a ring, forgets it, and exits.
+#[cfg(windows)]
+#[test]
+fn a_forgotten_ring_goes_with_its_process() {
+    const PROBE: &str = "LUMIT_OFX_RING_PROBE";
+    if let Ok(path) = std::env::var(PROBE) {
+        let ring = crate::ipc::shm::Ring::create(Path::new(&path), 8, 8).expect("a ring");
+        std::mem::forget(ring);
+        std::process::exit(0);
+    }
+    let path = std::env::temp_dir().join(format!("lumit-ofx-probe-{}.ring", std::process::id()));
+    let status = std::process::Command::new(std::env::current_exe().expect("this test binary"))
+        .args([
+            "a_forgotten_ring_goes_with_its_process",
+            "--exact",
+            "--test-threads=1",
+        ])
+        .env(PROBE, &path)
+        .status()
+        .expect("the probe runs");
+    assert!(status.success(), "the probe made its ring and exited");
+    let leaked = path.exists();
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        !leaked,
+        "the ring file outlived the process that made it: {}",
+        path.display()
+    );
+}


### PR DESCRIPTION
Every OFX and CLAP broker makes a shared memory file in the temp folder, half a gigabyte each for OFX, and it was only deleted if the ring was dropped. The host keeps its brokers in a static, so nothing ever dropped them and one test run left 28 GB behind, 171 GB in total on my machine. The maker's handle now carries delete-on-close on Windows, so the file goes when the process ends whether or not anything dropped it.

To test, run the lumit-ofx or lumit-aplug tests and check the temp folder for lumit-ofx-*.ring files afterwards. There should be none. Each crate also has a new test that makes a ring in a child process, forgets it, and checks the file is gone once the child exits.

Linux and macOS still rely on the drop, so a leak there is possible but the runners are throwaway.
