### PR TITLE
Ease a linked Scale as one curve

### DIFF
--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -1595,8 +1595,9 @@ the one sanctioned way a group reaches the picture.
     Anchor point, Position or Scale offers Separate axes** (docs/03 §6.5): each axis
     takes a row of its own, with its own stopwatch, its own lane and its own curve, and
     *Combine axes* puts them back — merging the axes' key times as it goes, exactly, so the
-    picture does not move. **Scale is linked by default** and draws one box, an edit holding
-    the x:y ratio; *Unlink axes* gives it a box per axis. Each command is one undo
+    picture does not move. **Scale is linked by default** and draws one box and one graph
+    curve, an edit to either holding the x:y ratio; *Unlink axes* gives it a box and a curve
+    per axis. Each command is one undo
     step. The Viewer's gizmo is unchanged by any of it: it reads the resolved transform,
     which has always been per-axis.
   - **Effects**, only when the layer has any: one row per effect, opening onto that effect's
@@ -2037,7 +2038,8 @@ instead (§4.4).
 **Shipped:** the graph editor is one **full-height pane** over the Timeline's own
 ruler, zoom and horizontal scroll (`Shift+F3` or the toolbar's Graph toggle), drawing every
 selected property as its own coloured curve — a multi-axis property contributes one curve
-per axis, and a static property draws as its flat value line. The curves are evaluated by a
+per axis (a linked Scale one curve, its other axis following every edit), and a static
+property draws as its flat value line. The curves are evaluated by a
 Dart port of the engine's cubic (`graph_maths.dart`, pinned to `anim.rs` by
 docs/impl/keyframe-eval.md and golden tests), so a paint costs zero bridge calls.
 Landed from the lists above: the **value and speed lenses** (key-command-strip buttons; the speed

--- a/flutter_ui/lib/panels/effect_param_row_frb.dart
+++ b/flutter_ui/lib/panels/effect_param_row_frb.dart
@@ -1585,11 +1585,13 @@ class EffectPointRowFrb extends StatelessWidget {
     // all — every number is nought times something — so a pair dragged off
     // zero separates instead of staying stuck there.
     //
-    // A **keyed** sibling scales whole: every keyframe's value times
-    // the factor, each key keeping its time, its interpolation and its eased
-    // shape, which is the same arithmetic `scale_property` does engine-side
-    // ([scaledScalar]). Scaling only the value under the playhead would plant
-    // keys nobody made.
+    // A **keyed** sibling of a static well scales whole: every keyframe's
+    // value times the factor, each key keeping its time, its interpolation
+    // and its eased shape, which is the same arithmetic `scale_property` does
+    // engine-side ([scaledScalar]). Once the well is keyed too, its edit is a
+    // key at the playhead, so the sibling takes a key there as well, at the
+    // ratio the pair reads on that frame. Stretching its whole curve instead
+    // left the two halves agreeing at the playhead and nowhere else.
     double? currentOf(BridgeScalar? scalar) => switch (scalar) {
           BridgeScalar_Static(:final field0) => field0,
           final BridgeScalar_Keyframed keyed =>
@@ -1606,13 +1608,17 @@ class EffectPointRowFrb extends StatelessWidget {
           : scalarWithValueAt(scalar, next, comp, frame));
       final other = param.id == xParam.id ? yParam : xParam;
       final otherScalar = other.id == xParam.id ? sx : sy;
-      final scaled = (!linked ||
-              before == null ||
-              before == 0 ||
-              otherScalar == null ||
-              otherScalar is BridgeScalar_Expression)
-          ? null
-          : BridgeEffectValue.float(scaledScalar(otherScalar, next / before));
+      BridgeEffectValue? scaled;
+      if (linked && before != null && before != 0 && otherScalar != null) {
+        final otherBefore = currentOf(otherScalar);
+        if (otherBefore != null) {
+          scaled = BridgeEffectValue.float(scalar is BridgeScalar_Keyframed &&
+                  otherScalar is BridgeScalar_Keyframed
+              ? scalarWithValueAt(
+                  otherScalar, next * otherBefore / before, comp, frame)
+              : scaledScalar(otherScalar, next / before));
+        }
+      }
       // Both halves as **one** op where the caller can commit one: two writes
       // would be two undo steps for a gesture that moved one well.
       if (!live && scaled != null && onWritePair != null) {

--- a/flutter_ui/lib/panels/graph_channels.dart
+++ b/flutter_ui/lib/panels/graph_channels.dart
@@ -92,6 +92,11 @@ class GraphChannel {
   /// Set for a transform channel; null for an effect parameter.
   final BridgeTransformProp? prop;
 
+  /// The axis that follows this one while the row is linked, or null. Not a
+  /// channel of its own: a linked pair is one curve, so the graph draws the
+  /// lead and every write to it is the pair's write ([withLinkedPartners]).
+  final BridgeTransformProp? linkedPartner;
+
   /// Set for an effect parameter channel.
   final BridgeEffectInstanceInfo? effect;
   final BridgeParamInfo? param;
@@ -129,6 +134,7 @@ class GraphChannel {
     required this.scalar,
     required this.entry,
     this.prop,
+    this.linkedPartner,
     this.effect,
     this.param,
     this.retime = false,
@@ -237,17 +243,22 @@ List<GraphChannel> graphChannels({
       for (final group in transformGroups(
           threeD: entry.info.switches.threeD, modes: entry.info.axisModes)) {
         if (group.axes.first.prop.name != lead) continue;
-        for (final axis in group.axes) {
+        // A linked pair is one curve, as it is one box on the row. The lead
+        // is drawn and edited; the partner follows every write at the ratio
+        // the pair holds ([withLinkedPartners]).
+        final axes = group.isLinked ? group.axes.sublist(0, 1) : group.axes;
+        for (final axis in axes) {
           out.add(GraphChannel(
             path: path,
             id: '$path@${axis.prop.name}',
-            label: group.axes.length == 1
+            label: axes.length == 1
                 ? '${entry.info.name} · ${group.label}'
                 : '${entry.info.name} · ${group.label} ${axisLetter(group.axes.indexOf(axis))}',
             colourIndex: out.length,
             scalar: read(entry.info.transform, axis.prop),
             entry: entry,
             prop: axis.prop,
+            linkedPartner: group.isLinked ? group.axes[1].prop : null,
           ));
         }
         break;

--- a/flutter_ui/lib/panels/graph_edits.dart
+++ b/flutter_ui/lib/panels/graph_edits.dart
@@ -10,20 +10,73 @@ import 'easing_curve.dart';
 import 'graph_channels.dart';
 import 'graph_maths.dart';
 import 'key_block.dart';
+import 'keyframe_controls_frb.dart' show scaledScalar;
 import 'layer_fold_frb.dart';
 import 'text_animator_rows_frb.dart';
 import 'transform_rows_frb.dart';
 
+/// [edits] with each linked partner's curve written beside its lead's.
+///
+/// A linked pair is one curve on the graph, so a write to the lead is the
+/// pair's write: the partner takes the same keys at the ratio the pair held.
+/// The commit and the preview both go through here, so a drag shows what its
+/// release will write. An expression on either side is left alone.
+Map<GraphChannel, BridgeScalar> withLinkedPartners(
+    Map<GraphChannel, BridgeScalar> edits) {
+  final out = Map.of(edits);
+  edits.forEach((channel, next) {
+    final partner = channel.linkedPartner;
+    if (partner == null) return;
+    final was = read(channel.entry.info.transform, partner);
+    if (channel.scalar is BridgeScalar_Expression ||
+        was is BridgeScalar_Expression ||
+        next is BridgeScalar_Expression) {
+      return;
+    }
+    out[GraphChannel(
+      path: channel.path,
+      id: '${channel.path}@${partner.name}',
+      label: channel.label,
+      colourIndex: channel.colourIndex,
+      scalar: was,
+      entry: channel.entry,
+      prop: partner,
+    )] = linkedPartnerScalar(channel.scalar, was, next);
+  });
+  return out;
+}
+
+/// The curve a linked partner takes when its lead is written [next]: the same
+/// keys and eases, every value at the ratio the pair held.
+///
+/// The ratio is read where the lead was furthest from nought, since a key at
+/// nought (a scale growing from nothing) has no ratio in it. A lead at nought
+/// everywhere has none to hold, so the partner simply matches it, as the
+/// row's drag does.
+BridgeScalar linkedPartnerScalar(
+    BridgeScalar lead, BridgeScalar partner, BridgeScalar next) {
+  var t = 0.0;
+  var x = evaluateScalar(lead, 0);
+  for (final key in keysOf(lead)) {
+    if (key.value.abs() > x.abs()) {
+      x = key.value;
+      t = rationalSeconds(key.time);
+    }
+  }
+  return scaledScalar(next, x == 0 ? 1 : evaluateScalar(partner, t) / x);
+}
+
 /// Commit new scalars for a set of channels in the fewest ops: one
 /// `setTransforms` batch per layer for its transform channels (one undo step),
-/// one staged `setEffects` per layer for its effect channels.
+/// one staged `setEffects` per layer for its effect channels. A linked lead's
+/// partner is written in the same batch ([withLinkedPartners]).
 void commitChannelEdits(Map<GraphChannel, BridgeScalar> edits) {
   // Transform channels, grouped by layer.
   final transforms = <String,
       (LayerReference, List<BridgeTransformProp>, List<BridgeScalar>)>{};
   final effects =
       <String, (LayerReference, Map<String, Map<String, BridgeScalar>>)>{};
-  edits.forEach((channel, next) {
+  withLinkedPartners(edits).forEach((channel, next) {
     final layerId = channel.entry.layer.internallayerId.toString();
     if (channel.prop != null) {
       final slot = transforms[layerId] ??= (channel.entry.layer, [], []);
@@ -58,8 +111,8 @@ void commitChannelEdits(Map<GraphChannel, BridgeScalar> edits) {
       // property; two curves on one mask are two writes and two undo steps,
       // which is what `SetLayerMasks` costs until it grows a per-key op.
       channel.entry.layer.setMask(
-        mask: maskWithScalar(mask, channel.maskValue!, next,
-            channel.maskVertex),
+        mask:
+            maskWithScalar(mask, channel.maskValue!, next, channel.maskVertex),
         at: null,
       );
     }
@@ -106,7 +159,8 @@ void previewChannelEdits({
   required double scale,
 }) {
   if (edits.isEmpty) return;
-  final lead = edits.keys.first;
+  final all = withLinkedPartners(edits);
+  final lead = all.keys.first;
   final layer = lead.entry.layer;
   final layerId = layer.internallayerId.toString();
   bool sameLayer(GraphChannel c) =>
@@ -118,14 +172,14 @@ void previewChannelEdits({
       frame: bigFrame,
       scale: scale,
       layer: layer,
-      retime: edits[lead]!,
+      retime: all[lead]!,
     );
     return;
   }
 
   if (lead.prop != null) {
     var transform = layer.getTransform();
-    edits.forEach((channel, next) {
+    all.forEach((channel, next) {
       if (!sameLayer(channel) || channel.prop == null) return;
       transform = writeScalar(transform, channel.prop!, next);
     });

--- a/flutter_ui/test/frb/effect_controls_frb_test.dart
+++ b/flutter_ui/test/frb/effect_controls_frb_test.dart
@@ -2117,9 +2117,76 @@ void main() {
           reason: 'x doubled, so y doubled — the ratio is what is kept');
     });
 
-    /// A **keyed** other half scales whole: every key's value times the
-    /// factor, every key's time, interpolation and eased shape held. Scaling
-    /// only the number under the playhead would plant keys nobody made.
+    /// Both halves keyed, the well's edit is a key at the playhead, so the
+    /// other half takes one there too, at the ratio the pair reads on that
+    /// frame. Stretching its whole curve instead left the two halves agreeing
+    /// at the playhead and nowhere else.
+    testWidgets(
+        'a chained pair keyed on both halves plants the other key at the playhead',
+        (tester) async {
+      final p = withLayer();
+      p.layer.addEffect(name: 'lens_flare');
+      p.uiState.model.refresh();
+      await mount(tester, p, transform: false);
+
+      final id = p.layer.getEffects().single.id();
+      List<BridgeKeyframe> keysOf(String param) => ((p.layer
+                  .getInfo()
+                  .effects
+                  .single
+                  .values
+                  .firstWhere((e) => e.id == param)
+                  .value as BridgeEffectValue_Float)
+              .field0 as BridgeScalar_Keyframed)
+          .field0;
+      BridgeKeyframe key(int seconds, double value) => BridgeKeyframe(
+            time: BridgeRational(num: seconds, den: 1),
+            value: value,
+            interpIn: const BridgeSideInterp.linear(),
+            interpOut: const BridgeSideInterp.linear(),
+          );
+
+      // x and y both ramp, at 2:1.
+      final stack = p.layer.getEffects();
+      stack.single
+        ..setValue(
+            id: 'light_x',
+            value: BridgeEffectValue.float(
+                BridgeScalar.keyframed([key(0, 100), key(2, 300)])))
+        ..setValue(
+            id: 'light_y',
+            value: BridgeEffectValue.float(
+                BridgeScalar.keyframed([key(0, 50), key(2, 150)])));
+      p.layer.setEffects(effects: stack);
+      p.uiState.model.refresh();
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.byKey(ValueKey<String>('fx-pair-link-$id-light_x')));
+      await tester.pumpAndSettle();
+
+      // Halfway along, where neither half has a key: x reads 200, y 100.
+      p.uiState.playheadFrame.value = p.uiState.selectedComp!
+          .frameAtTime(time: const BridgeRational(num: 1, den: 1));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(ValueKey<String>('fx-float-$id-light_x')));
+      await tester.pump();
+      await tester.enterText(find.byType(EditableText).first, '400');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      final x = keysOf('light_x');
+      final y = keysOf('light_y');
+      expect([for (final k in x) k.value], [100.0, 400.0, 300.0],
+          reason: 'the well took a key at the playhead');
+      expect([for (final k in y) k.value], [50.0, 200.0, 150.0],
+          reason: 'so did the other half, at the 2:1 the pair reads there');
+      expect([for (final k in y) k.time], [for (final k in x) k.time]);
+    });
+
+    /// A **keyed** other half of a static well scales whole: every key's
+    /// value times the factor, every key's time, interpolation and eased
+    /// shape held. Scaling only the number under the playhead would plant
+    /// keys nobody made.
     testWidgets('a chained pair scales a keyed half key by key',
         (tester) async {
       final p = withLayer();
@@ -2276,8 +2343,7 @@ void main() {
       p.layer.setGraph(
         drivers: p.layer.getGraphDrivers(),
         wiring: const BridgeGraphWiring(
-        outUnwired: false,
-            edges: [], layout: [], exposed: [], groups: []),
+            outUnwired: false, edges: [], layout: [], exposed: [], groups: []),
       );
       p.uiState.model.refresh();
       await tester.pump();

--- a/flutter_ui/test/frb/separate_axes_frb_test.dart
+++ b/flutter_ui/test/frb/separate_axes_frb_test.dart
@@ -13,6 +13,7 @@ import 'package:lumit_flutter/panels/graph_editor_frb.dart';
 import 'package:lumit_flutter/panels/layer_fold_frb.dart';
 import 'package:lumit_flutter/panels/transform_rows_frb.dart';
 import 'package:lumit_flutter/src/rust/api/composition.dart';
+import 'package:lumit_flutter/src/rust/api/effect.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
 
 import 'frb_test_support.dart';
@@ -130,7 +131,80 @@ void main() {
       expect(rows, containsAll(<String>['Scale x', 'Scale y']));
     });
 
-    testWidgets('a 3D layer separates Position into three rows', (tester) async {
+    /// A linked Scale is one curve as it is one box: the graph draws the lead
+    /// axis, and an edit to it reaches the other at the ratio the pair holds.
+    /// Two curves eased one at a time was the reported bug: easing x left y
+    /// linear, and the picture stretched on the way.
+    testWidgets(
+        'a linked Scale is one curve, and an ease on it reaches both axes',
+        (tester) async {
+      final p = withComp();
+      final layer = solid(p);
+      final id = layer.internallayerId.toString();
+      BridgeKeyframe key(int seconds, double value) => BridgeKeyframe(
+            time: BridgeRational(num: seconds, den: 1),
+            value: value,
+            interpIn: const BridgeSideInterp.linear(),
+            interpOut: const BridgeSideInterp.linear(),
+          );
+      layer.setTransforms(props: [
+        BridgeTransformProp.scaleX,
+        BridgeTransformProp.scaleY,
+      ], values: [
+        BridgeScalar.keyframed([key(0, 100), key(1, 200)]),
+        BridgeScalar.keyframed([key(0, 50), key(1, 100)]),
+      ]);
+      final scalePath = transformGroupPath(
+        id,
+        transformGroups(threeD: false, modes: entryOf(p).info.axisModes)
+            .firstWhere((g) => g.label == 'Scale'),
+      );
+
+      final channels =
+          graphChannels(layers: [entryOf(p)], selected: [scalePath]);
+      expect(channels.length, 1,
+          reason: 'one box on the row, one curve on the graph');
+      expect(channels.single.prop, BridgeTransformProp.scaleX);
+      expect(channels.single.linkedPartner, BridgeTransformProp.scaleY);
+      expect(channels.single.label, endsWith('Scale'),
+          reason: 'no axis letter on a row that shows none');
+
+      const eased =
+          BridgeSideInterp.bezier(BridgeBezierSide(speed: 0, influence: 0.5));
+      applyInterpToSelection(
+        channels: channels,
+        selectedKeys: {'${channels.single.id}#0', '${channels.single.id}#1'},
+        side: eased,
+      );
+
+      final tf = layer.getTransform();
+      final x = (tf.scaleX as BridgeScalar_Keyframed).field0;
+      final y = (tf.scaleY as BridgeScalar_Keyframed).field0;
+      expect(x.first.interpOut, eased);
+      expect(y.first.interpOut, eased,
+          reason: 'the ease reached the axis the graph does not draw');
+      expect([for (final k in y) k.value], [50.0, 100.0],
+          reason: 'the ratio held');
+      expect([for (final k in y) k.time], [for (final k in x) k.time]);
+
+      // The pair was one write, so one undo takes both back.
+      p.state.project!.undo();
+      expect(
+          (layer.getTransform().scaleY as BridgeScalar_Keyframed)
+              .field0
+              .first
+              .interpOut,
+          const BridgeSideInterp.linear());
+
+      // Unlinked, the pair is two curves again.
+      layer.setAxisMode(
+          pair: BridgeTransformPair.scale, mode: BridgeAxisMode.combined);
+      expect(
+          graphChannels(layers: [entryOf(p)], selected: [scalePath]).length, 2);
+    });
+
+    testWidgets('a 3D layer separates Position into three rows',
+        (tester) async {
       final p = withComp();
       final layer = solid(p)
         ..setSwitch(switch_: BridgeLayerSwitch.threeD, on_: true);

--- a/flutter_ui/test/graph_edits_test.dart
+++ b/flutter_ui/test/graph_edits_test.dart
@@ -1,0 +1,75 @@
+// The graph's linked-pair arithmetic: what the other axis of a linked Scale
+// takes when the drawn curve is written. Pure, so it is checked here rather
+// than through the engine, as graph_maths_test.dart checks the evaluator.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/panels/graph_edits.dart';
+import 'package:lumit_flutter/src/rust/api/effect.dart';
+
+BridgeKeyframe key(
+  int seconds,
+  double value, {
+  BridgeSideInterp interpIn = const BridgeSideInterp.linear(),
+  BridgeSideInterp interpOut = const BridgeSideInterp.linear(),
+}) =>
+    BridgeKeyframe(
+        time: BridgeRational(num: seconds, den: 1),
+        value: value,
+        interpIn: interpIn,
+        interpOut: interpOut);
+
+List<double> valuesOf(BridgeScalar scalar) =>
+    [for (final k in (scalar as BridgeScalar_Keyframed).field0) k.value];
+
+void main() {
+  group('linkedPartnerScalar', () {
+    const eased =
+        BridgeSideInterp.bezier(BridgeBezierSide(speed: 40, influence: 0.3));
+    final lead = BridgeScalar.keyframed([key(0, 100), key(1, 200)]);
+    final partner = BridgeScalar.keyframed([key(0, 50), key(1, 100)]);
+    // The lead rewritten: a key moved, a key eased.
+    final next = BridgeScalar.keyframed(
+        [key(0, 100, interpOut: eased), key(2, 300, interpIn: eased)]);
+
+    test('the partner takes the lead\'s keys at the ratio the pair held', () {
+      final got = linkedPartnerScalar(lead, partner, next);
+      expect(valuesOf(got), [50.0, 150.0]);
+      final keys = (got as BridgeScalar_Keyframed).field0;
+      expect([for (final k in keys) k.time],
+          [for (final k in (next as BridgeScalar_Keyframed).field0) k.time]);
+      const halved =
+          BridgeSideInterp.bezier(BridgeBezierSide(speed: 20, influence: 0.3));
+      expect(keys.first.interpOut, halved,
+          reason: 'speed is on the value axis, influence is not');
+      expect(keys.last.interpIn, halved);
+    });
+
+    test('a key at nought does not decide the ratio', () {
+      final fromNothing = BridgeScalar.keyframed([key(0, 0), key(1, 100)]);
+      final half = BridgeScalar.keyframed([key(0, 0), key(1, 50)]);
+      expect(valuesOf(linkedPartnerScalar(fromNothing, half, next)),
+          [50.0, 150.0]);
+    });
+
+    test('a lead at nought everywhere has no ratio, so the partner matches it',
+        () {
+      expect(
+          valuesOf(linkedPartnerScalar(const BridgeScalar.static_(0),
+              const BridgeScalar.static_(50), next)),
+          [100.0, 300.0]);
+    });
+
+    test('a static pair keyed through the graph keys both', () {
+      expect(
+          valuesOf(linkedPartnerScalar(const BridgeScalar.static_(100),
+              const BridgeScalar.static_(50), next)),
+          [50.0, 150.0]);
+    });
+
+    test('the last key deleted leaves the partner static at the ratio', () {
+      expect(
+          linkedPartnerScalar(lead, partner, const BridgeScalar.static_(200)),
+          const BridgeScalar.static_(100));
+    });
+  });
+}


### PR DESCRIPTION
A linked Scale drew two curves in the Graph editor, so easing one axis left the other linear and the picture stretched on the way. It now draws one curve for linked properties, and any edit affects the other axis at the ratio the pair holds.

Also fixes a linked pair in the effect controls once both halves are keyframed, which planted a key on one half but stretched the other half's whole curve. The other half now takes a key at the playhead too.

To test, keyframe a layer's Scale with the link on, open graph view and drag a bezier handle, there should be one curve and the picture should scale evenly. Then add a Transform effect, link its scale, keyframe both halves, move the playhead between the keys and change one half, the other should get a key there at the same ratio.
