### PR TITLE
fix(project): preserve disconnected graph outputs

### DIFF
--- a/crates/lumit-core/src/graph.rs
+++ b/crates/lumit-core/src/graph.rs
@@ -352,6 +352,7 @@ impl LayerGraph {
             && self.layout.is_empty()
             && self.exposed.is_empty()
             && self.groups.is_empty()
+            && !self.out_unwired
     }
 
     /// The driver instance named by `id`, if this graph carries one.
@@ -1560,6 +1561,22 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&LayerGraph::default()).expect("serialises"),
             "{}"
+        );
+    }
+
+    #[test]
+    fn disconnected_output_makes_the_graph_non_empty_and_persists() {
+        let graph = LayerGraph {
+            out_unwired: true,
+            ..LayerGraph::default()
+        };
+        assert!(!graph.is_empty());
+        let json = serde_json::to_string(&graph).expect("serialises");
+        assert!(json.contains("out_unwired"));
+        assert!(
+            serde_json::from_str::<LayerGraph>(&json)
+                .expect("deserialises")
+                .out_unwired
         );
     }
 }


### PR DESCRIPTION
# Preserve disconnected layer output across project save/load

Fixes a project round-trip issue where a disconnected layer output could be omitted during serialization and restored in the default connected state after reopening the project.

The graph is now considered non-empty when the output is explicitly disconnected, so that state is preserved on save/load.

Testing:
- Added a regression test for disconnected output persistence.
- Verified default and connected graph behavior remains unchanged.