### PR TITLE
Rename the Windows exe to lumit.exe and update by installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@
 #
 # Three things are *installed*: a Windows setup .exe, a macOS .dmg and a
 # Linux .flatpak — one per platform, and the Linux tarball is withdrawn. Beside
-# them ride the plain application archives the in-place updater fetches:
-# a Windows .zip and a macOS .zip, which are not installers and are not offered
-# as a way to install. Every job gates the release; nothing is
+# them rides the plain macOS .zip the in-place updater fetches, which is not an
+# installer and is not offered as a way to install. Windows updates run the
+# setup .exe again, silently. Every job gates the release; nothing is
 # continue-on-error, so a partial release is never published quietly.
 #
 # Toolchain steps mirror ci.yml's `windows` and `flutter-linux` jobs exactly
@@ -91,25 +91,13 @@ jobs:
         run: |
           $version = "$env:RELEASE_VERSION".TrimStart('v')
           & packaging/windows/build-installer.ps1 -Version $version
-      # The same files the installer lays down, as a plain archive.
-      # This is what a per-user installation fetches to update itself: no
-      # installer to run, no elevation, no questions already answered once.
-      - name: Package the app for in-place updates
-        shell: pwsh
-        run: |
-          $version = "$env:RELEASE_VERSION".TrimStart('v')
-          $stage = "$env:RUNNER_TEMP\lumit-package"
-          New-Item -ItemType Directory -Force -Path "$stage\icons" | Out-Null
-          Copy-Item -Recurse -Force flutter_ui\build\windows\x64\runner\Release\* $stage
-          Copy-Item assets\brand\lumit-project.ico, assets\brand\lumit-preset.ico "$stage\icons"
-          Compress-Archive -Path "$stage\*" -Force `
-            -DestinationPath "packaging/windows/dist/lumit-$version-windows-x64.zip"
+      # The installer is the whole Windows release. An update downloads it
+      # again and runs it silently, which is also what renames or removes
+      # files the last version left, so there is no plain archive beside it.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-installer
-          path: |
-            packaging/windows/dist/*.exe
-            packaging/windows/dist/*.zip
+          path: packaging/windows/dist/*.exe
           if-no-files-found: error
 
   linux-bundle:

--- a/docs/07-UI-SPEC.md
+++ b/docs/07-UI-SPEC.md
@@ -302,8 +302,10 @@ panel layout is.
   the state changes. Downloading MUST show progress in the same row, and a downloaded update
   MUST read "Restart to finish updating" until it is applied.
 - **How an update is applied** follows where Lumit is installed, and the restart
-  window MUST say which it is: swapped in place and restarted (a per-user installation, the
-  normal case), handed to the installer (anywhere Lumit cannot write to its own files), or
+  window MUST say which it is: swapped in place and restarted (a per-user macOS bundle),
+  handed to the installer (Windows, where the installer runs silently over the per-user
+  folder and is what rewrites the shortcut and the file associations, and anywhere else
+  Lumit cannot write to its own files), or
   handed to Flatpak with the install command, in which case Lumit MUST NOT offer to restart
   because it is not replacing anything.
 - **Before you update.** A release whose notes carry a *Before you update* section MUST

--- a/docs/impl/ui-performance.md
+++ b/docs/impl/ui-performance.md
@@ -764,7 +764,7 @@ cause. The wheel legs are sized from the measured vertical extent (printed) so t
 scroll rather than grind the stops — §2.6 is the row that mistake produced.
 `probe_frame_window_test.dart` pins the windowing. Two traps for whoever runs it
 next: fps figures from before this date read ~15% low, and **a leftover
-`lumit_flutter.exe` from an earlier run occludes the new window and halves the whole
+`lumit.exe` from an earlier run occludes the new window and halves the whole
 table** — kill it first, and trust the run only if the gesture rows reproduce their
 class.
 

--- a/flutter_ui/lib/state/updates.dart
+++ b/flutter_ui/lib/state/updates.dart
@@ -264,20 +264,19 @@ String _plainNotes(String line) => line
 
 /// Which attachments suit this machine, best first.
 ///
-/// A per-user installation prefers the *package* — the plain archive of the
-/// application's own files — because that can be swapped in without an
-/// installer or an administrator. An installation Lumit cannot write beside
-/// gets the installer, and gets it as the **only** candidate.
+/// Windows always takes the installer. It runs silently over the folder it
+/// installed into, needs no administrator there, and it is the one thing that
+/// rewrites the Start Menu shortcut and the file associations, which the
+/// in-place swap never touched. That is what let the runner be renamed to
+/// lumit.exe without stranding either. A per-user macOS bundle prefers the
+/// plain archive, which is swapped in without an installer, and a bundle Lumit
+/// can't write beside gets the disk image as the only candidate.
 ///
-/// **That last word is the whole of the fix.** [replaceable] used to be asked
-/// only of the delivery, not of the download, so an older installation in
-/// `Program Files` fetched the archive — correctly, the download worked — and
-/// was then told it would be applied by "installer", which means running the
-/// downloaded file. Running a `.zip` starts nothing. The update button did
-/// nothing, the application did not quit, and a restart by hand came back on
-/// the old version, because the archive it had was never going to be unpacked
-/// by anybody. The asset and the delivery are one decision and are taken here
-/// together.
+/// [replaceable] is asked of the download as well as the delivery, so an
+/// installation that can't be swapped never fetches an archive it would then
+/// be told to run. Running a `.zip` starts nothing, which was the v0.2 upgrade
+/// that downloaded, offered a restart, and did not restart. The asset and the
+/// delivery are one decision and are taken here together.
 ///
 /// Linux is the exception, and deliberately: there is no installer attachment
 /// to fall back to — the tarball is all a release carries — so an unwritable
@@ -291,9 +290,7 @@ List<String> assetSuffixesFor(String platform,
   if (kind == InstallKind.flatpak) return const ['.flatpak'];
   switch (platform) {
     case 'windows':
-      return kind == InstallKind.folder && replaceable
-          ? const ['windows-x64.zip', '.exe']
-          : const ['.exe'];
+      return const ['.exe'];
     case 'macos':
       return kind == InstallKind.bundle && replaceable
           ? const ['macos-arm64.zip', 'macos-x64.zip', 'macos.zip', '.dmg']

--- a/flutter_ui/test/updates_test.dart
+++ b/flutter_ui/test/updates_test.dart
@@ -449,15 +449,30 @@ void main() {
   });
 
   group('choosing how to update', () {
-    test('a per-user installation is offered the package, not the installer',
-        () {
+    test('a per-user Windows installation takes the installer too', () {
+      // The installer is the one thing that rewrites the Start Menu shortcut
+      // and the file associations, which is what let the runner be renamed,
+      // and a per-user folder needs no administrator for it to run. The
+      // sample release still carries the package 0.3.2 shipped, and Windows
+      // has to walk past it.
       final release = UpdateRelease.parse(
         _releaseJson(),
         platform: 'windows',
         kind: InstallKind.folder,
         replaceable: true,
       );
-      expect(release?.assetName, 'lumit-0.2.0-windows-x64.zip');
+      expect(release?.assetName, 'lumit-0.2.0-windows-x64-setup.exe');
+      expect(release?.delivery, UpdateDelivery.installer);
+    });
+
+    test('a per-user macOS bundle is offered the package, not the image', () {
+      final release = UpdateRelease.parse(
+        _releaseJson(),
+        platform: 'macos',
+        kind: InstallKind.bundle,
+        replaceable: true,
+      );
+      expect(release?.assetName, 'lumit-0.2.0-macos-arm64.zip');
       expect(release?.delivery, UpdateDelivery.inPlace);
     });
 

--- a/flutter_ui/windows/CMakeLists.txt
+++ b/flutter_ui/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(lumit_flutter LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "lumit_flutter")
+set(BINARY_NAME "lumit")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/flutter_ui/windows/runner/Runner.rc
+++ b/flutter_ui/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "dev.lumit" "\0"
-            VALUE "FileDescription", "lumit_flutter" "\0"
+            VALUE "FileDescription", "Lumit" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "lumit_flutter" "\0"
+            VALUE "InternalName", "lumit" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2026 dev.lumit. All rights reserved." "\0"
-            VALUE "OriginalFilename", "lumit_flutter.exe" "\0"
-            VALUE "ProductName", "lumit_flutter" "\0"
+            VALUE "OriginalFilename", "lumit.exe" "\0"
+            VALUE "ProductName", "Lumit" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/packaging/windows/lumit.iss
+++ b/packaging/windows/lumit.iss
@@ -12,7 +12,7 @@
 #ifndef MyAppVersion
 #define MyAppVersion "0.1.0"
 #endif
-#define MyAppExe "lumit_flutter.exe"
+#define MyAppExe "lumit.exe"
 
 [Setup]
 AppId={{8B6F1C6A-9E4B-4C7D-B1A4-6C1E5D2F7A31}
@@ -20,11 +20,11 @@ AppName=Lumit
 AppVersion={#MyAppVersion}
 AppPublisher=Lumit
 AppPublisherURL=https://github.com/luminalmvm/Lumit
-; Per user, not per machine. This is what lets Lumit update itself the
-; way Chrome and VS Code do: {localappdata} belongs to the person running it, so
-; the application can put a new version down beside the old one and swap them
-; over without an administrator and without running this installer again.
-; `PrivilegesRequired=lowest` means no UAC prompt to install in the first place.
+; Per user, not per machine, the way Chrome and VS Code install. {localappdata}
+; belongs to the person running it, so neither the first install nor an update
+; needs an administrator: an update downloads this installer again and runs it
+; silently over the folder it installed into. `PrivilegesRequired=lowest` means
+; no UAC prompt either way.
 PrivilegesRequired=lowest
 DefaultDirName={localappdata}\Programs\Lumit
 ; An existing installation keeps its folder, wherever a previous version put it
@@ -53,6 +53,11 @@ Source: "..\..\flutter_ui\build\windows\x64\runner\Release\*"; DestDir: "{app}";
 Source: "..\..\assets\brand\lumit-project.ico"; DestDir: "{app}\icons"
 Source: "..\..\assets\brand\lumit-preset.ico"; DestDir: "{app}\icons"
 Source: "..\..\assets\brand\lumit-theme.ico"; DestDir: "{app}\icons"
+
+[InstallDelete]
+; The runner was lumit_flutter.exe up to 0.3.2. An update over one of those
+; installs would leave the old name beside the new one without this.
+Type: files; Name: "{app}\lumit_flutter.exe"
 
 [Icons]
 Name: "{group}\Lumit"; Filename: "{app}\{#MyAppExe}"

--- a/scripts/discord-release.mjs
+++ b/scripts/discord-release.mjs
@@ -27,7 +27,6 @@ import { dirname, join } from 'node:path';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const NOTES_DIR = join(ROOT, 'web', 'src', 'content', 'releases');
 const SITE = 'https://lumitlab.com';
-const REPO = 'https://github.com/luminalmvm/Lumit';
 const LIMIT = 1900; // Discord's cap is 2000; leave room for a stray wide glyph
 
 const args = process.argv.slice(2);
@@ -201,9 +200,9 @@ async function main() {
     `# ${title}`,
     '',
     ...(meta.description ? [meta.description, ''] : []),
