### PR TITLE
OFX plugins receive frame info either side of current

### DIFF
--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -11498,6 +11498,7 @@ fn pressing_a_plugins_button_writes_what_it_did_into_the_document() {
             _time: f64,
             _params: &lumit_ofx::ParamSnapshot,
             source: lumit_ofx::Frame16,
+            _neighbours: &[(i32, lumit_ofx::Frame16)],
         ) -> lumit_ofx::Rendering {
             lumit_ofx::Rendering {
                 frame: source,
@@ -11838,6 +11839,7 @@ fn a_plugin_that_fails_a_frame_badges_its_layer_and_the_next_frame_clears_it() {
             _time: f64,
             _params: &lumit_ofx::ParamSnapshot,
             source: lumit_ofx::Frame16,
+            _neighbours: &[(i32, lumit_ofx::Frame16)],
         ) -> lumit_ofx::Rendering {
             if self.failing.load(Ordering::SeqCst) {
                 return lumit_ofx::Rendering {
@@ -11919,6 +11921,7 @@ fn a_plugin_that_fails_a_frame_badges_its_layer_and_the_next_frame_clears_it() {
         4,
         4,
         lumit_core::fx::Params::EMPTY,
+        &[],
     );
 
     // **Identity, byte for byte.** A failed plugin costs the layer its effect,
@@ -11951,6 +11954,7 @@ fn a_plugin_that_fails_a_frame_badges_its_layer_and_the_next_frame_clears_it() {
         4,
         4,
         lumit_core::fx::Params::EMPTY,
+        &[],
     );
     let cleared =
         crate::api::effect::read_instance_info(&instance, lumit_core::time::Rational::ZERO);
@@ -11973,6 +11977,7 @@ fn a_plugin_that_fails_a_frame_badges_its_layer_and_the_next_frame_clears_it() {
         4,
         4,
         lumit_core::fx::Params::EMPTY,
+        &[],
     );
     let switched_off =
         crate::api::effect::read_instance_info(&off, lumit_core::time::Rational::ZERO);

--- a/crates/lumit-core/src/fx/registry.rs
+++ b/crates/lumit-core/src/fx/registry.rs
@@ -258,6 +258,32 @@ pub trait EffectDef: Sync + Send + 'static {
         self.apply_cpu(rgba, w, h, p);
     }
 
+    /// [`apply_cpu_at`](EffectDef::apply_cpu_at) with the layer's decoded
+    /// **neighbour frames** beside the picture, keyed by source-relative offset
+    /// and laid out exactly as `rgba` is.
+    ///
+    /// The neighbours are the frames the stack's temporal window asked for
+    /// ([`super::stack_temporal_window`]), decoded by the same job that decoded
+    /// the frame in hand. Every built-in ignores them here: Echo and the flow
+    /// effects read theirs as textures in their own kernels. A **plugin** reads
+    /// them on the CPU, because a motion blur or a retimer asks its input clip
+    /// for the frames either side and a host that answers every such ask with
+    /// the frame in hand shows it a scene with no motion in it. The default
+    /// drops them and calls `apply_cpu_at`.
+    #[allow(clippy::too_many_arguments)]
+    fn apply_cpu_temporal(
+        &self,
+        inst: uuid::Uuid,
+        lt: f64,
+        rgba: &mut [f32],
+        w: u32,
+        h: u32,
+        p: Params<'_>,
+        _neighbours: &[(i32, &[f32])],
+    ) {
+        self.apply_cpu_at(inst, lt, rgba, w, h, p);
+    }
+
     /// Values derived at resolve time from things that are not parameters
     /// (docs/impl/effect-registry.md §2.4a): layer time, the marker
     /// context, a whole keyframed track.
@@ -336,7 +362,11 @@ pub trait EffectDef: Sync + Send + 'static {
     }
 
     /// The source-relative frame offsets **this instance** reads at this layer
-    /// time — the picture-side twin of [`driver_window`](EffectDef::driver_window).
+    /// frame, the picture-side twin of [`driver_window`](EffectDef::driver_window).
+    ///
+    /// `frame` is the layer's local time **in frames of the comp**, not in
+    /// seconds: a plugin is asked in the unit OFX counts in, and the answer it
+    /// gives is relative to the number it was asked at.
     ///
     /// `None` means "whatever the schema declares", which is every built-in:
     /// Echo's window is a fact about the effect, not about the copy of it on
@@ -347,7 +377,7 @@ pub trait EffectDef: Sync + Send + 'static {
     ///
     /// It must stay cheap and pure: [`super::stack_temporal_window`] calls it
     /// once per live effect per frame, from the key walk.
-    fn frames_needed(&self, _inst: &EffectInstance, _lt: f64) -> Option<Vec<i32>> {
+    fn frames_needed(&self, _inst: &EffectInstance, _frame: f64) -> Option<Vec<i32>> {
         None
     }
 

--- a/crates/lumit-core/src/fx/temporal.rs
+++ b/crates/lumit-core/src/fx/temporal.rs
@@ -344,12 +344,15 @@ fn is_catalogued(e: &EffectInstance) -> bool {
 }
 
 /// The union of source-relative frame offsets a layer's live effect stack
-/// needs at layer time `lt` (docs/08 §1.3 `temporal`), always sorted and always
-/// containing 0 (the current frame). `&[0]` when the stack is bypassed, empty,
-/// or every effect is a plain single-frame one — so a layer with no temporal
-/// effect pays nothing. The render pipeline decodes the layer's source at each
-/// of these offsets so a temporal effect (echo, flow motion blur, datamosh)
-/// can read its neighbours.
+/// needs at layer frame `frame` (docs/08 §1.3 `temporal`), always sorted and
+/// always containing 0 (the current frame). `&[0]` when the stack is bypassed,
+/// empty, or every effect is a plain single-frame one, so a layer with no
+/// temporal effect pays nothing. The render pipeline decodes the layer's source
+/// at each of these offsets so a temporal effect (echo, flow motion blur,
+/// datamosh) can read its neighbours.
+///
+/// `frame` is the layer's local time in **frames of the comp**, the unit a
+/// plugin is asked in and one a built-in never reads.
 ///
 /// **Per instance, not only per effect**. A built-in's window is a fact
 /// about the effect and comes off its declaration, exactly as it always did. A
@@ -359,14 +362,14 @@ fn is_catalogued(e: &EffectInstance) -> bool {
 /// answers for itself, falling back to the declaration when it has nothing more
 /// specific to say. The frames it names are then in the frame key and in the
 /// prefetch, which is what keeps a cached frame from outliving what it sampled.
-pub fn stack_temporal_window(effects: &[EffectInstance], fx_on: bool, lt: f64) -> Vec<i32> {
+pub fn stack_temporal_window(effects: &[EffectInstance], fx_on: bool, frame: f64) -> Vec<i32> {
     let mut offsets = vec![0i32];
     if fx_on {
         for e in effects.iter().filter(|e| e.enabled && is_catalogued(e)) {
             let Some(def) = super::BUILTIN_DEFS.get(&e.effect.match_name) else {
                 continue;
             };
-            match def.frames_needed(e, lt) {
+            match def.frames_needed(e, frame) {
                 Some(own) => offsets.extend_from_slice(&own),
                 None => offsets.extend_from_slice(def.schema().traits.temporal),
             }

--- a/crates/lumit-eval/src/lib.rs
+++ b/crates/lumit-eval/src/lib.rs
@@ -975,9 +975,14 @@ fn feed_layer(
         if let LayerKind::Footage { item, .. } = &layer.kind {
             let comp_dt = 1.0 / comp.frame_rate.fps().max(1.0);
             h.update(b"temporal/");
-            for o in lumit_core::fx::stack_temporal_window(&layer.effects, layer.switches.fx, lt)
-                .into_iter()
-                .filter(|&o| o != 0)
+            // Asked at the layer's frame, which is the unit a plugin counts in.
+            for o in lumit_core::fx::stack_temporal_window(
+                &layer.effects,
+                layer.switches.fx,
+                lt / comp_dt,
+            )
+            .into_iter()
+            .filter(|&o| o != 0)
             {
                 let nlt = lt + f64::from(o) * comp_dt;
                 let nst = layer.source_time_at(nlt);

--- a/crates/lumit-ofx-broker/src/main.rs
+++ b/crates/lumit-ofx-broker/src/main.rs
@@ -258,10 +258,18 @@ impl Session {
         inputs: &[lumit_ofx::ipc::proto::FrameRef],
     ) -> RenderRequest {
         let mut frames = BTreeMap::new();
+        let mut neighbours = Vec::new();
         if let Some(ring) = self.ring.as_ref() {
             for input in inputs {
-                if let Ok((_, frame)) = ring.read_frame(input.slot) {
+                let Ok((_, frame)) = ring.read_frame(input.slot) else {
+                    continue;
+                };
+                if time_key(input.time) == time_key(time) {
                     frames.insert(input.clip.clone(), frame);
+                } else {
+                    // The Source clip at another time, filed by its offset
+                    // from the frame being rendered.
+                    neighbours.push(((input.time - time).round() as i32, frame));
                 }
             }
         }
@@ -270,6 +278,7 @@ impl Session {
             bounds,
             order,
             inputs: frames,
+            neighbours,
         }
     }
 
@@ -301,15 +310,8 @@ impl Session {
         // watchdog covers the case that matters.
         let epoch = Epoch::new();
         let token = epoch.token();
-        let time = request.time;
 
-        let mut prefetch = |needed: &BTreeMap<String, (f64, f64)>| {
-            let wanted = frames_wanted(needed, time);
-            if wanted.is_empty() {
-                return Ok(BTreeMap::new());
-            }
-            fetch(sender, receiver, ring, &wanted)
-        };
+        let mut prefetch = |wanted: &[FrameWanted]| fetch(sender, receiver, ring, wanted);
 
         let rendered =
             render_with_prefetch(plugin, &live.instance, &request, &token, &mut prefetch);
@@ -365,34 +367,6 @@ impl Session {
             message: message.to_owned(),
         })
     }
-}
-
-/// Every frame `getFramesNeeded` asked for that is not the one being rendered,
-/// as one flat list. The ranges come back per clip as a first and a last frame;
-/// a retimer's t±5 is eleven frames, and eleven is what goes on the wire — once.
-fn frames_wanted(needed: &BTreeMap<String, (f64, f64)>, time: f64) -> Vec<FrameWanted> {
-    /// A range no plugin means, and a list no host should build. A plugin that
-    /// asks for a thousand frames of one output frame has asked for something
-    /// the ring cannot hold anyway.
-    const MAX_FRAMES: usize = 256;
-
-    let mut wanted = Vec::new();
-    for (clip, (first, last)) in needed {
-        if !first.is_finite() || !last.is_finite() || last < first {
-            continue;
-        }
-        let mut frame = first.floor();
-        while frame <= *last && wanted.len() < MAX_FRAMES {
-            if time_key(frame) != time_key(time) {
-                wanted.push(FrameWanted {
-                    clip: clip.clone(),
-                    time: frame,
-                });
-            }
-            frame += 1.0;
-        }
-    }
-    wanted
 }
 
 /// Ask the host for frames, and wait for the one shipment that answers.

--- a/crates/lumit-ofx-broker/tests/broker.rs
+++ b/crates/lumit-ofx-broker/tests/broker.rs
@@ -279,6 +279,50 @@ fn eleven_frames_cross_in_one_shipment() {
     );
 }
 
+/// The frames either side travel **with** the frame, not after it: the engine
+/// decodes a temporal effect's neighbours beside the frame in hand, and they
+/// go into the same shipment as it. A motion blur that fetches `t ± 1` inside
+/// its render then finds them in hand, and nothing crosses the pipe mid-render.
+/// Without them the plugin was handed the frame in hand for every other time,
+/// and a motion blur compared a frame with itself.
+#[test]
+fn neighbours_shipped_with_the_frame_reach_the_plugin_without_a_prefetch() {
+    let Ok(root) = tempfile::tempdir() else {
+        return;
+    };
+    let Some((mut broker, plugin)) = a_broker(root.path(), &[("LUMIT_TESTPLUG_TEMPORAL", "5")])
+    else {
+        skipped("neighbours_shipped_with_the_frame_reach_the_plugin_without_a_prefetch");
+        return;
+    };
+    let instance = broker
+        .create_instance(plugin, Context::Filter, ParamSnapshot::new())
+        .expect("an instance");
+
+    let value_at = |time: f64| (time / 100.0) as f32;
+    let mut request = RenderRequest::filter(20.0, a_flat_frame(value_at(20.0)));
+    request.neighbours = (-5..=5)
+        .filter(|offset| *offset != 0)
+        .map(|offset| (offset, a_flat_frame(value_at(20.0 + f64::from(offset)))))
+        .collect();
+    // Nothing to fetch from: every frame the plugin wants is already across.
+    let rendered = broker
+        .render(instance, &request, &|_, _| None)
+        .expect("a frame back");
+
+    assert!(!rendered.errored, "{:?}", rendered.error);
+    assert_eq!(
+        broker.shipments(),
+        0,
+        "the neighbours came with the frame, so no prefetch went out"
+    );
+    assert!(
+        (first(&rendered.frame) - 0.20).abs() < 1e-2,
+        "expected the mean of the frame and its ten neighbours, got {}",
+        first(&rendered.frame)
+    );
+}
+
 #[test]
 fn a_frame_crosses_the_ring_unchanged() {
     let Ok(root) = tempfile::tempdir() else {

--- a/crates/lumit-ofx/src/def.rs
+++ b/crates/lumit-ofx/src/def.rs
@@ -17,11 +17,15 @@
 //! # What this definition does with each hook
 //!
 //! * **`schema`** hands back the leaked declaration the describe made.
-//! * **`apply_cpu`** is the render: the picture is fp32 premultiplied linear,
-//!   which is exactly what the plugin boundary wants (docs/12 §2.1), so it goes
-//!   straight across to the [`PluginHost`] and comes straight back. The GPU
-//!   half is the generic read-back wrapper in `lumit-render`, which calls this;
-//!   there is no WGSL to write, because the maths is the plugin's.
+//! * **`apply_cpu_temporal`** is the render: the picture is fp32 premultiplied
+//!   linear, which is exactly what the plugin boundary wants (docs/12 §2.1), so
+//!   it goes straight across to the [`PluginHost`] and comes straight back,
+//!   with the layer's decoded neighbours beside it for a plugin that reads the
+//!   frames either side. The GPU half is the generic read-back wrapper in
+//!   `lumit-render`, which calls this. There is no WGSL to write, because the
+//!   maths is the plugin's. The time it is told is the layer's **frame**, the
+//!   unit OFX counts in, carried into the bag by `resolve_derived` from the
+//!   comp's rate.
 //! * **`frames_needed`** asks the plugin what other frames this instance reads,
 //!   which is `getFramesNeeded` (docs/12 §2.1) and is what puts a retimer's
 //!   sampled frames into the frame key and the prefetch.
@@ -90,16 +94,19 @@ pub trait PluginHost: Send + Sync {
     ///
     /// `instance` is the effect instance's own id, so the host can keep one
     /// live plugin instance per row rather than rebuilding it per frame, and so
-    /// a failure is attributable to the row it happened on. A host that cannot
-    /// render — disabled, crashed, out of deadline — answers with `source` and
-    /// an error rather than a failure: a comp that stops compositing is worse
-    /// than a comp with a badge on one layer.
+    /// a failure is attributable to the row it happened on. `time` is the
+    /// layer's frame. `neighbours` are the Source clip at other frames, by
+    /// offset from `time`, for a plugin that reads the frames either side. A
+    /// host that can't render (disabled, crashed, out of deadline) answers
+    /// with `source` and an error rather than a failure: a comp that stops
+    /// compositing is worse than a comp with a badge on one layer.
     fn render(
         &self,
         instance: Uuid,
         time: f64,
         params: &ParamSnapshot,
         source: Frame16,
+        neighbours: &[(i32, Frame16)],
     ) -> Rendering;
 
     /// The source-relative frame offsets this instance reads at this time —
@@ -368,6 +375,21 @@ fn read_component(slot: &PropValue, route: &ValueRoute) -> Option<Value> {
 /// renames the frames it changes.
 const DERIVED_MEMORY: ParamId = ParamId::new("derived.memory");
 
+/// The bag id the layer's frame rides under: what the plugin is told the time
+/// is, in the frames OFX counts in rather than the seconds the resolve walk
+/// speaks. A plugin asks for the frames either side as `time ± 1`, and a
+/// time in seconds would make that a second either side.
+const DERIVED_FRAME: ParamId = ParamId::new("derived.frame");
+
+/// The frame the plugin is told, out of the bag, or `lt` as it stands when no
+/// comp put one there, which is a stack built by hand.
+fn frame_in_bag(p: Params<'_>, lt: f64) -> f64 {
+    match p.get(DERIVED_FRAME) {
+        Some(Value::Int(frame)) => f64::from(frame),
+        _ => lt,
+    }
+}
+
 /// What each instance's plugin keeps beyond its rows, decoded once per change
 /// from `EffectInstance::plugin_state` and laid over the snapshot on every
 /// render. Keyed by the effect instance, with the hash it was decoded from.
@@ -439,6 +461,19 @@ impl EffectDef for OfxEffectDef {
     }
 
     fn apply_cpu_at(&self, inst: Uuid, lt: f64, rgba: &mut [f32], w: u32, h: u32, p: Params<'_>) {
+        self.apply_cpu_temporal(inst, lt, rgba, w, h, p, &[]);
+    }
+
+    fn apply_cpu_temporal(
+        &self,
+        inst: Uuid,
+        lt: f64,
+        rgba: &mut [f32],
+        w: u32,
+        h: u32,
+        p: Params<'_>,
+        neighbours: &[(i32, &[f32])],
+    ) {
         let expected = (w as usize) * (h as usize) * 4;
         if w == 0 || h == 0 || rgba.len() < expected {
             return;
@@ -446,6 +481,18 @@ impl EffectDef for OfxEffectDef {
         let Ok(source) = Frame16::from_f32(w as usize, h as usize, &rgba[..expected]) else {
             return;
         };
+        // A neighbour of another size is one the plugin could not compare
+        // with the frame in hand, and is left out: for that time the plugin
+        // gets the frame in hand, the spec's answer to a frame the host has
+        // not got.
+        let frames: Vec<(i32, Frame16)> = neighbours
+            .iter()
+            .filter(|(_, pixels)| pixels.len() == expected)
+            .filter_map(|(offset, pixels)| {
+                let frame = Frame16::from_f32(w as usize, h as usize, pixels).ok()?;
+                Some((*offset, frame))
+            })
+            .collect();
         let mut snapshot = self.snapshot(p);
         let memory = MEMORY
             .lock()
@@ -454,7 +501,9 @@ impl EffectDef for OfxEffectDef {
         if let Some(memory) = memory {
             recall(&mut snapshot, &memory);
         }
-        let rendered = self.host.render(inst, lt, &snapshot, source);
+        let rendered = self
+            .host
+            .render(inst, frame_in_bag(p, lt), &snapshot, source, &frames);
         let failed = rendered.error.is_some();
         LAST_ERROR.with(|slot| *slot.borrow_mut() = rendered.error);
         if failed {
@@ -475,8 +524,8 @@ impl EffectDef for OfxEffectDef {
         }
     }
 
-    fn frames_needed(&self, inst: &EffectInstance, lt: f64) -> Option<Vec<i32>> {
-        self.host.frames_needed(inst.id, lt, &self.defaults)
+    fn frames_needed(&self, inst: &EffectInstance, frame: f64) -> Option<Vec<i32>> {
+        self.host.frames_needed(inst.id, frame, &self.defaults)
     }
 
     fn last_error(&self) -> Option<String> {
@@ -485,9 +534,19 @@ impl EffectDef for OfxEffectDef {
 
     /// The plugin's memory reaches the render from here: this is the one hook
     /// that sees the document's instance every frame, so it files the memory
-    /// for `apply_cpu_at` and puts its hash in the bag for the frame key.
+    /// for `apply_cpu_temporal` and puts its hash in the bag for the frame key.
+    /// The layer's frame rides in beside it, because this is also the one hook
+    /// that can see the comp's rate.
     fn resolve_derived(&self, cx: &ResolveCx<'_>, push: &mut dyn FnMut(ParamId, Value)) {
         push(DERIVED_MEMORY, Value::Int(remember(cx.inst)));
+        let fps = cx
+            .context
+            .comp
+            .and_then(|id| cx.context.document.comp(id))
+            .map(|comp| comp.frame_rate.fps());
+        if let Some(fps) = fps {
+            push(DERIVED_FRAME, Value::Int((cx.lt * fps).round() as i32));
+        }
     }
 
     fn press(
@@ -632,8 +691,10 @@ impl PluginHost for LocalHost {
         time: f64,
         params: &ParamSnapshot,
         source: Frame16,
+        neighbours: &[(i32, Frame16)],
     ) -> Rendering {
-        let request = RenderRequest::filter(time, source.clone());
+        let mut request = RenderRequest::filter(time, source.clone());
+        request.neighbours = neighbours.to_vec();
         match self.attempt(instance, &request, params) {
             Ok(rendered) => Rendering {
                 frame: rendered.frame,
@@ -784,6 +845,7 @@ impl PluginHost for BrokerHost {
         time: f64,
         params: &ParamSnapshot,
         source: Frame16,
+        neighbours: &[(i32, Frame16)],
     ) -> Rendering {
         let Some(mut broker) = self.broker.lock() else {
             return Rendering {
@@ -798,12 +860,11 @@ impl PluginHost for BrokerHost {
             };
         };
         let _ = broker.set_params(id, params.clone());
-        let request = RenderRequest::filter(time, source.clone());
-        // Nothing is prefetched here: the neighbour frames a retimer asks for
-        // are the layer's own decoded neighbours, and threading them down to
-        // this call is the work of the package that gives the dispatch seam its
-        // side tables. Until then a frame at another time answers with the frame
-        // in hand, which is what the spec says an unfetchable clip gives.
+        let mut request = RenderRequest::filter(time, source.clone());
+        // The layer's decoded neighbours go across with the frame. A plugin
+        // that asks for a frame beyond them gets the frame in hand, which is
+        // what the spec says an unfetchable clip gives.
+        request.neighbours = neighbours.to_vec();
         let answer = broker.render(id, &request, &|_, _| None);
         let notes = broker.take_notes();
         drop(broker);

--- a/crates/lumit-ofx/src/discover.rs
+++ b/crates/lumit-ofx/src/discover.rs
@@ -194,14 +194,21 @@ struct Gated {
 }
 
 impl PluginHost for Gated {
-    fn render(&self, inst: Uuid, time: f64, params: &ParamSnapshot, source: Frame16) -> Rendering {
+    fn render(
+        &self,
+        inst: Uuid,
+        time: f64,
+        params: &ParamSnapshot,
+        source: Frame16,
+        neighbours: &[(i32, Frame16)],
+    ) -> Rendering {
         if is_disabled(&self.identifier) {
             return Rendering {
                 frame: source,
                 error: Some(DISABLED_REASON.to_owned()),
             };
         }
-        self.inner.render(inst, time, params, source)
+        self.inner.render(inst, time, params, source, neighbours)
     }
 
     fn frames_needed(&self, inst: Uuid, time: f64, params: &ParamSnapshot) -> Option<Vec<i32>> {
@@ -346,7 +353,14 @@ fn scan_in_process(
 struct Absent;
 
 impl PluginHost for Absent {
-    fn render(&self, _: Uuid, _: f64, _: &ParamSnapshot, source: Frame16) -> Rendering {
+    fn render(
+        &self,
+        _: Uuid,
+        _: f64,
+        _: &ParamSnapshot,
+        source: Frame16,
+        _: &[(i32, Frame16)],
+    ) -> Rendering {
         Rendering {
             frame: source,
             error: Some("the plugin's bundle could not be opened".to_owned()),

--- a/crates/lumit-ofx/src/instance.rs
+++ b/crates/lumit-ofx/src/instance.rs
@@ -532,7 +532,7 @@ fn build(
 
     for clip in &descriptor.clips {
         let mut clip_props = clip.props.clone();
-        seed_clip_instance_properties(&mut clip_props);
+        seed_clip_instance_properties(&mut clip_props, &clip.name);
         let props = state.props.insert(clip_props)?;
         let clip_handle = state.clips.insert(ClipBinding {
             effect: handle,
@@ -597,10 +597,10 @@ fn seed_instance_properties(
         keys::PROJECT_EXTENT,
         PropValue::Double(vec![DEFAULT_PROJECT.0, DEFAULT_PROJECT.1]),
     );
-    // One frame: Lumit renders a frame at a time and tells a plugin nothing
-    // about the layer it sits on (docs/12 §2.1). A plugin that reads this to
-    // place a ramp across the clip gets a one-frame clip, which is honest for a
-    // host that hands over one frame.
+    // One frame until the first render: Lumit renders a frame at a time and
+    // tells a plugin nothing about the layer it sits on (docs/12 §2.1), so the
+    // clip is as long as the frames in hand, which [`set_frame_range`] says
+    // before every render.
     props.seed(keys::EFFECT_DURATION, PropValue::double(1.0));
     props.seed(keys::SUPPORTS_TILES, PropValue::int(0));
     props.seed(keys::FRAME_RATE, PropValue::double(25.0));
@@ -616,8 +616,11 @@ fn seed_instance_properties(
 /// The properties a clip gains when it stops being a description and becomes
 /// an input. Every one is a promise: float RGBA, premultiplied, square pixels,
 /// no fields — which is exactly what the host table says and what
-/// [`crate::image`] hands over.
-fn seed_clip_instance_properties(props: &mut PropertySet) {
+/// [`crate::image`] hands over. Only the Source and the Output are connected:
+/// this host feeds one input, and a plugin's optional second one has nothing
+/// on it, which [`set_clip_state`] says again from the request before every
+/// render.
+fn seed_clip_instance_properties(props: &mut PropertySet, name: &str) {
     let mut seed_string = |key: &str, value: &str| {
         if let Ok(value) = PropValue::string(value) {
             props.seed(key, value);
@@ -630,7 +633,8 @@ fn seed_clip_instance_properties(props: &mut PropertySet) {
     seed_string(keys::PRE_MULTIPLICATION, values::IMAGE_PRE_MULTIPLIED);
     seed_string(keys::CLIP_FIELD_ORDER, values::IMAGE_FIELD_NONE);
 
-    props.seed(keys::CLIP_CONNECTED, PropValue::int(1));
+    let connected = name == SOURCE_CLIP || name == OUTPUT_CLIP;
+    props.seed(keys::CLIP_CONNECTED, PropValue::int(i32::from(connected)));
     props.seed(keys::CLIP_CONTINUOUS_SAMPLES, PropValue::int(0));
     props.seed(keys::PIXEL_ASPECT_RATIO, PropValue::double(1.0));
     props.seed(keys::FRAME_RATE, PropValue::double(25.0));
@@ -655,6 +659,51 @@ pub(crate) fn set_project_size(handle: Handle, width: f64, height: f64) -> Resul
     let set = state.props.get_mut(props)?;
     set.set(keys::PROJECT_SIZE, PropValue::Double(vec![width, height]));
     set.set(keys::PROJECT_EXTENT, PropValue::Double(vec![width, height]));
+    Ok(())
+}
+
+/// Tell an instance which of its clips have a picture on them, and how long
+/// the clip is: the first and last frame the host has a picture for, which is
+/// the frame in hand and the neighbours either side of it.
+///
+/// Called before the first action of every render, beside [`set_project_size`]
+/// and for the same reason. A plugin that reads the frames either side clamps
+/// what it asks for to this range. Told the clip is one frame long, it asks for
+/// nothing and finds no motion. A clip with no picture is unconnected, so a
+/// plugin with an optional second input does not ask for a picture that is
+/// not there and fail its render on the answer.
+pub(crate) fn set_clip_state(
+    handle: Handle,
+    connected: impl Fn(&str) -> bool,
+    first: f64,
+    last: f64,
+) -> Result<(), Status> {
+    let mut state = state();
+    let (props, clips) = {
+        let effect = state.effects.get(handle)?;
+        let clips: Vec<(String, Handle)> = effect
+            .clips
+            .iter()
+            .map(|clip| (clip.name.clone(), clip.props))
+            .collect();
+        (effect.props, clips)
+    };
+    state
+        .props
+        .get_mut(props)?
+        .set(keys::EFFECT_DURATION, PropValue::double(last - first + 1.0));
+    for (name, clip) in clips {
+        let set = state.props.get_mut(clip)?;
+        set.set(
+            keys::CLIP_CONNECTED,
+            PropValue::int(i32::from(connected(&name))),
+        );
+        set.set(keys::FRAME_RANGE, PropValue::Double(vec![first, last]));
+        set.set(
+            keys::CLIP_UNMAPPED_FRAME_RANGE,
+            PropValue::Double(vec![first, last]),
+        );
+    }
     Ok(())
 }
 

--- a/crates/lumit-ofx/src/ipc/broker.rs
+++ b/crates/lumit-ofx/src/ipc/broker.rs
@@ -561,7 +561,7 @@ impl Broker {
 
         // Every input, plus one for the answer. The slots are taken before the
         // message goes out, because the message names them.
-        let mut inputs = Vec::with_capacity(request.inputs.len());
+        let mut inputs = Vec::with_capacity(request.inputs.len() + request.neighbours.len());
         for (clip, frame) in &request.inputs {
             let slot = self.take_slot();
             self.ring.write_frame(slot, frame, request.bounds, true)?;
@@ -570,6 +570,23 @@ impl Broker {
                 time: request.time,
                 slot,
             });
+        }
+        // The frames either side go in the same shipment, each under its own
+        // time, when the ring has a slot for each: a shipment wider than the
+        // ring would write over a frame the broker has not read yet, so it
+        // ships the frame in hand alone and the plugin gets that frame for
+        // every other time, the same answer a refused prefetch gives.
+        let fits = request.inputs.len() + request.neighbours.len() <= self.ring.slots() as usize;
+        if fits {
+            for (offset, frame) in &request.neighbours {
+                let slot = self.take_slot();
+                self.ring.write_frame(slot, frame, request.bounds, true)?;
+                inputs.push(FrameRef {
+                    clip: SOURCE_CLIP.to_owned(),
+                    time: request.time + f64::from(*offset),
+                    slot,
+                });
+            }
         }
         let output = self.take_slot();
 

--- a/crates/lumit-ofx/src/ipc/proto.rs
+++ b/crates/lumit-ofx/src/ipc/proto.rs
@@ -29,7 +29,7 @@ use crate::instance::ParamSnapshot;
 
 /// The version both sides must agree on. Bump it whenever a message changes
 /// shape: an old broker beside a new host is a mismatch, not a crash.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Which instance a message is about. The host mints these; the broker only
 /// ever quotes one back.
@@ -124,7 +124,10 @@ pub enum HostMessage {
         bounds: RectI,
         /// Which way up the pictures are handed to the plugin.
         order: RowOrder,
-        /// One picture per input clip, already in the ring.
+        /// One picture per input clip, already in the ring, and the Source
+        /// clip's frames at other times, each under its own time, the
+        /// neighbours a motion blur or a retimer reads, shipped with the frame
+        /// rather than fetched after it (docs/impl/ofx-host.md §4).
         inputs: Vec<FrameRef>,
         /// The slot the answer goes in.
         output: Slot,

--- a/crates/lumit-ofx/src/render.rs
+++ b/crates/lumit-ofx/src/render.rs
@@ -42,7 +42,7 @@
 //! queues behind one lock (docs/12 §2.3, [`crate::instance::ThreadSafety`]).
 
 use std::cell::Cell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use lumit_eval::epoch::{Cancelled, EpochToken};
 use thiserror::Error;
@@ -54,7 +54,8 @@ use crate::ffi::{
 use crate::handles::Handle;
 use crate::host::state;
 use crate::image::{Frame16, Image, RectI, RowOrder};
-use crate::instance::{add_images_at, set_images, take_images, Instance};
+use crate::instance::{add_images_at, set_images, take_images, time_key, Instance};
+use crate::ipc::proto::FrameWanted;
 use crate::props::{PropValue, PropertySet};
 use crate::status::Status;
 
@@ -122,6 +123,11 @@ pub struct RenderRequest {
     pub order: RowOrder,
     /// One picture per input clip, by the name the plugin gave the clip.
     pub inputs: BTreeMap<String, Frame16>,
+    /// The Source clip at other times, by source-relative frame offset: the
+    /// frames either side that a motion blur or a retimer reads, decoded by
+    /// the engine beside the frame in hand and the same size as it. Empty for
+    /// a plain filter.
+    pub neighbours: Vec<(i32, Frame16)>,
 }
 
 impl RenderRequest {
@@ -140,7 +146,20 @@ impl RenderRequest {
             bounds,
             order: RowOrder::BottomUp,
             inputs,
+            neighbours: Vec::new(),
         }
+    }
+
+    /// The first and last frame the Source clip has a picture for in this
+    /// request: the frame in hand, widened by the neighbours either side of it.
+    #[must_use]
+    pub fn frame_span(&self) -> (f64, f64) {
+        let (mut low, mut high) = (0, 0);
+        for (offset, _) in &self.neighbours {
+            low = low.min(*offset);
+            high = high.max(*offset);
+        }
+        (self.time + f64::from(low), self.time + f64::from(high))
     }
 }
 
@@ -152,7 +171,8 @@ pub struct Rendered {
     pub region_of_definition: RectI,
     /// `getFramesNeeded`'s answer: per clip, the first and last frame the
     /// plugin wants to see. The evaluation graph's temporal edges are made from
-    /// this (docs/05 §4.2); nothing prefetches it yet.
+    /// this (docs/05 §4.2), and the engine decodes the frames it names for the
+    /// next render's [`RenderRequest::neighbours`].
     pub frames_needed: BTreeMap<String, (f64, f64)>,
     /// The clip the plugin said it was a pass-through of, if it said so. When
     /// this is set, no render happened at all.
@@ -214,17 +234,45 @@ pub fn render_is_cancelled() -> bool {
     token.cancelled()
 }
 
-/// What fetches the frames a plugin asked for beyond the one being rendered.
+/// What fetches the frames a plugin asked for and does not have.
 ///
-/// It is handed `getFramesNeeded`'s answer — per clip, the first and last frame
-/// wanted — and answers with the pictures, keyed by clip and
+/// It is handed the frames `getFramesNeeded` named that did not come with the
+/// request, one entry each, and answers with the pictures, keyed by clip and
 /// [`crate::instance::time_key`]. In process there is nothing to fetch from and
-/// the answer is empty; in the broker it is one round trip for the lot, which
+/// the answer is empty. In the broker it is one round trip for the lot, which
 /// is the whole reason `getFramesNeeded` is dispatched before the render rather
 /// than after (docs/impl/ofx-host.md §4).
-pub type Prefetch<'a> = &'a mut dyn FnMut(
-    &BTreeMap<String, (f64, f64)>,
-) -> Result<BTreeMap<(String, i64), Frame16>, RenderError>;
+pub type Prefetch<'a> =
+    &'a mut dyn FnMut(&[FrameWanted]) -> Result<BTreeMap<(String, i64), Frame16>, RenderError>;
+
+/// Every frame `getFramesNeeded` asked for that is not the one being rendered,
+/// as one flat list. The ranges come back per clip as a first and a last frame.
+/// A retimer's t±5 is eleven frames, and eleven is what goes on the wire, once.
+#[must_use]
+pub fn frames_wanted(needed: &BTreeMap<String, (f64, f64)>, time: f64) -> Vec<FrameWanted> {
+    /// A range no plugin means, and a list no host should build. A plugin that
+    /// asks for a thousand frames of one output frame has asked for something
+    /// the ring can't hold anyway.
+    const MAX_FRAMES: usize = 256;
+
+    let mut wanted = Vec::new();
+    for (clip, (first, last)) in needed {
+        if !first.is_finite() || !last.is_finite() || last < first {
+            continue;
+        }
+        let mut frame = first.floor();
+        while frame <= *last && wanted.len() < MAX_FRAMES {
+            if time_key(frame) != time_key(time) {
+                wanted.push(FrameWanted {
+                    clip: clip.clone(),
+                    time: frame,
+                });
+            }
+            frame += 1.0;
+        }
+    }
+    wanted
+}
 
 /// Render one frame through one instance of one plugin.
 ///
@@ -272,6 +320,18 @@ pub fn render_with_prefetch(
         OUTPUT_CLIP.to_owned(),
         Image::black(request.bounds, request.order)?,
     );
+    // The frames either side go on with the picture, each under the time the
+    // plugin will ask for it at. They can't wait for `getFramesNeeded`: a
+    // plugin answers that after reading how long its clip is, and a motion
+    // blur fetches its neighbours inside the render itself.
+    let mut images_at = BTreeMap::new();
+    for (offset, frame) in &request.neighbours {
+        let at = crate::instance::time_key(request.time + f64::from(*offset));
+        images_at.insert(
+            (SOURCE_CLIP.to_owned(), at),
+            Image::from_frame(frame, request.order)?,
+        );
+    }
 
     // Taken with no host lock held, and now held for the whole conversation
     // rather than for the render alone: every action in it calls into the
@@ -280,7 +340,7 @@ pub fn render_with_prefetch(
     let guard = instance.render_lock();
     let _held = guard.as_ref().map(crate::instance::RenderGuard::hold);
 
-    let previous = set_images(handle, images, BTreeMap::new())?;
+    let previous = set_images(handle, images, images_at)?;
     drop(previous);
     // The project is the frame being rendered, and the plugin is told so before
     // it is asked anything: a generator places itself by these two numbers.
@@ -288,6 +348,18 @@ pub fn render_with_prefetch(
         handle,
         f64::from(request.bounds.x2 - request.bounds.x1),
         f64::from(request.bounds.y2 - request.bounds.y1),
+    )?;
+    // And the clip is as long as the frames in hand. A plugin that reads the
+    // frames either side clamps what it asks for to its clip's range, so a
+    // range that stops at the frame in hand is a plugin that never sees a
+    // second frame and finds no motion in the first. A clip the request has
+    // no picture for is unconnected, so nothing asks for it.
+    let (first, last) = request.frame_span();
+    crate::instance::set_clip_state(
+        handle,
+        |name| name == OUTPUT_CLIP || request.inputs.contains_key(name),
+        first,
+        last,
     )?;
 
     let outcome = ask(plugin, instance, request, token, prefetch);
@@ -371,11 +443,28 @@ fn ask(
     let frames_needed = get_frames_needed(plugin, handle, request)?;
     token.check()?;
 
-    // The one place a frame at another time can be asked for: after the plugin
-    // has said which frames it wants and before it is asked for anything else.
-    // One call, however many frames — a retimer's per-frame fetches are the
-    // thing this exists to keep off the wire.
-    let temporal = prefetch(&frames_needed)?;
+    // Whatever the plugin wants beyond the frames that came with the request
+    // is asked for here, after it has said which frames those are and before
+    // it is asked for anything else. One call, however many frames, since a
+    // retimer's per-frame fetches are the thing this exists to keep off the
+    // wire. A frame already in hand is not asked for again.
+    let in_hand: BTreeSet<(String, i64)> = request
+        .neighbours
+        .iter()
+        .map(|(offset, _)| {
+            let at = time_key(request.time + f64::from(*offset));
+            (SOURCE_CLIP.to_owned(), at)
+        })
+        .collect();
+    let wanted: Vec<FrameWanted> = frames_wanted(&frames_needed, request.time)
+        .into_iter()
+        .filter(|want| !in_hand.contains(&(want.clip.clone(), time_key(want.time))))
+        .collect();
+    let temporal = if wanted.is_empty() {
+        BTreeMap::new()
+    } else {
+        prefetch(&wanted)?
+    };
     let mut images_at = BTreeMap::new();
     for (key, frame) in &temporal {
         images_at.insert(key.clone(), Image::from_frame(frame, request.order)?);

--- a/crates/lumit-ofx/src/tests.rs
+++ b/crates/lumit-ofx/src/tests.rs
@@ -1824,6 +1824,95 @@ fn an_instance_knows_how_big_the_project_is_and_the_render_keeps_it_true() {
     instance.destroy(plugin).expect("destroyed");
 }
 
+/// **The clip is as long as the frames in hand, and the plugin is told so.**
+/// A plugin that reads the frames either side clamps what it asks for to its
+/// clip's frame range, so a range that stops at the frame in hand is a plugin
+/// that never asks for a second frame. The neighbours a request carries widen
+/// the range before the plugin's first question, and come off with the
+/// pictures afterwards. A second input the request has no picture for is
+/// unconnected, so a plugin with an optional one does not fetch from it.
+#[test]
+fn a_render_with_neighbours_tells_the_plugin_how_long_its_clip_is() {
+    let _ledger = image_ledger();
+    let Some((_root, bundle, report)) = a_described_bundle("a_render_with_neighbours") else {
+        return;
+    };
+    let plugin = plugin_of(&bundle, "com.lumitlab.testplug.passthrough");
+    let mut descriptor = described(&report, "com.lumitlab.testplug.passthrough")
+        .descriptor
+        .clone();
+    // A second, optional input the plugin never fetches from, as RSMB Pro's.
+    descriptor.clips.push(crate::describe::ClipDescription {
+        name: "Vectors".to_owned(),
+        props: PropertySet::new(),
+    });
+    let instance = Instance::create(plugin, &descriptor, Context::Filter, &ParamSnapshot::new())
+        .expect("an instance");
+
+    let clip_props = |handle: Handle, name: &str| -> PropertySet {
+        let state = state();
+        let clip = state
+            .effects
+            .get(handle)
+            .expect("the instance")
+            .clips
+            .iter()
+            .find(|clip| clip.name == name)
+            .expect("the clip")
+            .props;
+        state.props.get(clip).expect("its property set").clone()
+    };
+    let source_clip = |handle: Handle| clip_props(handle, crate::render::SOURCE_CLIP);
+    assert_eq!(
+        clip_props(instance.handle(), "Vectors").get_int(keys::CLIP_CONNECTED, 0),
+        Ok(0),
+        "an input this host never feeds is born unconnected"
+    );
+    let duration = |handle: Handle| -> f64 {
+        let state = state();
+        let props = state.effects.get(handle).expect("the instance").props;
+        state
+            .props
+            .get(props)
+            .expect("its property set")
+            .get_double(keys::EFFECT_DURATION, 0)
+            .expect("a duration")
+    };
+
+    let token = Epoch::new().token();
+    let mut request = RenderRequest::filter(20.0, a_test_frame(9, 4));
+    request.neighbours = vec![(-2, a_test_frame(9, 4)), (1, a_test_frame(9, 4))];
+    assert_eq!(request.frame_span(), (18.0, 21.0));
+    crate::render::render(plugin, &instance, &request, &token).expect("it rendered");
+
+    let after = source_clip(instance.handle());
+    assert_eq!(after.get_double(keys::FRAME_RANGE, 0), Ok(18.0));
+    assert_eq!(after.get_double(keys::FRAME_RANGE, 1), Ok(21.0));
+    assert_eq!(
+        after.get_double(keys::CLIP_UNMAPPED_FRAME_RANGE, 0),
+        Ok(18.0)
+    );
+    assert_eq!(
+        after.get_double(keys::CLIP_UNMAPPED_FRAME_RANGE, 1),
+        Ok(21.0)
+    );
+    assert_eq!(after.get_int(keys::CLIP_CONNECTED, 0), Ok(1));
+    assert_eq!(duration(instance.handle()), 4.0);
+    let vectors = clip_props(instance.handle(), "Vectors");
+    assert_eq!(vectors.get_int(keys::CLIP_CONNECTED, 0), Ok(0));
+    assert_eq!(vectors.get_double(keys::FRAME_RANGE, 1), Ok(21.0));
+
+    // A plain frame afterwards is a clip of that one frame again.
+    let plain = RenderRequest::filter(30.0, a_test_frame(9, 4));
+    crate::render::render(plugin, &instance, &plain, &token).expect("it rendered");
+    let after = source_clip(instance.handle());
+    assert_eq!(after.get_double(keys::FRAME_RANGE, 0), Ok(30.0));
+    assert_eq!(after.get_double(keys::FRAME_RANGE, 1), Ok(30.0));
+    assert_eq!(duration(instance.handle()), 1.0);
+
+    instance.destroy(plugin).expect("destroyed");
+}
+
 /// **A plugin writes its own controls, and the host must let it.** The OFX
 /// support library every commercial vendor is built on settles a plugin's
 /// parameters with `paramSetValue` while `kOfxActionCreateInstance` is still
@@ -2546,6 +2635,7 @@ impl PluginHost for DeadHost {
         _time: f64,
         _params: &ParamSnapshot,
         source: Frame16,
+        _neighbours: &[(i32, Frame16)],
     ) -> Rendering {
         Rendering {
             frame: source,
@@ -2826,6 +2916,7 @@ fn a_plugins_memory_reaches_its_render() {
             _time: f64,
             params: &ParamSnapshot,
             source: Frame16,
+            _neighbours: &[(i32, Frame16)],
         ) -> Rendering {
             *self.0.lock().expect("the record") = Some(params.clone());
             Rendering {
@@ -2944,6 +3035,173 @@ fn a_plugins_memory_reaches_its_render() {
     assert_eq!(resolve(&inst)[0].1, Value::Int(0));
     def.apply_cpu_at(inst.id, 0.0, &mut rgba, 2, 2, Params::EMPTY);
     assert_eq!(recorded().get("vendorBlob"), None);
+}
+
+/// **The plugin is told its frame, and handed the frames either side.** The
+/// resolve walk speaks in seconds and OFX counts in frames, so the comp's rate
+/// turns the layer time into the frame the bag carries. The neighbours the
+/// pass read back go to the host by offset, beside the picture, with one of
+/// another size left out.
+#[test]
+fn a_plugin_is_told_its_frame_and_handed_its_neighbours() {
+    use lumit_core::expression::ExpressionContext;
+    use lumit_core::fx::{MarkerContext, ResolveCx};
+    use lumit_core::model::{Composition, Document, LinearColour, ProjectItem};
+    use lumit_core::time::{Duration, FrameRate, Rational};
+
+    type Seen = (f64, Vec<(i32, f32)>);
+    struct Seeing(std::sync::Mutex<Option<Seen>>);
+
+    impl PluginHost for Seeing {
+        fn render(
+            &self,
+            _instance: uuid::Uuid,
+            time: f64,
+            _params: &ParamSnapshot,
+            source: Frame16,
+            neighbours: &[(i32, Frame16)],
+        ) -> Rendering {
+            let seen = neighbours
+                .iter()
+                .map(|(offset, frame)| (*offset, frame.pixel(0, 0)[0]))
+                .collect();
+            *self.0.lock().expect("the record") = Some((time, seen));
+            Rendering {
+                frame: source,
+                error: None,
+            }
+        }
+
+        fn frames_needed(
+            &self,
+            _instance: uuid::Uuid,
+            _time: f64,
+            _params: &ParamSnapshot,
+        ) -> Option<Vec<i32>> {
+            None
+        }
+
+        fn press(
+            &self,
+            _instance: uuid::Uuid,
+            _time: f64,
+            _params: &ParamSnapshot,
+            _name: &str,
+            _source: Frame16,
+        ) -> Result<ParamSnapshot, String> {
+            Err("not this test".to_owned())
+        }
+    }
+
+    let descriptor = PluginDescriptor {
+        identifier: "test.frame".to_owned(),
+        version: (1, 0),
+        grouping: String::new(),
+        label: "Frame test plugin".to_owned(),
+        contexts: vec![Context::Filter],
+        params: Vec::new(),
+        clips: Vec::new(),
+        temporal: true,
+        render_thread_safety: None,
+    };
+    let schema: &'static EffectSchema = Box::leak(Box::new(
+        crate::schema::schema_of(&descriptor).expect("a schema"),
+    ));
+    let host = std::sync::Arc::new(Seeing(std::sync::Mutex::new(None)));
+    let def = OfxEffectDef::new(&descriptor, schema, host.clone());
+    let seen = || {
+        host.0
+            .lock()
+            .expect("the record")
+            .clone()
+            .expect("a render happened")
+    };
+    let inst = lumit_core::model::EffectInstance {
+        id: uuid::Uuid::now_v7(),
+        effect: lumit_core::model::EffectKey {
+            namespace: lumit_core::model::EffectNamespace::Ofx,
+            match_name: schema.match_name.to_owned(),
+            version: 1,
+            extra: serde_json::Map::new(),
+        },
+        enabled: true,
+        params: Vec::new(),
+        sample_temporally: true,
+        custom_name: None,
+        linked_pairs: Vec::new(),
+        plugin_state: None,
+        roto: None,
+        extra: serde_json::Map::new(),
+    };
+
+    // A comp at sixty frames a second, resolved half a second in: frame 30.
+    let comp = Composition {
+        master_volume_db: 0.0,
+        groups: Vec::new(),
+        beat_grid: None,
+        id: uuid::Uuid::now_v7(),
+        name: "c".into(),
+        width: 16,
+        height: 16,
+        frame_rate: FrameRate::new(60, 1).expect("a rate"),
+        duration: Duration(Rational::new(10, 1).expect("a length")),
+        background: LinearColour([0.0, 0.0, 0.0, 1.0]),
+        work_area: None,
+        layers: Vec::new(),
+        markers: Vec::new(),
+        motion_blur: Default::default(),
+        extra: serde_json::Map::new(),
+    };
+    let comp_id = comp.id;
+    let mut document = Document::new();
+    document.items.push(ProjectItem::Composition(comp));
+    let cx = ResolveCx {
+        inst: &inst,
+        lt: 0.5,
+        diag_px: 100.0,
+        px_scale: 1.0,
+        markers: &MarkerContext::NONE,
+        context: std::sync::Arc::new(ExpressionContext {
+            document: std::sync::Arc::new(document),
+            comp: Some(comp_id),
+            layer: None,
+            comp_time: 0.5,
+            current_depth: 0,
+        }),
+    };
+    let mut bag = Vec::new();
+    def.resolve_derived(&cx, &mut |id, value| bag.push((id, value)));
+
+    let mut rgba = vec![0.5_f32; 2 * 2 * 4];
+    let previous = vec![0.25_f32; 2 * 2 * 4];
+    let next = vec![0.75_f32; 2 * 2 * 4];
+    let short = vec![1.0_f32; 4];
+    def.apply_cpu_temporal(
+        inst.id,
+        0.5,
+        &mut rgba,
+        2,
+        2,
+        Params::new(&bag),
+        &[(-1, &previous), (1, &next), (2, &short)],
+    );
+    let (time, neighbours) = seen();
+    assert_eq!(time, 30.0, "half a second at sixty a second is frame 30");
+    assert_eq!(
+        neighbours.len(),
+        2,
+        "a neighbour of another size is left out: {neighbours:?}"
+    );
+    assert_eq!(neighbours[0].0, -1);
+    assert!((neighbours[0].1 - 0.25).abs() < 1e-3);
+    assert_eq!(neighbours[1].0, 1);
+    assert!((neighbours[1].1 - 0.75).abs() < 1e-3);
+
+    // A stack built by hand names no comp, and the time it gives stands.
+    def.apply_cpu_at(inst.id, 7.0, &mut rgba, 2, 2, Params::EMPTY);
+    let (time, neighbours) = seen();
+    assert_eq!(time, 7.0);
+    assert!(neighbours.is_empty());
 }
 
 // --------------------------------------------------------- console windows --

--- a/crates/lumit-ofx/tests/conformance.rs
+++ b/crates/lumit-ofx/tests/conformance.rs
@@ -182,6 +182,7 @@ fn request_for(clips: &[String], source: &Frame16) -> RenderRequest {
         bounds: RectI::sized(width as i32, height as i32),
         order: RowOrder::BottomUp,
         inputs,
+        neighbours: Vec::new(),
     }
 }
 

--- a/crates/lumit-render/src/gpufx.rs
+++ b/crates/lumit-render/src/gpufx.rs
@@ -6919,6 +6919,88 @@ mod tests {
             .any(|(id, _)| *id == inst.id));
     }
 
+    /// **A run-time effect is handed the layer's decoded neighbours**, read
+    /// back as plain floats beside the picture. A plugin that reads the frames
+    /// either side (a motion blur) was handed nothing but the frame in hand
+    /// and compared it with itself. This is the seam that carries the
+    /// neighbours from the decode to the definition's CPU render.
+    #[test]
+    fn a_run_time_effect_is_handed_the_decoded_neighbours() {
+        let Some(ctx) = lumit_gpu::test_support::lease() else {
+            return;
+        };
+        /// Paints every pixel with the -1 neighbour's red, or leaves the
+        /// picture alone when there is no such neighbour.
+        struct Previous(&'static lumit_core::fx::EffectSchema);
+        impl lumit_core::fx::EffectDef for Previous {
+            fn schema(&self) -> &'static lumit_core::fx::EffectSchema {
+                self.0
+            }
+            fn apply_cpu_temporal(
+                &self,
+                _inst: uuid::Uuid,
+                _lt: f64,
+                rgba: &mut [f32],
+                _w: u32,
+                _h: u32,
+                _p: lumit_core::fx::Params<'_>,
+                neighbours: &[(i32, &[f32])],
+            ) {
+                let Some((_, previous)) = neighbours.iter().find(|(o, _)| *o == -1) else {
+                    return;
+                };
+                for (out, from) in rgba.iter_mut().zip(previous.iter()) {
+                    *out = *from;
+                }
+            }
+        }
+        let def: &'static Previous = Box::leak(Box::new(Previous(
+            a_run_time_def("ofx:test.render.previous").schema,
+        )));
+        assert!(crate::gpufx::ofx::register(def), "it registered");
+
+        let fx = ctx.fx();
+        let (w, h) = (4u32, 4u32);
+        let source: Vec<f32> = (0..(w * h)).flat_map(|_| [0.2f32, 0.2, 0.2, 1.0]).collect();
+        let previous: Vec<f32> = (0..(w * h)).flat_map(|_| [0.8f32, 0.4, 0.1, 1.0]).collect();
+        let inst = a_run_time_instance("ofx:test.render.previous");
+        let ops = lumit_core::fx::resolve_stack(
+            std::slice::from_ref(&inst),
+            0.0,
+            1000.0,
+            1.0,
+            &lumit_core::fx::MarkerContext::NONE,
+            std::sync::Arc::new(lumit_core::expression::ExpressionContext::detached()),
+        );
+
+        let tex = lumit_gpu::fx::upload_linear_f32(&ctx, &source, w, h);
+        let neighbours = [(-1, lumit_gpu::fx::upload_linear_f32(&ctx, &previous, w, h))];
+        let out = crate::fxops::run_ops(
+            fx,
+            &ctx,
+            tex,
+            w,
+            h,
+            &ops,
+            &neighbours,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+        );
+        let got = lumit_gpu::fx::readback_linear_f32(&ctx, &out, w, h).expect("readback");
+        assert!(
+            (got[0] - 0.8).abs() < 1e-2 && (got[1] - 0.4).abs() < 1e-2,
+            "the neighbour never reached the definition: {:?}",
+            &got[..4]
+        );
+    }
+
     /// **Shake picks its own kernel** (docs/08 §3.4, T18).
     ///
     /// Shake is the one migrated effect whose dispatch forks: plain, it is the

--- a/crates/lumit-render/src/gpufx/ofx.rs
+++ b/crates/lumit-render/src/gpufx/ofx.rs
@@ -18,8 +18,12 @@
 //! host of anything). `lumit-ofx` builds the definition; the composition root
 //! registers it here and in the catalogue; this draws it.
 //!
-//! **It takes no side table** — `aux()` is [`AuxKind::None`] — and it consumes
-//! no matte of its own, so the generic dissolve beside the dispatch spends it
+//! **Its one side table is the layer's neighbours**: `aux()` is
+//! [`AuxKind::Neighbours`], the decoded frames either side that Echo reads as
+//! textures, read back here for a plugin that reads them on the CPU. A motion
+//! blur asks its input for `t - 1` and `t + 1`, and a host that answers both
+//! with the frame in hand shows it a scene with no motion. It consumes no
+//! matte of its own, so the generic dissolve beside the dispatch spends it
 //! exactly as it does for any other effect on
 //! [`MatteRole::Strength`](lumit_core::fx::MatteRole). A plugin's rows
 //! are its own; a Matte the plugin never heard of would be a control nothing
@@ -33,7 +37,7 @@ use lumit_gpu::fx::FxEngine;
 use lumit_gpu::GpuContext;
 use uuid::Uuid;
 
-use super::{AuxSlot, GpuEffect};
+use super::{AuxKind, AuxSlot, GpuEffect};
 
 type Tex = wgpu::Texture;
 
@@ -83,13 +87,14 @@ pub fn clear_errored(instance: Uuid) {
 
 /// Run one definition's own CPU render and file whatever it says about it.
 ///
-/// This is the pass below, minus the two transfers: the picture goes to the
-/// definition as plain floats and the badge comes back. It is a function rather
-/// than three lines inside [`CpuPass::run`] because the failure path — a plugin
-/// that died, hung or was switched off — has to be provable without a graphics
-/// card, and the seam that turns "the plugin failed" into "the layer wears a
-/// badge" is exactly these two calls in this order
-/// (docs/impl/ofx-host.md §5 item 4).
+/// This is the pass below, minus the transfers: the picture and its neighbours
+/// go to the definition as plain floats and the badge comes back. It is a
+/// function rather than three lines inside [`CpuPass::run`] because the
+/// failure path (a plugin that died, hung or was switched off) has to be
+/// provable without a graphics card, and the seam that turns "the plugin
+/// failed" into "the layer wears a badge" is exactly these two calls in this
+/// order (docs/impl/ofx-host.md §5 item 4).
+#[allow(clippy::too_many_arguments)]
 pub fn apply_and_note(
     def: &'static dyn EffectDef,
     instance: Uuid,
@@ -98,8 +103,9 @@ pub fn apply_and_note(
     w: u32,
     h: u32,
     p: Params<'_>,
+    neighbours: &[(i32, &[f32])],
 ) {
-    def.apply_cpu_at(instance, lt, rgba, w, h, p);
+    def.apply_cpu_temporal(instance, lt, rgba, w, h, p, neighbours);
     note(instance, def.last_error());
 }
 
@@ -131,6 +137,10 @@ impl GpuEffect for CpuPass {
         self.0.schema().match_name
     }
 
+    fn aux(&self) -> AuxKind {
+        AuxKind::Neighbours
+    }
+
     fn run(
         &self,
         _fx: &FxEngine,
@@ -152,7 +162,24 @@ impl GpuEffect for CpuPass {
             );
             return tex.clone();
         };
-        apply_and_note(self.0, instance, lt, &mut rgba, w, h, p);
+        // The neighbours come off the card the same way, those at the
+        // picture's own size: one at another size is one the plugin could not
+        // compare with the frame in hand, and it is left out rather than
+        // padded, so the plugin gets the frame in hand for that time.
+        let neighbours: Vec<(i32, Vec<f32>)> = aux
+            .neighbours()
+            .iter()
+            .filter(|(_, neighbour)| neighbour.width() == w && neighbour.height() == h)
+            .filter_map(|(offset, neighbour)| {
+                let pixels = lumit_gpu::fx::readback_linear_f32(ctx, neighbour, w, h).ok()?;
+                Some((*offset, pixels))
+            })
+            .collect();
+        let borrowed: Vec<(i32, &[f32])> = neighbours
+            .iter()
+            .map(|(offset, pixels)| (*offset, pixels.as_slice()))
+            .collect();
+        apply_and_note(self.0, instance, lt, &mut rgba, w, h, p, &borrowed);
         lumit_gpu::fx::upload_linear_f32(ctx, &rgba, w, h)
     }
 }

--- a/crates/lumit-render/src/plan.rs
+++ b/crates/lumit-render/src/plan.rs
@@ -472,18 +472,23 @@ pub fn collect_comp_jobs(
                 let temporal =
                     if lumit_core::fx::stack_is_temporal(&layer.effects, layer.switches.fx) {
                         let comp_dt = 1.0 / comp.frame_rate.fps().max(1.0);
-                        lumit_core::fx::stack_temporal_window(&layer.effects, layer.switches.fx, lt)
-                            .into_iter()
-                            .filter(|&o| o != 0)
-                            .map(|o| {
-                                let nlt = lt + f64::from(o) * comp_dt;
-                                let nst = layer.source_time_at(nlt);
-                                let (nf, _) = lumit_core::pixels::frame_pick(
-                                    nst, fps, src_frames, false, None,
-                                );
-                                (o, nf)
-                            })
-                            .collect()
+                        // Asked at the layer's frame, the unit a plugin counts
+                        // in, and the same number the frame key asks at.
+                        lumit_core::fx::stack_temporal_window(
+                            &layer.effects,
+                            layer.switches.fx,
+                            lt / comp_dt,
+                        )
+                        .into_iter()
+                        .filter(|&o| o != 0)
+                        .map(|o| {
+                            let nlt = lt + f64::from(o) * comp_dt;
+                            let nst = layer.source_time_at(nlt);
+                            let (nf, _) =
+                                lumit_core::pixels::frame_pick(nst, fps, src_frames, false, None);
+                            (o, nf)
+                        })
+                        .collect()
                     } else {
                         Vec::new()
                     };

--- a/docs/impl/ofx-host.md
+++ b/docs/impl/ofx-host.md
@@ -138,8 +138,23 @@ What the built transport pins, beyond the sketch above:
 - Frames cross the ring as fp32 RGBA, tightly packed top-down. The header's row bytes
   describe *the ring*; the flip to OFX's bottom-up layout happens at the plugin boundary
   inside the broker.
-- The prefetch hook sits between `getFramesNeeded` and `isIdentity` — the only point in
-  §3's order where a frame at another time may be asked for.
+- **The frames either side travel with the frame.** The engine decodes a temporal effect's
+  neighbours beside the frame in hand (`stack_temporal_window`), and the render request
+  carries them by offset. They go into the same shipment as the frame, each `FrameRef` under
+  its own time, and onto the instance before the first question. That is where they have to
+  be: a plugin answers `getFramesNeeded` after reading how long its clip is, and a motion
+  blur (RSMB) fetches `t ± 1` inside its render. The clip's frame range and the instance's
+  duration are set to exactly the frames in hand before every render, so a plugin that
+  clamps to its clip sees a clip with neighbours in it. Told the clip was one frame long,
+  it asked for nothing and found no motion, which is what "RSMB does nothing" was. A
+  shipment the ring can't hold whole ships the frame alone. A clip the request has no
+  picture for (a plugin's optional second input) is unconnected, so nothing fetches from it.
+- The prefetch hook sits between `getFramesNeeded` and `isIdentity`, for whatever a plugin
+  asks for beyond what came with the frame, and those answer with the frame in hand.
+- **Time is in frames.** OFX counts in frames and the resolve walk speaks in seconds. The
+  definition's `resolve_derived` puts the layer's frame (`round(lt × comp fps)`) in the bag
+  as `derived.frame`, and the render, `getFramesNeeded` (asked through
+  `stack_temporal_window`, which now takes the frame) and the neighbour keys all use it.
 
 ## 4a. Becoming an effect
 
@@ -175,7 +190,10 @@ registered into the same catalogue the built-ins live in — the seam
 - **`getFramesNeeded` is asked per instance and per frame** through
   `EffectDef::frames_needed`, and the offsets it answers reach `stack_temporal_window` — and
   through it the frame key and the neighbour decode. The static declaration §3's describe
-  produced is the fallback and the gate.
+  produced is the fallback and the gate. The decoded neighbours come back down through
+  `EffectDef::apply_cpu_temporal`: the read-back pass declares `AuxKind::Neighbours`, reads
+  each neighbour at the picture's size off the card, and the definition hands them to the
+  host with the frame (§4).
 - **A failed render is identity, byte for byte**: the definition returns without writing,
   and files a sentence under the instance for the badge.
 - **Two hosts.** `LocalHost` drives a bundle in this process; `BrokerHost` drives §4's


### PR DESCRIPTION
Any effect which required other frame data didn't do anything, since it received the frame data of the current frame, which for effects such as RSMB resulted in visually nothing changing. The neighbours the engine already decodes for Echo now go across with the frame, the clip's frame range says they are there, and plugins are given their frame number rather than a time in seconds.

To test, install the RSMB demo into Common Files\OFX\Plugins, drop a clip with real motion on the timeline, add RSMB and scrub. The blur should follow the motion, and with the effect switched off the layer should look as it did before. The new tests cover the broker, the host and the read-back pass, and the OFX note has the details.

Still to do: step 4 of the commercial pass in docs/impl/ofx-host.md against a real RSMB build, since none is on this machine.
