### PR TITLE
Fix/ofx bundle host identity

### DIFF
--- a/crates/lumit-ofx/src/bundle.rs
+++ b/crates/lumit-ofx/src/bundle.rs
@@ -278,21 +278,15 @@ impl Bundle {
             return;
         }
         self.loaded = true;
-        // Who the host says it is, for this bundle. The name is on
-        // one property set the whole process shares, so it is set before the
-        // bundle's first `setHost` and left for the bundle's lifetime.
-        // ponytail: a process-wide name, so two bundles hosted in one process
-        // with different quirks would see the last one set; the shipping
-        // arrangement is one bundle per broker process, where it cannot
-        // happen. A per-host-struct name is the upgrade if in-process hosting
-        // ever ships third-party bundles.
+        // Each compatibility alias receives an immutable host/property pair.
+        // A later bundle can never change what an already-loaded plugin sees.
         let presented = self.plugins.iter().find_map(|plugin| {
             quirks
                 .for_plugin(&plugin.identifier, plugin.version.0)
                 .present_as
         });
-        let _ = crate::host::present_as(presented.as_deref());
-        let host = host();
+        let host =
+            crate::host::host_for_presentation(presented.as_deref()).unwrap_or_else(|_| host());
         for plugin in &mut self.plugins {
             if !plugin.is_supported_image_effect() {
                 continue;

--- a/crates/lumit-ofx/src/host.rs
+++ b/crates/lumit-ofx/src/host.rs
@@ -377,13 +377,29 @@ mod tests {
         // Host structs returned by this module are leaked and immutable.
         let handle = Handle::from_ptr(unsafe { (*host).host });
         let state = state();
-        dump(state.props.get(handle).expect("bundle host property set"))
+        let props = state.props.get(handle);
+        assert!(props.is_ok(), "bundle host property set is missing");
+        let Ok(props) = props else {
+            return String::new();
+        };
+        dump(props)
     }
 
     #[test]
     fn compatibility_presentations_are_bundle_scoped() {
-        let first = host_for_presentation(Some("Compatibility A")).expect("first host");
-        let second = host_for_presentation(Some("Compatibility B")).expect("second host");
+        let first = host_for_presentation(Some("Compatibility A"));
+        assert!(first.is_ok(), "first compatibility host should be created");
+        let Ok(first) = first else {
+            return;
+        };
+        let second = host_for_presentation(Some("Compatibility B"));
+        assert!(
+            second.is_ok(),
+            "second compatibility host should be created"
+        );
+        let Ok(second) = second else {
+            return;
+        };
         assert_ne!(first, second);
         assert!(presented_name(first).contains("Compatibility A"));
         assert!(presented_name(second).contains("Compatibility B"));

--- a/crates/lumit-ofx/src/host.rs
+++ b/crates/lumit-ofx/src/host.rs
@@ -163,6 +163,24 @@ pub fn host() -> *const OfxHost {
     .0
 }
 
+/// A host pointer for one bundle's compatibility presentation.
+///
+/// The normal identity shares the process default. Compatibility aliases get a
+/// separate immutable property set and host struct, both intentionally leaked
+/// because plugins retain the pointers for their whole loaded lifetime.
+pub fn host_for_presentation(name: Option<&str>) -> Result<*const OfxHost, Status> {
+    let Some(name) = name.filter(|name| *name != HOST_NAME) else {
+        return Ok(host());
+    };
+    let mut props = host_property_set();
+    props.set(keys::NAME, PropValue::string(name)?);
+    let handle = state().props.insert(props)?;
+    Ok(Box::into_raw(Box::new(OfxHost {
+        host: handle.as_ptr(),
+        fetch_suite: Some(fetch_suite),
+    })))
+}
+
 /// `OfxHost::fetchSuite`.
 ///
 /// Returning null is a legitimate answer, and this host gives it for every
@@ -220,13 +238,6 @@ pub const HOST_NAME: &str = "com.lumitlab.Lumit";
 ///
 /// [`Status::ErrBadHandle`] if the host has no property set, which is the
 /// state before the host exists.
-pub fn present_as(name: Option<&str>) -> Result<(), Status> {
-    let handle = host_props_handle()?;
-    let value = PropValue::string(name.unwrap_or(HOST_NAME))?;
-    state().props.get_mut(handle)?.set(keys::NAME, value);
-    Ok(())
-}
-
 fn host_property_set() -> PropertySet {
     /// A key or value with a NUL in it would be a literal in this file with a
     /// NUL in it; there is nothing to report to and nothing to do, so the
@@ -356,4 +367,26 @@ pub fn dump(set: &PropertySet) -> String {
         out.push('\n');
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn presented_name(host: *const OfxHost) -> String {
+        // Host structs returned by this module are leaked and immutable.
+        let handle = Handle::from_ptr(unsafe { (*host).host });
+        let state = state();
+        dump(state.props.get(handle).expect("bundle host property set"))
+    }
+
+    #[test]
+    fn compatibility_presentations_are_bundle_scoped() {
+        let first = host_for_presentation(Some("Compatibility A")).expect("first host");
+        let second = host_for_presentation(Some("Compatibility B")).expect("second host");
+        assert_ne!(first, second);
+        assert!(presented_name(first).contains("Compatibility A"));
+        assert!(presented_name(second).contains("Compatibility B"));
+        assert!(presented_name(host()).contains(HOST_NAME));
+    }
 }

--- a/crates/lumit-ofx/src/tests.rs
+++ b/crates/lumit-ofx/src/tests.rs
@@ -639,60 +639,6 @@ fn the_shipped_quirks_file_presents_the_host_to_universe_as_resolve() {
     );
 }
 
-/// What the host's property set says its name and label are, right now.
-fn host_name_and_label() -> (String, String) {
-    let handle = host_props_handle().expect("the host has its own property set");
-    let state = state();
-    let set = state.props.get(handle).expect("the host set is live");
-    let read = |key: &str| {
-        set.get_string(key, 0)
-            .expect("a string")
-            .to_string_lossy()
-            .into_owned()
-    };
-    (read(keys::NAME), read(keys::LABEL))
-}
-
-/// Presenting the host under another name changes `kOfxPropName` and nothing
-/// else, and `None` puts Lumit's own name back.
-#[test]
-fn the_host_presents_itself_under_a_quirks_name_and_takes_it_back() {
-    let _name = host_name_lock();
-    crate::host::present_as(Some("SomeOtherHost")).expect("the host exists");
-    assert_eq!(
-        host_name_and_label(),
-        ("SomeOtherHost".to_owned(), "Lumit".to_owned()),
-        "the name changes and the label stays Lumit's own"
-    );
-    crate::host::present_as(None).expect("the host exists");
-    assert_eq!(host_name_and_label().0, crate::host::HOST_NAME);
-}
-
-/// Loading a bundle applies its quirks entry: the name the plugin reads from
-/// the host during load is the entry's.
-#[test]
-fn a_bundle_loads_under_the_name_its_quirks_entry_says() {
-    let _name = host_name_lock();
-    let root = tempfile::tempdir().expect("a temp dir");
-    let Some(binary) = a_bundle_in(root.path()) else {
-        skipped("a_bundle_loads_under_the_name_its_quirks_entry_says");
-        return;
-    };
-    let table = QuirksTable::parse(
-        r#"{ "plugins": [ {
-            "identifier": "com.lumitlab.testplug",
-            "present_as": "SomeOtherHost"
-        } ] }"#,
-    )
-    .expect("a well-formed table parses");
-    let mut bundle = Bundle::open(&binary).expect("the bundle opens");
-    bundle.load_with(&table);
-    assert_eq!(host_name_and_label().0, "SomeOtherHost");
-
-    bundle.unload();
-    crate::host::present_as(None).expect("the host exists");
-}
-
 #[test]
 fn a_quirks_entry_overrides_only_what_it_names() {
     let table = QuirksTable::parse(


### PR DESCRIPTION
Fixes OFX compatibility host identity being stored in process-global mutable state.

Each bundle now owns its own immutable host/property identity, so loading a plugin with a compatibility alias no longer changes the identity observed by previously loaded bundles.

Testing:
- Added a regression covering multiple compatibility identities.
- Verified the default host identity remains unchanged.