-    `Full notes: <${SITE}/releases/${version}>`,
+    // One link, to the download page. The notes below say what changed, and
+    // the site and the GitHub release are a click away from there.
     `Download: <${SITE}/download>`,
-    `GitHub release: <${REPO}/releases/tag/v${version}>`,
     '',
     unwrap(body),
   ].join('\n');


### PR DESCRIPTION
The in-place update swap renamed the install folder, which Windows refuses while the OFX brokers run out of it, so an update downloaded, offered a restart and then did nothing. Windows updates now download the setup exe and run it silently, which closes the brokers and rewrites the Start Menu shortcut and the .lum associations as well. The runner is lumit.exe rather than lumit_flutter.exe, and the installer deletes the old name when it updates over an older install. macOS keeps the bundle swap and Linux is unchanged.

The Windows zip is no longer built or attached to a release. That is what makes this reach people already on 0.3.1 and 0.3.2, since their updater prefers the zip and falls back to the setup exe when there isn't one. The zip is already off the 0.3.2 release, and a 0.3.1 install updated itself to 0.3.2 from inside the application to prove it.

To test, install an older version, then Help > Check for updates and take it through to Restart now. It should close, install and reopen on the new version with nothing to answer. Check the Start Menu shortcut still opens it, a .lum file still opens in Lumit, and lumit_flutter.exe is gone from the install folder.

No new translation keys.
