### PR TITLE
Harden the release pipeline and the updater

### DIFF
--- a/.github/actions/ffmpeg8-macos/action.yml
+++ b/.github/actions/ffmpeg8-macos/action.yml
@@ -86,7 +86,7 @@ runs:
     # primary key, and the next run finds it ahead of the stale one.
     - name: Restore the built keg
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.paths.outputs.cellar }}
         key: ffmpeg-8.1.2-${{ runner.os }}-${{ runner.arch }}-bump${{ inputs.cache-bump }}-${{ github.run_id }}
@@ -190,7 +190,7 @@ runs:
     # run's prefix restore finds it first.
     - name: Save the built keg
       if: steps.build.outcome == 'success'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.paths.outputs.cellar }}
         key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Keeps the commit pins current, since a pinned commit never moves on its own.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /.github/actions/ffmpeg8-macos
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
   # on something outside the tree (a runner hiccup, a registry timeout).
   workflow_dispatch:
 
+# Nothing here writes to the repository, so the token cannot either.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -25,9 +29,10 @@ jobs:
     name: fmt + clippy + tests (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
       # Homebrew has no ffmpeg@8 formula (only @2.8, @4, @5, @6, @7) and its
       # plain `ffmpeg` is already 9.x, which no published rsmpeg supports — so
@@ -49,7 +54,7 @@ jobs:
         uses: ./.github/actions/ffmpeg8-macos
       # Cellar paths are versioned; a cached rusty_ffmpeg build script must not
       # outlive its keg, so the keg's version is part of the Rust cache key.
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: ffmpeg-${{ steps.ffmpeg.outputs.version }}
       - run: cargo fmt --all -- --check
@@ -74,10 +79,12 @@ jobs:
       # A dated tag's assets are immutable, so re-pin deliberately rather than
       # tracking a moving URL.
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-win64-gpl-shared-8.1
+      FFMPEG_SHA256: 0a41f31caff48e3035b48f09f5d840bd8d1863008240fc43e457f15e589cf5b3
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
       # FFmpeg 8.1 dev libs for lumit-media. rusty_ffmpeg links the import libs in
       # FFMPEG_LIBS_DIR and reads headers from FFMPEG_INCLUDE_DIR (it ignores
@@ -88,6 +95,9 @@ jobs:
         run: |
           $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/$env:FFMPEG_ASSET.zip"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
+          # The archive must match the hash pinned beside its name above.
+          $hash = (Get-FileHash "$env:RUNNER_TEMP\ffmpeg.zip" -Algorithm SHA256).Hash
+          if ($hash -ne $env:FFMPEG_SHA256) { throw "FFmpeg archive hash $hash is not the pinned $env:FFMPEG_SHA256" }
           Expand-Archive "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
           $root = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
           "FFMPEG_LIBS_DIR=$root\lib"        >> $env:GITHUB_ENV
@@ -97,7 +107,7 @@ jobs:
       # broken opaque structs against very new libclang (20+). Installed to a temp
       # dir so it never clashes with any LLVM preinstalled on the runner.
       - name: Install LLVM 18 (libclang for bindgen)
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
         with:
           version: "18.1.8"
           directory: ${{ runner.temp }}/llvm
@@ -105,7 +115,7 @@ jobs:
         shell: pwsh
         run: |
           "LIBCLANG_PATH=$env:RUNNER_TEMP\llvm\bin" >> $env:GITHUB_ENV
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # The shipping target runs the full gate, media included — this is the parity
       # the desktop-dev setup unlocked (previously Windows built --no-default-features).
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -137,6 +147,7 @@ jobs:
       # three platforms link an identical FFmpeg. The distro's own is 6.x,
       # which the crate's `ffmpeg8` feature does not match.
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
       # This runner installs Mesa's lavapipe below, so every GPU test MUST run
       # here: a missing adapter is a broken runner, not a machine without a
       # graphics card, and `lumit_gpu::no_adapter` turns the polite skip into a
@@ -148,9 +159,10 @@ jobs:
       # has been verified. Flip it on there the day a run proves they do.
       LUMIT_REQUIRE_GPU: 1
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: stable
           components: rustfmt, clippy
       # The desktop stack's system libraries: ALSA (cpal), GL/EGL (eframe's
       # glow backend), X11 / Wayland / xkb (winit), and Mesa's lavapipe so
@@ -171,6 +183,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -194,7 +208,7 @@ jobs:
       # structs and rsmpeg stops compiling) — installed above from the distro.
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo clippy --workspace --all-targets -- -D warnings
       # GPU crates included: the tests share one device under a lock (see the
       # `windows` job), so a software rasteriser neither races nor thrashes.
@@ -245,13 +259,16 @@ jobs:
     timeout-minutes: 60
     env:
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
       BENCH_SPAN_FRACTION: "10"
       # A missing adapter is a broken runner here, exactly as in the `linux` job:
       # a benchmark that measured nothing must not report green.
       LUMIT_REQUIRE_GPU: 1
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -266,6 +283,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -275,7 +294,7 @@ jobs:
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # Released, always: the harness's own loop is only comparable with itself
       # when the whole thing is optimised, and a debug number means nothing.
       #
@@ -312,7 +331,7 @@ jobs:
       # looking at it, and a passing run's are what the next baseline is made from.
       - name: Keep the numbers
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bench-results-linux
           path: bench-results.json
@@ -325,9 +344,12 @@ jobs:
       # The same BtbN "shared, GPL" n8.1 build the other jobs take, so the
       # bridge .so links the identical FFmpeg lumit-media expects.
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       # `cargo build -p lumit_bridge` (default features) pulls lumit-media
       # (FFmpeg) and, through `render`, lumit-render (wgpu/GL). The Flutter Linux
       # runner additionally needs GTK 3 + clang/cmake/ninja. This is the
@@ -352,6 +374,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -365,19 +389,19 @@ jobs:
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # Flutter stable pinned to the SAME version the desktop dev box runs
       # (3.47.1), so CI and the owner's machine agree. It has to be: the runner
       # calls `DartProject::set_impeller_switch`, which 3.44.7's Windows
       # embedder does not have, so a stale pin fails to compile main.cpp. `cache: true` caches the
       # SDK; the pub cache is cached separately below.
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
           cache: true
       - name: Cache pub packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.pub-cache
           key: pub-${{ runner.os }}-${{ hashFiles('flutter_ui/pubspec.lock') }}
@@ -457,8 +481,10 @@ jobs:
     name: flutter frontend (macOS runner build)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       # The same extracted FFmpeg 8 keg the macOS Rust jobs take (the `check`
       # job explains it). The build_pod.sh phase inside the Xcode build compiles
       # the bridge crate, so rusty_ffmpeg needs the keg here, and the podspec's
@@ -470,17 +496,17 @@ jobs:
       - name: FFmpeg 8.1.2 (extracted formula, cached keg)
         id: ffmpeg
         uses: ./.github/actions/ffmpeg8-macos
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: ffmpeg-${{ steps.ffmpeg.outputs.version }}
       # The same pinned Flutter the Linux job takes, so the two agree.
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
           cache: true
       - name: Cache pub packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.pub-cache
           key: pub-${{ runner.os }}-${{ hashFiles('flutter_ui/pubspec.lock') }}
@@ -543,12 +569,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       # The generator formats its Dart output, so it needs the SDK — pinned to
       # the same version the other Flutter job takes.
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -569,6 +598,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -580,7 +611,7 @@ jobs:
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # The version is pinned once, on the runtime crate the generated glue links
       # against (`flutter_rust_bridge = { version = "=2.12.0", … }`). Read it from
       # there rather than restating it here: a generator that drifts from its
@@ -625,18 +656,21 @@ jobs:
     name: engine-crate coverage gate
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
         with:
+          toolchain: stable
           components: llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@5f8ff1a44efd92cf3d48505f1adfee33393eb853 # main
+        with:
+          tool: cargo-llvm-cov
       # As in the `check` job above, which explains the extracted formula: the
       # action exports the pkg-config path rather than .cargo/config.toml
       # carrying it.
       - name: FFmpeg 8.1.2 (extracted formula, cached keg)
         id: ffmpeg
         uses: ./.github/actions/ffmpeg8-macos
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           key: ffmpeg-${{ steps.ffmpeg.outputs.version }}
       # Engine crates must hold the line; the threshold may rise, never fall.
@@ -672,10 +706,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
       LUMIT_OFX_BENCH: ${{ github.workspace }}/target/ofx-bench
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -684,6 +721,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -693,13 +732,13 @@ jobs:
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # The **bundles only**, not the checkouts they were built from: the
       # runner's `ensure` hands back a folder that already has bundles in it
       # without looking at a compiler, so a green run pays for the eighty
       # plugins once and never unpacks their source again.
       - name: Cache the built bench
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target/ofx-bench/*.ofx.bundle
           key: ofx-bench-${{ runner.os }}-v1
@@ -718,7 +757,7 @@ jobs:
           fi
       - name: Keep the table
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ofx-conformance
           path: target/ofx-conformance.md
@@ -746,9 +785,11 @@ jobs:
       # nothing else.
       LUMIT_OFX_FUZZ_ITERS: 20000
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       # `+nightly` explicitly: rust-toolchain.toml pins stable for the whole
       # repository, and it wins over whichever toolchain the step above made the
       # default - so without this cargo runs stable and `-Zsanitizer` is refused.
@@ -758,7 +799,7 @@ jobs:
     name: design-token lint (no hex literals outside the theme module)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       # All colours live in the Flutter theme (flutter_ui/lib/theme/); no Rust
       # crate may carry one.
       - run: |
@@ -830,11 +871,11 @@ jobs:
     name: dependency hygiene (licences, advisories, sources)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       # The upstream action rather than `cargo install cargo-deny`: it ships the
       # binary and caches the advisory database, so this job is seconds rather
       # than a three-minute build of a tool that checks a lock file.
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check
 
@@ -842,7 +883,7 @@ jobs:
     name: bridge lint (no panic paths in the frb API surface)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - run: |
           # Only the *shipping* half of each file is linted: everything from a
           # `#[cfg(test)]` onward is test code, which may legitimately `expect`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ on:
         description: "Version to build, with or without the leading v"
         required: true
 
+# Only the publish job writes to the repository, so only it gets a token
+# that can.
 permissions:
-  contents: write
+  contents: read
 
 env:
   # A tag run takes its version from the tag; a manual run from the input. The
@@ -48,21 +50,27 @@ jobs:
     runs-on: windows-latest
     env:
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-win64-gpl-shared-8.1
+      FFMPEG_SHA256: 0a41f31caff48e3035b48f09f5d840bd8d1863008240fc43e457f15e589cf5b3
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       - name: Install FFmpeg 8.1 (BtbN shared build)
         shell: pwsh
         run: |
           $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/$env:FFMPEG_ASSET.zip"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
+          # The archive must match the hash pinned beside its name above.
+          $hash = (Get-FileHash "$env:RUNNER_TEMP\ffmpeg.zip" -Algorithm SHA256).Hash
+          if ($hash -ne $env:FFMPEG_SHA256) { throw "FFmpeg archive hash $hash is not the pinned $env:FFMPEG_SHA256" }
           Expand-Archive "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
           $root = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
           "FFMPEG_LIBS_DIR=$root\lib"        >> $env:GITHUB_ENV
           "FFMPEG_INCLUDE_DIR=$root\include" >> $env:GITHUB_ENV
           "$root\bin" >> $env:GITHUB_PATH
       - name: Install LLVM 18 (libclang for bindgen)
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
         with:
           version: "18.1.8"
           directory: ${{ runner.temp }}/llvm
@@ -70,8 +78,8 @@ jobs:
         shell: pwsh
         run: |
           "LIBCLANG_PATH=$env:RUNNER_TEMP\llvm\bin" >> $env:GITHUB_ENV
-      - uses: Swatinem/rust-cache@v2
-      - uses: subosito/flutter-action@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -96,7 +104,7 @@ jobs:
           Copy-Item assets\brand\lumit-project.ico, assets\brand\lumit-preset.ico "$stage\icons"
           Compress-Archive -Path "$stage\*" -Force `
             -DestinationPath "packaging/windows/dist/lumit-$version-windows-x64.zip"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-installer
           path: |
@@ -109,9 +117,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FFMPEG_ASSET: ffmpeg-n8.1.2-50-g1a748fe2cd-linux64-gpl-shared-8.1
+      FFMPEG_SHA256: 35dc428bf78d3f8a4447a68707338ecf9560ebcc7459967974f9ff5b1f84be24
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       - name: Install desktop + Flutter build dependencies
         run: |
           sudo apt-get update
@@ -125,6 +136,8 @@ jobs:
         run: |
           url="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-31-13-27/${FFMPEG_ASSET}.tar.xz"
           curl -fsSL "$url" -o "$RUNNER_TEMP/ffmpeg.tar.xz"
+          # Checked against the hash pinned beside the asset name above.
+          echo "$FFMPEG_SHA256  $RUNNER_TEMP/ffmpeg.tar.xz" | sha256sum -c -
           mkdir -p "$RUNNER_TEMP/ffmpeg"
           tar -xJf "$RUNNER_TEMP/ffmpeg.tar.xz" -C "$RUNNER_TEMP/ffmpeg" --strip-components=1
           root="$RUNNER_TEMP/ffmpeg"
@@ -135,8 +148,8 @@ jobs:
           echo "$root/bin" >> "$GITHUB_PATH"
       - name: Point bindgen at libclang
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-18/lib" >> "$GITHUB_ENV"
-      - uses: Swatinem/rust-cache@v2
-      - uses: subosito/flutter-action@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -202,7 +215,7 @@ jobs:
             flatpak-build packaging/flatpak/io.github.luminalmvm.Lumit.yml
           flatpak build-bundle flatpak-repo \
             "lumit-$version-linux-x64.flatpak" io.github.luminalmvm.Lumit
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: linux-bundle
           path: lumit-*-linux-x64.flatpak
@@ -219,8 +232,10 @@ jobs:
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # master
+        with:
+          toolchain: stable
       # Mirrors ci.yml's macOS jobs: FFmpeg 8.1.2 from a formula extracted out
       # of homebrew-core's history, built once and cached, with the major
       # asserted before anything links against it. The action exports
@@ -230,8 +245,8 @@ jobs:
         uses: ./.github/actions/ffmpeg8-macos
       - name: Install the packaging tools
         run: brew install dylibbundler create-dmg
-      - uses: Swatinem/rust-cache@v2
-      - uses: subosito/flutter-action@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -292,7 +307,7 @@ jobs:
           mkdir -p packaging/macos/dist
           ditto -c -k --keepParent "$app" \
             "packaging/macos/dist/lumit-$version-macos-$(uname -m).zip"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: macos-dmg
           path: |
@@ -303,12 +318,14 @@ jobs:
   publish:
     name: GitHub release
     needs: [windows-installer, linux-bundle, macos-dmg]
+    permissions:
+      contents: write
     # A manual run is a rehearsal and publishes nothing.
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           merge-multiple: true
           path: dist
@@ -338,7 +355,7 @@ jobs:
       # simply goes unannounced.
       DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Post the release notes to Discord
         if: env.DISCORD_RELEASE_WEBHOOK != ''
         run: node scripts/discord-release.mjs "${GITHUB_REF_NAME#v}"

--- a/crates/lumit-bridge/src/faults.rs
+++ b/crates/lumit-bridge/src/faults.rs
@@ -28,10 +28,8 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Once;
 
-/// The file's name inside the system's temporary directory. Temp rather than a
-/// directory of our own: it needs no permissions, no creation step, and no
-/// decision about where an application's data lives — and a diagnostic file is
-/// exactly the kind of thing a machine is entitled to clear out.
+/// The file's name inside Lumit's cache directory (`lumit_project::cache_dir`),
+/// or inside the system's temporary directory on a machine with no home.
 const FILE: &str = "lumit-diagnostics.log";
 
 /// Past this many bytes the file starts again. A crash report wants the *last*
@@ -42,7 +40,9 @@ const CAP: u64 = 256 * 1024;
 /// Where the diagnostics go. Printed once at startup so a bug report can say
 /// where to look.
 pub(crate) fn path() -> PathBuf {
-    std::env::temp_dir().join(FILE)
+    lumit_project::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(FILE)
 }
 
 /// Append one line, with the seconds since the epoch in front of it so two
@@ -65,6 +65,10 @@ fn record_to(file: &std::path::Path, line: &str) {
     let over = std::fs::metadata(file)
         .map(|m| m.len() > CAP)
         .unwrap_or(false);
+    // The cache directory may not exist yet on a first run.
+    if let Some(parent) = file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let opened = std::fs::OpenOptions::new()
         .create(true)
         .append(!over)

--- a/crates/lumit-project/src/lib.rs
+++ b/crates/lumit-project/src/lib.rs
@@ -414,6 +414,13 @@ pub fn frame_cache_dir(doc_id: Uuid) -> Option<PathBuf> {
     Some(dirs.cache_dir().join("frames").join(doc_id.to_string()))
 }
 
+/// The application's own cache directory, the parent of every folder below,
+/// which unlike `/tmp` belongs to one user on every platform.
+pub fn cache_dir() -> Option<PathBuf> {
+    let dirs = directories::ProjectDirs::from("dev", "Lumit", "Lumit")?;
+    Some(dirs.cache_dir().to_path_buf())
+}
+
 /// Camera-solve sidecar directory (docs/10-FILE-FORMAT.md §3) — where a
 /// tracked clip's solve is parked so the next session does not re-track it.
 ///

--- a/flutter_ui/lib/state/cache_dir.dart
+++ b/flutter_ui/lib/state/cache_dir.dart
@@ -1,0 +1,35 @@
+// Lumit's cache folder, the same one the engine names in
+// `lumit_project::cache_dir`, worked out without the bridge so the fault log
+// and the updater still work when the engine is the thing that broke.
+
+import 'dart:io';
+
+/// Lumit's cache folder as the engine's `ProjectDirs` names it:
+/// `%LOCALAPPDATA%\Lumit\Lumit\cache`, `~/Library/Caches/dev.Lumit.Lumit` or
+/// `$XDG_CACHE_HOME/lumit` (default `~/.cache/lumit`), with the system
+/// temporary folder only when there is no home at all.
+Directory lumitCacheDir({String? platform, Map<String, String>? env}) {
+  final os = platform ?? Platform.operatingSystem;
+  final vars = env ?? Platform.environment;
+  String? base;
+  switch (os) {
+    case 'windows':
+      final local = vars['LOCALAPPDATA'];
+      if (local != null) base = '$local\\Lumit\\Lumit\\cache';
+    case 'macos':
+      final home = vars['HOME'];
+      if (home != null) base = '$home/Library/Caches/dev.Lumit.Lumit';
+    default:
+      // The engine's `directories` crate ignores a relative XDG_CACHE_HOME,
+      // so this does too.
+      final xdg = vars['XDG_CACHE_HOME'];
+      final home = vars['HOME'];
+      if (xdg != null && xdg.startsWith('/')) {
+        base = '$xdg/lumit';
+      } else if (home != null) {
+        base = '$home/.cache/lumit';
+      }
+  }
+  return Directory(
+      base ?? '${Directory.systemTemp.path}${Platform.pathSeparator}lumit');
+}

--- a/flutter_ui/lib/state/faults.dart
+++ b/flutter_ui/lib/state/faults.dart
@@ -33,6 +33,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:lumit_flutter/l10n/strings.dart';
+import 'package:lumit_flutter/state/cache_dir.dart';
 import 'package:lumit_flutter/theme/theme.dart';
 
 /// The file the engine appends its own faults to
@@ -48,7 +49,7 @@ import 'package:lumit_flutter/theme/theme.dart';
 /// wrong dependency for a diagnostic: this has to work when the engine is what
 /// went wrong. Both sides append whole records in a single write, which is what
 /// keeps two writers from splitting each other's lines.
-File faultLog() => File('${Directory.systemTemp.path}'
+File faultLog() => File('${lumitCacheDir().path}'
     '${Platform.pathSeparator}lumit-diagnostics.log');
 
 /// Past this many bytes the file starts again — the engine's own cap
@@ -79,6 +80,8 @@ void recordFault(String message, StackTrace? stack) =>
 /// without filling the file a real session is writing to.
 void recordFaultTo(File file, String message, StackTrace? stack) {
   try {
+    // The cache folder may not exist yet on a first run.
+    file.parent.createSync(recursive: true);
     // Checked before the write, as the engine does it: the record lands in the
     // file that keeps it rather than in one about to be truncated.
     final over = file.existsSync() && file.lengthSync() > _capBytes;

--- a/flutter_ui/lib/state/updates.dart
+++ b/flutter_ui/lib/state/updates.dart
@@ -32,6 +32,7 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 
+import 'cache_dir.dart';
 import 'install_site.dart';
 import 'package:lumit_flutter/l10n/strings.dart';
 
@@ -161,7 +162,9 @@ class UpdateRelease {
         if (raw is! Map) continue;
         final asset = raw.cast<String, dynamic>();
         final name = asset['name'];
-        if (name is String && name.toLowerCase().endsWith(suffix)) {
+        if (name is String &&
+            isPlainFileName(name) &&
+            name.toLowerCase().endsWith(suffix)) {
           chosen = asset;
           break;
         }
@@ -249,6 +252,12 @@ UpdateDelivery deliveryFor(
 
 /// `v0.2.0` → `0.2.0`. Anything else is handed back unchanged, so an oddly
 /// named tag is compared rather than silently treated as version zero.
+/// Whether [name] is a bare file name, so a separator, a `..` or a drive
+/// letter in it can't name a file outside the download folder.
+bool isPlainFileName(String name) => _plainFileName.hasMatch(name);
+
+final RegExp _plainFileName = RegExp(r'^[A-Za-z0-9][A-Za-z0-9._-]*$');
+
 String versionFromTag(String tag) =>
     tag.startsWith('v') ? tag.substring(1) : tag;
 
@@ -356,9 +365,9 @@ class UpdateService extends ChangeNotifier {
   /// be tested without waiting a day.
   final int Function() _now;
 
-  /// Where the installer is put. The system temporary folder in the shipped
-  /// application: it is a file the operating system may clean up, and once the
-  /// update is installed there is no reason to keep it.
+  /// Where the installer is put, which in the shipped application is Lumit's
+  /// own cache folder (`cache_dir.dart`), one nobody else on the machine can
+  /// write to.
   final Directory Function() _downloadFolder;
 
   UpdateService({
@@ -674,7 +683,7 @@ class UpdateService extends ChangeNotifier {
     try {
       if (file.existsSync()) file.deleteSync();
     } catch (_) {
-      // A file we cannot delete is litter in a temporary folder, not a fault
+      // A file we cannot delete is litter in a cache folder, not a fault
       // worth showing anybody.
     }
   }
@@ -694,8 +703,7 @@ int _epochMillis() => DateTime.now().millisecondsSinceEpoch;
 void _exitProcess() => exit(0);
 
 Directory _defaultDownloadFolder() =>
-    Directory('${Directory.systemTemp.path}${Platform.pathSeparator}'
-        'lumit-update');
+    Directory('${lumitCacheDir().path}${Platform.pathSeparator}update');
 
 /// GitHub wants a user agent and answers JSON. Nothing is authenticated: the
 /// releases of a public repository are public, and asking anonymously means

--- a/flutter_ui/test/cache_dir_test.dart
+++ b/flutter_ui/test/cache_dir_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/state/cache_dir.dart';
+
+void main() {
+  test('each platform gets the folder the engine names', () {
+    expect(
+      lumitCacheDir(
+        platform: 'windows',
+        env: const {'LOCALAPPDATA': r'C:\Users\a\AppData\Local'},
+      ).path,
+      r'C:\Users\a\AppData\Local\Lumit\Lumit\cache',
+    );
+    expect(
+      lumitCacheDir(platform: 'macos', env: const {'HOME': '/Users/a'}).path,
+      '/Users/a/Library/Caches/dev.Lumit.Lumit',
+    );
+    expect(
+      lumitCacheDir(platform: 'linux', env: const {'HOME': '/home/a'}).path,
+      '/home/a/.cache/lumit',
+    );
+  });
+
+  test('a Flatpak names its own cache through XDG_CACHE_HOME', () {
+    expect(
+      lumitCacheDir(platform: 'linux', env: const {
+        'HOME': '/home/a',
+        'XDG_CACHE_HOME': '/home/a/.var/app/io.github.luminalmvm.Lumit/cache',
+      }).path,
+      '/home/a/.var/app/io.github.luminalmvm.Lumit/cache/lumit',
+    );
+    expect(
+      lumitCacheDir(platform: 'linux', env: const {
+        'HOME': '/home/a',
+        'XDG_CACHE_HOME': 'relative/cache',
+      }).path,
+      '/home/a/.cache/lumit',
+    );
+  });
+
+  test('no home at all falls back to the temporary folder, not a crash', () {
+    expect(
+      lumitCacheDir(platform: 'linux', env: const {}).path,
+      startsWith(Directory.systemTemp.path),
+    );
+  });
+}

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -98,6 +98,29 @@ void main() {
       );
       expect(release?.sha256, 'sha256:abc');
     });
+
+    test('an attachment whose name is not a bare file name is never offered',
+        () {
+      // The name ends up in a local path, so anything that could leave the
+      // download folder is refused before the suffix is even looked at.
+      for (final name in const [
+        '../evil.exe',
+        r'..\..\evil.exe',
+        '/tmp/evil.tar.gz',
+        r'C:\Temp\evil.exe',
+        'lumit/0.2.0-windows-x64-setup.exe',
+        '.exe',
+      ]) {
+        expect(isPlainFileName(name), isFalse, reason: name);
+        final json = _releaseJson(assets: [_asset(name)]);
+        for (final platform in const ['windows', 'macos', 'linux']) {
+          expect(UpdateRelease.parse(json, platform: platform), isNull,
+              reason: '$name on $platform');
+        }
+      }
+      expect(isPlainFileName('lumit-0.2.0-windows-x64-setup.exe'), isTrue);
+      expect(isPlainFileName('Lumit-0.2.0-rc1_macos-arm64.zip'), isTrue);
+    });
   });
 
   group('checking', () {


### PR DESCRIPTION
Hardens the release pipeline and the updater, from issue #105. To test,
run a manual release build and check the FFmpeg step passes, then update
from inside Lumit and check the download lands in the cache folder.
