### PR TITLE
Show a release warning before the update restarts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,9 +320,20 @@ jobs:
           # dry run of the whole pipeline never becomes the download page's
           # "latest". Plain v0.2.0 is the real thing.
           case "$GITHUB_REF_NAME" in *-*) prerelease=--prerelease ;; *) prerelease= ;; esac
+          # The "Before you update" section of the release notes, when the
+          # file has one, goes at the top of the release ahead of the generated
+          # notes. Lumit reads it from there and shows it once the update is
+          # downloaded, before it restarts (flutter_ui/lib/state/updates.dart).
+          notes="web/src/content/releases/${GITHUB_REF_NAME#v}.md"
+          before=
+          if [ -f "$notes" ]; then
+            awk '/^#/ { keep = (tolower($0) ~ /^#+[[:space:]]*before you update[[:space:]]*$/) } keep' \
+              "$notes" > before.md
+            if [ -s before.md ]; then before="--notes-file before.md"; fi
+          fi
           gh release create "$GITHUB_REF_NAME" dist/* \
             --title "Lumit $GITHUB_REF_NAME" \
-            --generate-notes $prerelease
+            --generate-notes $prerelease $before
 
   announce:
     name: Discord announcement

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -306,6 +306,11 @@ panel layout is.
   normal case), handed to the installer (anywhere Lumit cannot write to its own files), or
   handed to Flatpak with the install command, in which case Lumit MUST NOT offer to restart
   because it is not replacing anything.
+- **Before you update.** A release whose notes carry a *Before you update* section MUST
+  show that section in a window of its own once the download has finished and before the
+  restart question, every time the row is pressed, and MUST NOT apply the update until it
+  has been answered. *Not now* keeps the download and the row that offers it. A release
+  with no such section shows no window.
 
 ### 1.9 The application window
 

--- a/flutter_ui/lib/l10n/app_en.arb
+++ b/flutter_ui/lib/l10n/app_en.arb
@@ -7445,6 +7445,10 @@
       }
     }
   },
+  "updateContinue": "Continue",
+  "@updateContinue": {
+    "description": "Button on the dialogue showing a release's warning: go on to the restart question."
+  },
   "updateDownload": "Download",
   "@updateDownload": {
     "description": "Button that fetches an update."
@@ -7525,6 +7529,24 @@
   "updateNotNow": "Not now",
   "@updateNotNow": {
     "description": "Button that declines an update for the moment."
+  },
+  "updateNoticeBody": "Lumit {version} is downloaded. Before it is installed, its release notes say:",
+  "@updateNoticeBody": {
+    "description": "Body of the dialogue showing a release's warning, above the warning itself. {version} is the new version, such as 0.4.0.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "updateNoticeTitle": "Before you update to Lumit {version}",
+  "@updateNoticeTitle": {
+    "description": "Title of the dialogue showing what a release warns about before it is installed. {version} is the new version, such as 0.4.0.",
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
   },
   "updateOfferBody": "{name} is {size}. Lumit downloads it now and installs it when you restart, so you can carry on working in the meantime.",
   "@updateOfferBody": {

--- a/flutter_ui/lib/shell/update_dialog_frb.dart
+++ b/flutter_ui/lib/shell/update_dialog_frb.dart
@@ -6,7 +6,9 @@
 // is the part the user sees: the one question before a few hundred megabytes
 // are downloaded, the progress while it comes, and the restart at the end —
 // with the offer to save first, because the update cannot finish while Lumit is
-// running and nobody should lose an evening's work to a version number.
+// running and nobody should lose an evening's work to a version number. A
+// release with something to say before it is applied says it ahead of the
+// restart question, on a window of its own.
 //
 // Nothing here decides anything about updating. It asks, it shows, and it calls
 // back into the service, so the two can be read separately: what an update *is*
@@ -128,6 +130,24 @@ Future<void> _askAboutRestart(
   required bool Function() projectIsDirty,
   required Future<void> Function() saveProject,
 }) async {
+  // What the release says to read first, on its own window and ahead of the
+  // restart question, every time the row is pressed: someone who chose Later
+  // yesterday is being asked the same thing today.
+  final notice = updates.release?.notice ?? const <UpdateNoticeLine>[];
+  if (notice.isNotEmpty) {
+    final read = await showLumitModal<bool>(
+      context: context,
+      builder: (close) => _BeforeYouUpdate(
+        version: updates.release?.version ?? '',
+        lines: notice,
+        onChoose: close,
+      ),
+    );
+    // Not now, Escape and the scrim all leave the update where it is,
+    // downloaded and still offered by the row.
+    if (read != true || !context.mounted) return;
+  }
+
   final answer = await showLumitModal<_RestartAnswer>(
     context: context,
     builder: (close) => _RestartToFinish(
@@ -146,6 +166,116 @@ Future<void> _askAboutRestart(
 
 /// What the restart window can be answered with.
 enum _RestartAnswer { restart, saveAndRestart, later }
+
+/// What the release says to read before it is applied. Only ever shown for a
+/// release with something to say, and always ahead of the restart question.
+class _BeforeYouUpdate extends StatelessWidget {
+  final String version;
+  final List<UpdateNoticeLine> lines;
+  final ValueChanged<bool?> onChoose;
+
+  const _BeforeYouUpdate({
+    required this.version,
+    required this.lines,
+    required this.onChoose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final t = ThemeScope.of(context).theme;
+    return FloatSurface(
+      width: 460,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Text(l10n.updateNoticeTitle(version), style: t.bodyPrimary),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Text(
+              l10n.updateNoticeBody(version),
+              style: t.small.copyWith(color: t.textMuted),
+            ),
+          ),
+          // The notes themselves, in a box edged in the warning colour (kraft,
+          // never a red alert). Capped and scrolling, so a release with a lot
+          // to say does not push the buttons off the screen.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 8, 10, 0),
+            child: Container(
+              key: const ValueKey('update-notice'),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: t.surface2,
+                border: Border.all(color: t.warning),
+                borderRadius: BorderRadius.circular(t.tokens.floatRadius),
+              ),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 220),
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      for (final (index, line) in lines.indexed)
+                        Padding(
+                          padding: EdgeInsets.only(top: index == 0 ? 0 : 4),
+                          child: line.bullet
+                              ? Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    SizedBox(
+                                      width: 10,
+                                      child: Text('•', style: t.body),
+                                    ),
+                                    Expanded(
+                                      child: Text(line.text, style: t.body),
+                                    ),
+                                  ],
+                                )
+                              : Text(line.text, style: t.body),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 14),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                HouseButton(
+                  key: const ValueKey('update-notice-not-now'),
+                  small: true,
+                  frameless: true,
+                  onPressed: () => onChoose(false),
+                  child: Text(l10n.updateNotNow, style: t.small),
+                ),
+                const SizedBox(width: 8),
+                HouseButton(
+                  key: const ValueKey('update-notice-continue'),
+                  small: true,
+                  // The window's default action: Enter goes on to the restart
+                  // question, the same as every other window in the sequence.
+                  primary: true,
+                  autofocus: true,
+                  onPressed: () => onChoose(true),
+                  child: Text(l10n.updateContinue),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+        ],
+      ),
+    );
+  }
+}
 
 /// "There is a newer Lumit — shall I fetch it?", with what that costs.
 class _OfferUpdate extends StatelessWidget {
@@ -192,11 +322,12 @@ class _OfferUpdate extends StatelessWidget {
                 HouseButton(
                   key: const ValueKey('update-offer-yes'),
                   small: true,
-                  // The window's default action: Enter downloads.
+                  // The window's default action: Enter downloads. No style
+                  // on the label: the filled action sets its own capitals.
                   primary: true,
                   autofocus: true,
                   onPressed: () => onChoose(true),
-                  child: Text(l10n.updateDownload, style: t.small),
+                  child: Text(l10n.updateDownload),
                 ),
               ],
             ),
@@ -386,7 +517,7 @@ class _RestartToFinish extends StatelessWidget {
                     primary: true,
                     autofocus: true,
                     onPressed: () => onChoose(_RestartAnswer.saveAndRestart),
-                    child: Text(l10n.updateSaveAndRestart, style: t.small),
+                    child: Text(l10n.updateSaveAndRestart),
                   ),
                 ] else
                   HouseButton(
@@ -396,8 +527,7 @@ class _RestartToFinish extends StatelessWidget {
                     autofocus: true,
                     onPressed: () => onChoose(_RestartAnswer.restart),
                     child: Text(
-                        quits ? l10n.updateRestartNow : l10n.updateShowTheFile,
-                        style: t.small),
+                        quits ? l10n.updateRestartNow : l10n.updateShowTheFile),
                   ),
               ],
             ),

--- a/flutter_ui/lib/state/updates.dart
+++ b/flutter_ui/lib/state/updates.dart
@@ -119,6 +119,10 @@ class UpdateRelease {
   /// without it is verified by size alone.
   final String? sha256;
 
+  /// What the release says to read before it is applied, a line at a time.
+  /// Empty for most releases, which have nothing to say ([updateNoticeFrom]).
+  final List<UpdateNoticeLine> notice;
+
   const UpdateRelease({
     required this.version,
     required this.tag,
@@ -128,6 +132,7 @@ class UpdateRelease {
     required this.assetBytes,
     required this.delivery,
     this.sha256,
+    this.notice = const [],
   });
 
   /// How big the download is, for a sentence a human reads. Whole MB: the
@@ -184,9 +189,75 @@ class UpdateRelease {
       assetBytes: size is int ? size : 0,
       delivery: deliveryFor(name, kind: kind, replaceable: replaceable),
       sha256: chosen['digest'] is String ? chosen['digest'] as String : null,
+      notice: updateNoticeFrom(
+          json['body'] is String ? json['body'] as String : ''),
     );
   }
 }
+
+/// The heading a release puts over what to read before it is applied.
+///
+/// It is written in the release notes file (web/src/content/releases), the
+/// release pipeline copies that section to the top of the GitHub release, and
+/// this file reads it back out of the release it already fetched. So the same
+/// words are on the site, on GitHub and in the window, and a warning added to
+/// the release page after the event reaches the window on the next check.
+const String updateNoticeHeading = 'Before you update';
+
+/// One line of that section: a bullet, or a paragraph.
+typedef UpdateNoticeLine = ({bool bullet, String text});
+
+/// What a release says to read before it is applied.
+///
+/// The lines under [updateNoticeHeading] in the release's notes, up to the
+/// next heading. Most releases have no such section and get an empty list,
+/// which is the window's cue to stay away. The notes are hard-wrapped
+/// Markdown, so a paragraph is joined back into one line, a bullet keeps its
+/// own, and the marks a window has no use for (bold, code, the address of a
+/// link) are dropped.
+List<UpdateNoticeLine> updateNoticeFrom(String body) {
+  final lines = <UpdateNoticeLine>[];
+  var inside = false;
+  var bullet = false;
+  var text = '';
+  void flush() {
+    if (text.isNotEmpty) lines.add((bullet: bullet, text: _plainNotes(text)));
+    text = '';
+    bullet = false;
+  }
+
+  for (final raw in body.split(RegExp(r'\r?\n'))) {
+    final line = raw.trim();
+    final heading = RegExp(r'^#+\s*(.*?)\s*$').firstMatch(line);
+    if (heading != null) {
+      flush();
+      inside =
+          heading.group(1)!.toLowerCase() == updateNoticeHeading.toLowerCase();
+      continue;
+    }
+    if (!inside) continue;
+    if (line.isEmpty) {
+      flush();
+      continue;
+    }
+    final mark = RegExp(r'^[-*+]\s+').firstMatch(line);
+    if (mark != null) {
+      flush();
+      bullet = true;
+      text = line.substring(mark.end);
+      continue;
+    }
+    text = text.isEmpty ? line : '$text $line';
+  }
+  flush();
+  return lines;
+}
+
+/// Bold, code and link marks off a line: `**Glow**` reads as Glow, and a link
+/// keeps its words and loses its address.
+String _plainNotes(String line) => line
+    .replaceAllMapped(RegExp(r'\[([^\]]+)\]\([^)]*\)'), (m) => m[1]!)
+    .replaceAll(RegExp(r'\*\*|__|`'), '');
 
 /// Which attachments suit this machine, best first.
 ///

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -98,6 +98,42 @@ void main() {
       );
       expect(release?.sha256, 'sha256:abc');
     });
+
+    test('what a release says to read first comes out of its notes', () {
+      final release = UpdateRelease.parse(_releaseJson(body: _noticeBody),
+          platform: 'windows');
+      // Wrapped lines joined, bullets kept, bold and the link's address gone,
+      // and nothing from the section after it.
+      expect(release?.notice, [
+        (
+          bullet: false,
+          text: 'Glow is drawn by a new renderer, so a project that uses it '
+              'will not look the same as it did in 0.3.'
+        ),
+        (bullet: true, text: 'Lens flare loses its Streak count parameter.'),
+        (bullet: true, text: 'See the notes for the rest.'),
+      ]);
+    });
+
+    test('a release with nothing to say before it is applied has no notice',
+        () {
+      final plain = UpdateRelease.parse(
+        _releaseJson(body: "## What's Changed\n\n- A fix\n"),
+        platform: 'windows',
+      );
+      expect(plain?.notice, isEmpty);
+      // GitHub answers without a body when the release has none.
+      expect(UpdateRelease.parse(_releaseJson(), platform: 'windows')?.notice,
+          isEmpty);
+    });
+
+    test('the heading is found whatever its level or case', () {
+      expect(
+        updateNoticeFrom(
+            '### BEFORE YOU UPDATE\nRead this.\n#### Next\nNot this.'),
+        [(bullet: false, text: 'Read this.')],
+      );
+    });
   });
 
   group('checking', () {
@@ -679,19 +715,79 @@ void main() {
       expect(downloads, 0);
       expect(service.stage, UpdateStage.available);
     });
+
+    testWidgets(
+        'a release with something to say says it before the restart question',
+        (tester) async {
+      final service = await _readyService(scratch, notes: _noticeBody);
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+
+      // The notice, with the release's own words, and no restart question yet.
+      expect(find.byKey(const ValueKey('update-notice')), findsOneWidget);
+      expect(find.text('Before you update to Lumit 0.2.0'), findsOneWidget);
+      expect(find.textContaining('Glow is drawn by a new renderer'),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('update-restart-now')), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('update-notice-continue')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('update-notice')), findsNothing);
+      expect(find.byKey(const ValueKey('update-restart-now')), findsOneWidget);
+    });
+
+    testWidgets('Not now on the notice keeps the update waiting and asks again',
+        (tester) async {
+      final service = await _readyService(scratch, notes: _noticeBody);
+      final h = harness(service, dirty: false);
+      await tester.pumpWidget(h.host);
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('update-notice-not-now')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('update-restart-now')), findsNothing);
+      expect(service.stage, UpdateStage.ready);
+      expect(service.downloadedInstaller?.existsSync(), isTrue);
+
+      // The next press of the row puts the same notice up first.
+      await tester.tap(find.byKey(const ValueKey('host-press')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('update-notice')), findsOneWidget);
+    });
   });
 }
 
+/// Release notes with something to say before the update is applied, in the
+/// shape the release pipeline puts at the top of a GitHub release: the section
+/// first, the generated notes after it.
+const String _noticeBody = '''
+## Before you update
+
+Glow is drawn by a new renderer, so a project that uses it
+will not look the same as it did in 0.3.
+
+- **Lens flare** loses its Streak count parameter.
+- See [the notes](https://lumitlab.com/releases/0.4.0) for the rest.
+
+## What's Changed
+
+- Something else entirely
+''';
+
 /// A service already holding a verified download, for the windows that come
 /// after one.
-Future<UpdateService> _readyService(Directory scratch) async {
+Future<UpdateService> _readyService(Directory scratch, {String? notes}) async {
   final body = utf8.encode('installer');
   final service = _service(
     platform: 'windows',
     folder: () => scratch,
     fetch: (_) async => _releaseJson(assets: [
       _asset('lumit-0.2.0-windows-x64-setup.exe', size: body.length),
-    ]),
+    ], body: notes),
     download: (url, into, {required onProgress, required cancelled}) async =>
         into.writeAsBytesSync(body),
     launch: (file, _) async {},
@@ -750,12 +846,15 @@ Map<String, dynamic> _releaseJson({
   bool draft = false,
   bool prerelease = false,
   List<Map<String, dynamic>>? assets,
+  // The release notes. Left out, as an older API answer leaves it out.
+  String? body,
 }) =>
     {
       'tag_name': tag,
       'draft': draft,
       'prerelease': prerelease,
       'html_url': 'https://github.com/luminalmvm/lumit/releases/tag/$tag',
+      if (body != null) 'body': body,
       // What a release actually carries: an installer and a package
       // per platform, plus the Flatpak bundle.
       'assets': assets ??

--- a/web-docs/src/content/docs/start/install.md
+++ b/web-docs/src/content/docs/start/install.md
@@ -60,6 +60,9 @@ within the application via **Help ▸ Check for updates**, or in **Edit ▸ Sett
 General**. If these options don't work, you can manually update by downloading the 
 [latest build](https://lumitlab.com/download).
 
+A release that changes something a project may depend on says so after the download,
+before Lumit restarts. **Not now** keeps the download and leaves the update in the menu.
+
 Releases are announced on the [Lumit releases page](https://lumitlab.com/releases/), 
 [GitHub releases page](https://github.com/luminalmvm/Lumit/releases), and our 
 [Discord](https://discord.gg/dc3p3XC7mM).

--- a/web/README.md
+++ b/web/README.md
@@ -86,6 +86,12 @@ This is separate from the download page, which reads the GitHub releases API: th
 API gives the assets, these files give the prose. Nothing here needs a tag to exist,
 so notes can be written before or after the release goes out.
 
+One section is read by more than the site. A `## Before you update` section, for a
+release that changes something a project may depend on, is copied by `release.yml` to
+the top of the GitHub release, and Lumit shows it after the update is downloaded and
+before it restarts. It has to be in the file when the tag is pushed, and it can be
+edited on the GitHub release afterwards.
+
 ## Brand
 
 `web/src/components/Wordmark.astro` builds the wordmark out of the app icon on load,

--- a/web/src/content/releases/_template.md
+++ b/web/src/content/releases/_template.md
@@ -21,3 +21,10 @@ release is for, then break the detail into sections.
 ## Fixed
 
 - Past tense, one line per fix.
+
+## Before you update
+
+- Only when the release changes something a project may depend on, such as an
+  effect that no longer draws the same. Leave the section out otherwise.
+- Lumit shows this section after the update is downloaded and before it restarts,
+  so keep it to what the reader has to know.


### PR DESCRIPTION
A release can now carry a `## Before you update` section in its notes (web/src/content/releases/version.md), for an effect that no longer draws the same or anything else a project may depend on. After the download Lumit shows that section, before the restart question, and Not now doesn't perform the update. release.yml copies the section to the top of the GitHub release, so writing it in the notes file is the only place it needs to be written, and editing the release on GitHub afterwards works too. A release without the section gets no window.

To test, edit the latest release on GitHub and add a `## Before you update` section with a couple of bullets, then in a build older than that release run Help ▸ Check for updates and download it. 

Also fixes the filled buttons on the update windows, which drew their label in grey. New strings for the translation page: updateContinue, updateNoticeBody, updateNoticeTitle.
