### PR TITLE
Fix torn frames from accumulation motion blur on footage

### DIFF
--- a/crates/lumit-flow/src/lib.rs
+++ b/crates/lumit-flow/src/lib.rs
@@ -1030,6 +1030,36 @@ fn occlusion_raw(f: &FlowField, g: &FlowField) -> Vec<u8> {
 /// plain smear, never a fault).
 pub fn confidence(f: &FlowField, g: &FlowField) -> Vec<f32> {
     let (w, h) = (f.w, f.h);
+    let raw = agreement(f, g);
+    let n = raw.len();
+    // 3×3 box blur: ramp the confidence over a pixel so the streak-length taper
+    // has no visible seam.
+    let mut out = vec![0f32; n];
+    for y in 0..h {
+        for x in 0..w {
+            let (mut acc, mut cnt) = (0f32, 0f32);
+            for oy in -1i32..=1 {
+                for ox in -1i32..=1 {
+                    let qx = (x as i32 + ox).clamp(0, w as i32 - 1) as usize;
+                    let qy = (y as i32 + oy).clamp(0, h as i32 - 1) as usize;
+                    acc += raw[qy * w + qx];
+                    cnt += 1.0;
+                }
+            }
+            out[y * w + x] = acc / cnt;
+        }
+    }
+    out
+}
+
+/// [`confidence`] before its blur: each pixel's own agreement between the two
+/// fields, exactly 0 where its vector fails the consistency test. The blur
+/// lends a pixel some of its neighbours' trust, which is right for tapering a
+/// streak and wrong for weighting a vector, since the pixel keeps its own bad
+/// vector while gaining the trust. [`borrow_uncertain`] reads this one.
+#[must_use]
+pub fn agreement(f: &FlowField, g: &FlowField) -> Vec<f32> {
+    let (w, h) = (f.w, f.h);
     let n = w * h;
     if g.w != w || g.h != h || f.u.len() != n || g.u.len() != n {
         return vec![1.0; n];
@@ -1056,24 +1086,131 @@ pub fn confidence(f: &FlowField, g: &FlowField) -> Vec<f32> {
             raw[i] = agree * if f.valid[i] == 0 { VALID_DIM } else { 1.0 };
         }
     }
-    // 3×3 box blur: ramp the confidence over a pixel so the streak-length taper
-    // has no visible seam.
-    let mut out = vec![0f32; n];
-    for y in 0..h {
-        for x in 0..w {
-            let (mut acc, mut cnt) = (0f32, 0f32);
-            for oy in -1i32..=1 {
-                for ox in -1i32..=1 {
-                    let qx = (x as i32 + ox).clamp(0, w as i32 - 1) as usize;
-                    let qy = (y as i32 + oy).clamp(0, h as i32 - 1) as usize;
-                    acc += raw[qy * w + qx];
-                    cnt += 1.0;
+    raw
+}
+
+/// `f` with every uncertain vector replaced by the motion of the nearest
+/// pixels the measurement is confident about, ready for synthesis. Each pixel
+/// blends its own vector with that borrowed one by its [`agreement`] with `g`,
+/// the way Motion blur steers an uncertain pixel (docs/impl/optical-flow.md
+/// §4.7), so a confident pixel keeps its vector to the bit and a pixel nothing
+/// explains takes the borrowed one whole. The agreement rather than the
+/// blurred [`confidence`], because a bad vector must weigh nothing at all.
+///
+/// The borrowed motion is the confidence-weighted average of the confident
+/// pixels round about, nearer ones counting for more: a push-pull pyramid,
+/// where each level averages the level below with confidence as the weight and
+/// a pixel short of confidence takes the rest from the level above. It is not
+/// the tile's longest vector the blur borrows, and deliberately. A still thing
+/// in front of a moving background, a rifle scope in a game capture, say,
+/// shares its tiles with the background, so the tile's dominant motion is the
+/// background's and its featureless inside would be warped along with the
+/// wall behind it. Its nearest confident pixels are its own rim, which stands
+/// still, which is the right answer. A streak can afford to be short and
+/// roughly directed, but a warp has to land a pixel where its neighbours
+/// land, or the seam is a tear.
+///
+/// Why synthesis needs it: a pixel whose vector the measurement does not trust
+/// used to be warped along that vector anyway, and a wild vector drops the
+/// pixel somewhere unrelated. Every pixel comes back valid, so the consistency
+/// test in synthesis judges the borrowed vector on its merits rather than
+/// writing the patch off unseen. A CPU pass over the field, so a caller that
+/// draws many moments from one pair keeps the result beside the pair.
+#[must_use]
+pub fn borrow_uncertain(f: &FlowField, g: &FlowField) -> FlowField {
+    let (w, h) = (f.w, f.h);
+    let n = w * h;
+    if n == 0 || f.u.len() != n || f.v.len() != n {
+        return f.clone();
+    }
+    let conf = agreement(f, g);
+    // Push: each level is the confidence-weighted average of the one below,
+    // carried premultiplied as (u * c, v * c, c) so the weights ride along.
+    let mut levels: Vec<(usize, usize, Vec<[f32; 3]>)> = vec![(
+        w,
+        h,
+        (0..n)
+            .map(|i| {
+                let c = conf[i].clamp(0.0, 1.0);
+                [f.u[i] * c, f.v[i] * c, c]
+            })
+            .collect(),
+    )];
+    while let Some(&(lw, lh, _)) = levels.last().filter(|(lw, lh, _)| *lw > 1 || *lh > 1) {
+        let src = &levels[levels.len() - 1].2;
+        let (nw, nh) = (lw.div_ceil(2), lh.div_ceil(2));
+        let mut next = vec![[0.0f32; 3]; nw * nh];
+        for (i, cell) in next.iter_mut().enumerate() {
+            let (cx, cy) = (i % nw, i / nw);
+            let mut sum = [0.0f32; 3];
+            let mut count = 0.0f32;
+            for y in (cy * 2)..((cy * 2) + 2).min(lh) {
+                for x in (cx * 2)..((cx * 2) + 2).min(lw) {
+                    let s = src[y * lw + x];
+                    sum = [sum[0] + s[0], sum[1] + s[1], sum[2] + s[2]];
+                    count += 1.0;
                 }
             }
-            out[y * w + x] = acc / cnt;
+            *cell = [sum[0] / count, sum[1] / count, sum[2] / count];
         }
+        levels.push((nw, nh, next));
     }
-    out
+    // Pull: from the coarsest level down, a pixel takes its own average by
+    // however much confidence it has and the rest from the level above, read
+    // bilinearly between that level's cell centres.
+    let normalised = |s: [f32; 3]| {
+        if s[2] > 0.0 {
+            [s[0] / s[2], s[1] / s[2]]
+        } else {
+            [0.0, 0.0]
+        }
+    };
+    let top = levels.len() - 1;
+    let mut coarse: Vec<[f32; 2]> = levels[top].2.iter().map(|&s| normalised(s)).collect();
+    let mut cw = levels[top].0;
+    let mut ch = levels[top].1;
+    for level in (0..top).rev() {
+        let (lw, lh, ref cells) = levels[level];
+        let mut cur = vec![[0.0f32; 2]; lw * lh];
+        for (i, out) in cur.iter_mut().enumerate() {
+            let (x, y) = (i % lw, i / lw);
+            let fx = ((x as f32 + 0.5) / 2.0 - 0.5).clamp(0.0, cw as f32 - 1.0);
+            let fy = ((y as f32 + 0.5) / 2.0 - 0.5).clamp(0.0, ch as f32 - 1.0);
+            let (x0, y0) = (fx.floor() as usize, fy.floor() as usize);
+            let (x1, y1) = ((x0 + 1).min(cw - 1), (y0 + 1).min(ch - 1));
+            let (tx, ty) = (fx - x0 as f32, fy - y0 as f32);
+            let (c00, c10, c01, c11) = (
+                coarse[y0 * cw + x0],
+                coarse[y0 * cw + x1],
+                coarse[y1 * cw + x0],
+                coarse[y1 * cw + x1],
+            );
+            let up = [
+                (c00[0] * (1.0 - tx) + c10[0] * tx) * (1.0 - ty)
+                    + (c01[0] * (1.0 - tx) + c11[0] * tx) * ty,
+                (c00[1] * (1.0 - tx) + c10[1] * tx) * (1.0 - ty)
+                    + (c01[1] * (1.0 - tx) + c11[1] * tx) * ty,
+            ];
+            let s = cells[i];
+            let own = normalised(s);
+            let c = s[2].min(1.0);
+            *out = [
+                own[0] * c + up[0] * (1.0 - c),
+                own[1] * c + up[1] * (1.0 - c),
+            ];
+        }
+        coarse = cur;
+        cw = lw;
+        ch = lh;
+    }
+    let (u, v) = coarse.iter().map(|p| (p[0], p[1])).unzip();
+    FlowField {
+        w,
+        h,
+        u,
+        v,
+        valid: vec![1; n],
+    }
 }
 
 /// Speed (px per frame pair) below which a pixel counts as fully static, and
@@ -1621,31 +1758,12 @@ impl FlowEngine {
         if phi >= 1.0 {
             return b.to_vec();
         }
-        let (ga, gb, reduced) = grays_at::<Bytes>(a, b, w, h, set);
+        let (ga, gb, _) = grays_at::<Bytes>(a, b, w, h, set);
         let (fwd, bwd) = self.flow_pair_with(&ga, &gb, set);
-        // The card paints straight from the working-resolution field: no
-        // upsample, no per-pixel CPU, no round trip. A failure here
-        // costs speed, never the frame.
-        if let Some(s) = self.synth.as_ref() {
-            match s.synthesize(a, b, w, h, &fwd, &bwd, phi, set) {
-                Ok(px) => return px,
-                Err(_) => self.synth = None, // degrade for the rest of this engine
-            }
-        }
-        let hud = set.hud_guard.then(|| hud_weights(&ga, &fwd));
-        let (fwd, bwd) = if reduced {
-            (upsample_field(&fwd, w, h), upsample_field(&bwd, w, h))
-        } else {
-            (fwd, bwd)
-        };
-        let hud = hud.map(|g| {
-            if reduced {
-                weights_to_size(&g, ga.w, ga.h, w, h)
-            } else {
-                g
-            }
-        });
-        synthesize_with(a, b, w, h, &fwd, &bwd, phi, set, hud.as_deref())
+        // Each field is steadied against the other as measured, before either
+        // is changed, so both borrow from the same confidence.
+        let (fwd, bwd) = (borrow_uncertain(&fwd, &bwd), borrow_uncertain(&bwd, &fwd));
+        self.synthesize_at(a, b, w, h, &fwd, &bwd, phi, set)
     }
 
     /// Paint the frame at `phi` from flow that has *already* been measured —
@@ -1654,7 +1772,9 @@ impl FlowEngine {
     /// Separating the halves is what lets a caller cache the measurement: the
     /// field between two source frames is one field however many phases are
     /// drawn from it, and a slow ramp draws many. `fwd`/`bwd` are at their own
-    /// (working) resolution, which need not be the frames'.
+    /// (working) resolution, which need not be the frames', and the caller
+    /// hands them steadied ([`borrow_uncertain`]), which it caches for the
+    /// same reason.
     #[allow(clippy::too_many_arguments)]
     pub fn synthesize_at(
         &mut self,
@@ -1673,10 +1793,13 @@ impl FlowEngine {
         if phi >= 1.0 {
             return b.to_vec();
         }
+        // The card paints straight from the working-resolution field: no
+        // upsample, no per-pixel CPU, no round trip. A failure here costs
+        // speed, never the frame.
         if let Some(s) = self.synth.as_ref() {
             match s.synthesize(a, b, w, h, fwd, bwd, phi, set) {
                 Ok(px) => return px,
-                Err(_) => self.synth = None,
+                Err(_) => self.synth = None, // degrade for the rest of this engine
             }
         }
         self.synthesize_cpu::<Bytes>(a, b, w, h, fwd, bwd, phi, set)
@@ -2545,6 +2668,61 @@ mod tests {
             valid: vec![1; 4],
         };
         assert!(confidence(&f, &small).iter().all(|&x| x == 1.0));
+    }
+
+    // An uncertain patch inside a neighbourhood that agrees ends up moving
+    // with the neighbourhood, and a confident pixel keeps its own vector to
+    // the bit. Synthesis used to warp the patch along its wild vector and drop
+    // it somewhere unrelated, which is what the torn blocks on a fast edge
+    // were.
+    #[test]
+    fn an_uncertain_patch_borrows_the_motion_its_neighbourhood_agrees_on() {
+        let (w, h) = (48usize, 48usize);
+        let n = w * h;
+        // Everything moves (8, 0), the backward twin (-8, 0), so the pair is
+        // consistent and fully confident.
+        let mut f = FlowField {
+            w,
+            h,
+            u: vec![8.0; n],
+            v: vec![0.0; n],
+            valid: vec![1; n],
+        };
+        let g = FlowField {
+            w,
+            h,
+            u: vec![-8.0; n],
+            v: vec![0.0; n],
+            valid: vec![1; n],
+        };
+        // A 6x6 patch in the middle has a wild vector nothing explains, and
+        // the measurement marked it invalid.
+        for y in 20..26 {
+            for x in 20..26 {
+                f.u[y * w + x] = -15.0;
+                f.v[y * w + x] = 15.0;
+                f.valid[y * w + x] = 0;
+            }
+        }
+        let out = borrow_uncertain(&f, &g);
+        assert_eq!((out.w, out.h, out.u.len()), (w, h, n));
+        let centre = 23 * w + 23;
+        assert!(
+            (out.u[centre] - 8.0).abs() < 0.5 && out.v[centre].abs() < 0.5,
+            "the patch moves with its neighbourhood: ({}, {})",
+            out.u[centre],
+            out.v[centre]
+        );
+        assert_eq!(
+            out.valid[centre], 1,
+            "a borrowed vector is judged on its merits"
+        );
+        let far = 4 * w + 4;
+        assert_eq!(
+            (out.u[far], out.v[far]),
+            (8.0, 0.0),
+            "a confident pixel is untouched"
+        );
     }
 
     // ---- The WGSL backend against the CPU oracle (impl note §6.5) ----

--- a/crates/lumit-render/src/decode.rs
+++ b/crates/lumit-render/src/decode.rs
@@ -94,12 +94,13 @@ pub struct CompJob {
     /// a layer no such adjustment covers, so a plain layer decodes exactly one
     /// frame. Each is the frame pair the moment falls between, picked the way
     /// the Blend policy picks: a moment that lands on a real frame is that
-    /// frame alone, and one between two is synthesised from both with
-    /// [`Self::shutter_flow`].
+    /// frame alone, and one between two is a crossfade of both, or a flow
+    /// synthesis of both when [`Self::shutter_flow`] says so.
     pub shutter: Vec<ShutterSample>,
-    /// How the in-between moments in [`Self::shutter`] are made: the layer's
-    /// own Flow settings when its Retime uses Flow, otherwise the defaults.
-    /// `None` only when `shutter` is empty.
+    /// The layer's own Flow settings when its Retime uses Flow, so its
+    /// in-between moments are synthesised the way its retime is. `None`
+    /// otherwise, and the moments crossfade: flow can tear on footage it
+    /// cannot measure, and it runs only where the user switched it on.
     pub shutter_flow: Option<lumit_core::retime::FlowParams>,
 }
 
@@ -367,9 +368,10 @@ impl lumit_cache::ByteSized for CachedFlow {
 }
 
 /// What a cached flow pair is filed under: which source, which two frames of
-/// it, and the settings it was measured with — every one of which changes the
-/// field.
-type FlowKey = (Uuid, usize, usize, u64);
+/// it, and the settings it was measured with, every one of which changes the
+/// field. The flag says whether it is the pair as measured or the pair
+/// steadied for synthesis (see [`flow_for`]).
+type FlowKey = (Uuid, usize, usize, u64, bool);
 
 /// A stable hash of the settings that shape a measurement.
 fn flow_settings_key(s: &lumit_flow::FlowSettings) -> u64 {
@@ -679,6 +681,13 @@ impl PreviewEngine {
 ///
 /// Keyed by content, never by timeline position: the source, the two frames,
 /// and the settings that shape the measurement.
+///
+/// `settled` asks for the pair with every uncertain vector replaced by its
+/// confident neighbours' motion ([`lumit_flow::borrow_uncertain`]), which is
+/// what synthesis warps along. Motion blur wants the pair as measured, since
+/// it does that borrowing itself in its own kernel. The steadied pair is a CPU
+/// pass over the field, so it is cached like the measurement: an eight-sample
+/// shutter draws eight moments from one pair and pays once.
 #[allow(clippy::too_many_arguments)]
 fn flow_for(
     flow_engine: &mut Option<lumit_flow::FlowEngine>,
@@ -690,14 +699,37 @@ fn flow_for(
     a: &lumit_flow::Gray,
     b: &lumit_flow::Gray,
     set: &lumit_flow::FlowSettings,
+    settled: bool,
 ) -> (lumit_flow::FlowField, lumit_flow::FlowField) {
-    let key = (item, frame_a, frame_b, flow_settings_key(set));
+    let key = (item, frame_a, frame_b, flow_settings_key(set), settled);
     if let Some(hit) = flow_cache.get(&key) {
         return (hit.fwd.clone(), hit.bwd.clone());
     }
-    let (fwd, bwd) = flow_engine
-        .get_or_insert_with(|| flow_engine_for(gpu))
-        .flow_pair_with(a, b, set);
+    let (fwd, bwd) = if settled {
+        // Steadied from the pair as measured, which is cached on its own so a
+        // Motion blur on the same clip reads the raw measurement it wants.
+        // Each field borrows against the other before either is changed.
+        let (fwd, bwd) = flow_for(
+            flow_engine,
+            flow_cache,
+            gpu,
+            item,
+            frame_a,
+            frame_b,
+            a,
+            b,
+            set,
+            false,
+        );
+        (
+            lumit_flow::borrow_uncertain(&fwd, &bwd),
+            lumit_flow::borrow_uncertain(&bwd, &fwd),
+        )
+    } else {
+        flow_engine
+            .get_or_insert_with(|| flow_engine_for(gpu))
+            .flow_pair_with(a, b, set)
+    };
     flow_cache.insert(
         key,
         CachedFlow {
@@ -822,6 +854,7 @@ fn combine_pair(
         &ga,
         &gb,
         &set,
+        true,
     );
     let engine = flow_engine.get_or_insert_with(|| flow_engine_for(gpu));
     // The float synthesis runs on the processor rather than the card — see
@@ -961,6 +994,7 @@ fn decode_comp(
                         &ga,
                         &gb,
                         &set,
+                        false,
                     );
                     // The per-pixel confidence Motion blur tapers the streak
                     // by (FX-19); the same deterministic function export runs, so
@@ -1311,7 +1345,7 @@ mod tests {
         let set = lumit_flow::FlowSettings::default();
         let call = |e: &mut Option<lumit_flow::FlowEngine>,
                     c: &mut lumit_cache::ByteLru<FlowKey, CachedFlow>| {
-            flow_for(e, c, None, item, 0, 1, &ga, &gb, &set)
+            flow_for(e, c, None, item, 0, 1, &ga, &gb, &set, false)
         };
         let (f1, _) = call(&mut engine, &mut cache);
         assert_eq!(cache.len(), 1, "the first ask files an entry");
@@ -1323,5 +1357,22 @@ mod tests {
         assert_eq!(f1.u, f2.u);
         assert_eq!(f1.v, f2.v);
         assert_eq!(f1.valid, f2.valid);
+        // The steadied pair synthesis warps along is filed beside the
+        // measurement and made from it, so it needs no engine either, and a
+        // second ask for it is a plain hit.
+        let (s1, _) = flow_for(
+            &mut none, &mut cache, None, item, 0, 1, &ga, &gb, &set, true,
+        );
+        assert!(
+            none.is_none(),
+            "the steadied pair comes from the cached measurement"
+        );
+        assert_eq!(cache.len(), 2, "the steadied pair has an entry of its own");
+        assert!(s1.valid.iter().all(|&v| v == 1));
+        let (s2, _) = flow_for(
+            &mut none, &mut cache, None, item, 0, 1, &ga, &gb, &set, true,
+        );
+        assert_eq!(cache.len(), 2);
+        assert_eq!(s1.u, s2.u);
     }
 }

--- a/crates/lumit-render/src/plan.rs
+++ b/crates/lumit-render/src/plan.rs
@@ -492,9 +492,11 @@ pub fn collect_comp_jobs(
                 // sub-frame re-renders smear footage motion and not only
                 // transforms. Each moment is picked the way the Blend policy
                 // picks, so a moment on a real frame is that frame alone and
-                // one between two is synthesised from both, by the layer's own
-                // Flow settings where its Retime uses Flow and the defaults
-                // otherwise. Empty for every layer no such adjustment covers.
+                // one between two is a crossfade of both. Only a layer whose
+                // Retime uses Flow gets its moments synthesised by flow, with
+                // its own settings: flow can tear on footage it cannot
+                // measure, and it runs only where the user switched it on.
+                // Empty for every layer no such adjustment covers.
                 let shutter: Vec<crate::decode::ShutterSample> = shutter_offsets[idx]
                     .iter()
                     .map(|&off| {
@@ -512,10 +514,10 @@ pub fn collect_comp_jobs(
                         }
                     })
                     .collect();
-                let shutter_flow = (!shutter.is_empty()).then(|| match &layer.interpolation {
-                    Interpolation::Flow(p) => p.clone(),
-                    _ => lumit_core::retime::FlowParams::default(),
-                });
+                let shutter_flow = match &layer.interpolation {
+                    Interpolation::Flow(p) if !shutter.is_empty() => Some(p.clone()),
+                    _ => None,
+                };
                 jobs.push(CompJob {
                     layer: layer.id,
                     item: *item,
@@ -1659,7 +1661,7 @@ mod tests {
         let (above_id, below_id) = (above.id, below.id);
         // A 30 fps comp over 60 fps clips: a quarter of a comp frame is half a
         // source frame, so every moment lands between two frames.
-        let comp = Composition {
+        let mut comp = Composition {
             master_volume_db: 0.0,
             groups: Vec::new(),
             beat_grid: None,
@@ -1711,10 +1713,11 @@ mod tests {
             ],
             "each shutter moment is the pair of source frames it falls between"
         );
+        // Flow runs only where the user switched it on. A clip whose Retime
+        // does not use Flow crossfades its in-betweens.
         assert_eq!(
-            covered.shutter_flow,
-            Some(lumit_core::retime::FlowParams::default()),
-            "a Nearest clip makes its in-betweens with the default flow settings"
+            covered.shutter_flow, None,
+            "a Nearest clip crossfades its in-betweens"
         );
 
         let clear = job_for(above_id);
@@ -1731,5 +1734,20 @@ mod tests {
             std::slice::from_ref(covered),
             std::slice::from_ref(clear)
         ));
+
+        // A clip whose Retime uses Flow has asked for synthesis, and its
+        // moments are made with its own settings.
+        let flow = lumit_core::retime::FlowParams {
+            smoothness: 0.25,
+            ..lumit_core::retime::FlowParams::default()
+        };
+        comp.layers[2].interpolation = lumit_core::retime::Interpolation::Flow(flow.clone());
+        let jobs = plan_comp_frame(&doc, &comp, 1.0, Quality::default(), &probes);
+        let covered = jobs.iter().find(|j| j.layer == below_id).expect("planned");
+        assert_eq!(
+            covered.shutter_flow,
+            Some(flow),
+            "a Flow clip makes its in-betweens with its own flow settings"
+        );
     }
 }

--- a/docs/08-EFFECTS.md
+++ b/docs/08-EFFECTS.md
@@ -2102,11 +2102,14 @@ keep their own switches (a v1 follow-up).
 preview frame equals an export frame. A **still scene** averaged over N is bit-identical to the
 plain composite (pinned by test — `1/N` is exact in fp16, the N copies sum back exactly); a
 **moving scene** smears (a coverage-widening test). **Footage moves too**: each covered clip is
-decoded at every moment of the open shutter — the real frame where the moment lands on one,
-otherwise a flow-synthesised in-between made the way a Flow retime makes its frames — and each
-sample's below-stack reads that picture in place of the frame-time one, so a clip playing under
-the adjustment smears as a moving layer does (N decodes per covered clip per frame, one flow
-measurement per source-frame pair; `docs/impl/temporal-rerender.md` §2). **Boundaries (v1):**
+decoded at every moment of the open shutter. A moment that lands on a real frame is that frame,
+and one between two frames is a crossfade of the pair, made the way a Blend retime makes its
+frames. A layer whose Retime uses Flow gets flow-synthesised in-betweens with its own settings
+instead. Flow can tear on footage it cannot measure, and it runs only where the user switched
+it on. Each sample's below-stack reads that picture in place of the frame-time one, so a clip
+playing under the adjustment smears as a moving layer does (N decodes per covered clip per
+frame, and under Flow one measurement per source-frame pair, see
+`docs/impl/temporal-rerender.md` §2). **Boundaries (v1):**
 temporal effects inside the sampled below-stack (echo, flow motion blur, datamosh) hold to
 stills (the same v1 boundary Posterize takes), a Sequence clip under the adjustment holds its
 frame-time picture, and an accumulation adjustment inside a collapsed Precomp degrades to a

--- a/docs/impl/optical-flow.md
+++ b/docs/impl/optical-flow.md
@@ -162,6 +162,16 @@ out = (wA·A(x+uA) + wB·B(x+uB)) / (wA + wB)
 - The flow sampled for warping at x should ideally be the flow *at the destination*;
   approximate with one fixed-point iteration: sample F at x, then re-sample F at
   `x − φ·F₀(x)`, use that. Two lines in the shader, visibly reduces edge doubling.
+- Before either field is warped along, each is **steadied** (`borrow_uncertain`): a pixel
+  blends its own vector with the motion of the nearest confident pixels by its own agreement
+  with the reverse field (§2's measure before its blur, since a bad vector must weigh
+  nothing), the way the blur in §4.7 steers an uncertain pixel, so a vector the measurement
+  does not trust is not warped along as if it were. The borrowed motion is
+  a confidence-weighted push-pull average rather than the blur's tile maximum, since a warp
+  has to land a pixel where its neighbours land and a still thing in front of a moving
+  background shares its tiles with that background. A CPU pass over the field, so the
+  render crate caches the steadied pair beside the measured one and the Motion blur kernel,
+  which borrows for itself, keeps reading the measured one.
 - Where **both** endpoints are occluded/invalid (revealed background with no source):
   fall back to blend `lerp(A, B, φ)` — soft failure identical to Frame-Mix, which is the
   documented graceful-degradation behaviour ([08-EFFECTS.md](../08-EFFECTS.md): confidence-

--- a/docs/impl/temporal-rerender.md
+++ b/docs/impl/temporal-rerender.md
@@ -35,13 +35,16 @@ accumulation sample it is the frame-time decode with **each covered clip's pictu
 moment swapped in**: the decode planner reads `lumit_core::fx::accumulation_shutter_offsets`
 (the union of every live accumulation adjustment's offsets above each layer) and asks for the
 clip at each offset as a `CompJob::shutter` entry — a real frame where the moment lands on one,
-otherwise the pair it falls between, synthesised by flow (the layer's own Flow settings when its
-Retime uses Flow, else the defaults) through the same `combine_pair` a Flow retime uses. The
-worker files them on `CompLayerPixels::shutter` keyed by offset, `accumulation_mb_below` builds
-each sample's map from them, and a clip with no picture for a moment (a Sequence clip, a dropped
-decode) keeps its frame-time pixels. So footage motion smears as transforms do, at N decodes
-per covered clip per frame; the flow field between two source frames is measured once and
-reused across every moment drawn from it. A **plain layer carrying the effect** gets its own
+otherwise the pair it falls between, crossfaded through the same `combine_pair` a Blend retime
+uses. Only a layer whose Retime uses Flow gets its moments synthesised by flow, with its own
+settings: flow can tear on footage it cannot measure (a 60 fps game capture in a 24 fps comp
+showed it, a featureless scope sliding over a wall), and it runs only where the user switched
+it on. The worker files them on `CompLayerPixels::shutter` keyed by offset,
+`accumulation_mb_below` builds each sample's map from them, and a clip with no picture for a
+moment (a Sequence clip, a dropped decode) keeps its frame-time pixels. So footage motion
+smears as transforms do, at N decodes per covered clip per frame, and under Flow the field
+between two source frames is measured and steadied once and reused across every moment drawn
+from it. A **plain layer carrying the effect** gets its own
 offsets from the same helper and is not a re-render at all: `build::own_shutter_average`
 averages the clip's shutter moments in the decoded bytes (Mix blending back toward the
 frame-time picture) before masks and paint, so the effect on a footage layer blurs the motion


### PR DESCRIPTION
Accumulation motion blur on footage was making its in-between moments with optical flow whether or not the layer used Flow. Flow tears on footage it can't measure, such as a featureless scope sliding across a wall, so a 60fps clip in a 24fps comp came out blocky round the edge. The moments are now a crossfade of the two frames they fall between, and a layer with its Retime set to Flow still gets flow with its own settings. Also steadies the flow field before synthesis, so a pixel the measurement doesn't trust borrows the motion of its nearest confident neighbours the way Motion blur does, cached beside the measurement.

To test, drop a 60fps or 120fps clip into a 24fps comp and add Accumulation motion blur to it. Fast moving edges should smear cleanly with no torn blocks. Then set the layer's Retime to Flow and check it still tears less than it did on the same clip.

No new strings.
