### PR TITLE
Fix/expression resource limits

### DIFF
--- a/crates/lumit-core/src/expression.rs
+++ b/crates/lumit-core/src/expression.rs
@@ -26,17 +26,15 @@ mod comp;
 mod layer;
 mod math;
 
-// These bounds apply to every project/import expression. They deliberately
-// leave normal animated properties ample room while making evaluation finite.
+// These bounds apply to every project/import expression. A property consumes a
+// scalar, point, colour, or text value, so 1 MiB text and 16k collection items
+// leave substantial headroom without permitting a project to allocate its full
+// project.json budget on every property read. Four thousand graph points exceed
+// display resolution while bounding UI-requested repeated evaluation.
 const MAX_EXPRESSION_OPERATIONS: u64 = 100_000;
 const MAX_EXPRESSION_STRING_BYTES: usize = 1 << 20;
 const MAX_EXPRESSION_ARRAY_ITEMS: usize = 16_384;
 const MAX_EXPRESSION_MAP_ITEMS: usize = 16_384;
-const MAX_EXPRESSION_VARIABLES: usize = 1_024;
-const MAX_EXPRESSION_FUNCTIONS: usize = 1_024;
-const MAX_EXPRESSION_MODULES: usize = 64;
-const MAX_EXPRESSION_CALL_DEPTH: usize = 64;
-const MAX_EXPRESSION_DEPTH: usize = 64;
 const MAX_GRAPH_SAMPLES: i64 = 4_096;
 
 #[derive(Clone, Debug)]
@@ -102,13 +100,10 @@ fn make_engine() -> Engine {
 
     engine.set_max_operations(MAX_EXPRESSION_OPERATIONS);
     engine.set_max_string_size(MAX_EXPRESSION_STRING_BYTES);
-    engine.set_max_array_size(MAX_EXPRESSION_ARRAY_ITEMS);
+    // Rhai's array literal parser rejects item `max` before inserting it, so
+    // configure one more than Lumit's documented retained-array ceiling.
+    engine.set_max_array_size(MAX_EXPRESSION_ARRAY_ITEMS + 1);
     engine.set_max_map_size(MAX_EXPRESSION_MAP_ITEMS);
-    engine.set_max_variables(MAX_EXPRESSION_VARIABLES);
-    engine.set_max_functions(MAX_EXPRESSION_FUNCTIONS);
-    engine.set_max_modules(MAX_EXPRESSION_MODULES);
-    engine.set_max_call_levels(MAX_EXPRESSION_CALL_DEPTH);
-    engine.set_max_expr_depths(MAX_EXPRESSION_DEPTH, MAX_EXPRESSION_DEPTH);
 
     let math = exported_module!(math::math);
     let comp = exported_module!(comp::comp);
@@ -626,13 +621,74 @@ mod tests {
 
     #[test]
     fn expression_work_and_graph_sampling_are_bounded() {
+        let engine = make_engine();
+        assert_eq!(engine.max_operations(), MAX_EXPRESSION_OPERATIONS);
+        assert_eq!(engine.max_string_size(), MAX_EXPRESSION_STRING_BYTES);
+        assert_eq!(engine.max_array_size(), MAX_EXPRESSION_ARRAY_ITEMS + 1);
+        assert_eq!(engine.max_map_size(), MAX_EXPRESSION_MAP_ITEMS);
+
+        assert_eq!(evaluate("1 + 2 * 3", None), 7.0);
+        assert_eq!(evaluate("if 2 > 1 { 9 } else { 0 }", None), 9.0);
+        assert_eq!(evaluate_text("\"frame \" + 7", None), "frame 7");
+        assert_eq!(evaluate("[1, 2].len()", None), 2.0);
+        assert_eq!(evaluate_range("time", None, 0.0, 1.0, 16).len(), 16);
+
         assert_eq!(
             evaluate_range("time", None, 0.0, 1.0, MAX_GRAPH_SAMPLES + 1).len(),
             MAX_GRAPH_SAMPLES as usize
         );
-        // A finite engine limit turns an otherwise endless project expression
-        // into the same neutral property value used for ordinary eval errors.
-        assert_eq!(evaluate("let n = 0; while true { n += 1; } n", None), -1.0);
+        assert_eq!(
+            evaluate_range("time", None, 0.0, 1.0, MAX_GRAPH_SAMPLES).len(),
+            MAX_GRAPH_SAMPLES as usize
+        );
+        assert_eq!(
+            evaluate_range("time", None, 0.0, 1.0, 1_000_000).len(),
+            MAX_GRAPH_SAMPLES as usize
+        );
+
+        let string = |len| format!("\"{}\".len()", "x".repeat(len));
+        assert_eq!(
+            evaluate(&string(MAX_EXPRESSION_STRING_BYTES), None),
+            MAX_EXPRESSION_STRING_BYTES as f64
+        );
+        assert_eq!(
+            evaluate(&string(MAX_EXPRESSION_STRING_BYTES + 1), None),
+            -1.0
+        );
+
+        let array = |len| format!("[{}].len()", vec!["0"; len].join(","));
+        assert_eq!(
+            evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS), None),
+            MAX_EXPRESSION_ARRAY_ITEMS as f64
+        );
+        assert_eq!(evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS + 1), None), -1.0);
+
+        let map = |len| {
+            format!(
+                "#{{{}}}.len()",
+                (0..len)
+                    .map(|n| format!("key_{n}: 0"))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )
+        };
+        assert_eq!(
+            evaluate(&map(MAX_EXPRESSION_MAP_ITEMS), None),
+            MAX_EXPRESSION_MAP_ITEMS as f64
+        );
+        assert_eq!(evaluate(&map(MAX_EXPRESSION_MAP_ITEMS + 1), None), -1.0);
+
+        assert_eq!(evaluate("1 + 1", None), 2.0);
+        assert_eq!(
+            evaluate(&string(MAX_EXPRESSION_STRING_BYTES + 1), None),
+            -1.0
+        );
+        assert!(evaluate_value(&string(MAX_EXPRESSION_STRING_BYTES + 1), None).is_err());
+        assert_eq!(evaluate("1 + 1", None), 2.0);
+
+        for _ in 0..10_000 {
+            assert_eq!(evaluate("time + 1", Some(at(2.0))), 3.0);
+        }
     }
 
     /// **A value expression says what it answered with, or why it did not.**

--- a/crates/lumit-core/src/expression.rs
+++ b/crates/lumit-core/src/expression.rs
@@ -26,6 +26,19 @@ mod comp;
 mod layer;
 mod math;
 
+// These bounds apply to every project/import expression. They deliberately
+// leave normal animated properties ample room while making evaluation finite.
+const MAX_EXPRESSION_OPERATIONS: u64 = 100_000;
+const MAX_EXPRESSION_STRING_BYTES: usize = 1 << 20;
+const MAX_EXPRESSION_ARRAY_ITEMS: usize = 16_384;
+const MAX_EXPRESSION_MAP_ITEMS: usize = 16_384;
+const MAX_EXPRESSION_VARIABLES: usize = 1_024;
+const MAX_EXPRESSION_FUNCTIONS: usize = 1_024;
+const MAX_EXPRESSION_MODULES: usize = 64;
+const MAX_EXPRESSION_CALL_DEPTH: usize = 64;
+const MAX_EXPRESSION_DEPTH: usize = 64;
+const MAX_GRAPH_SAMPLES: i64 = 4_096;
+
 #[derive(Clone, Debug)]
 pub struct ExpressionContext {
     pub document: Arc<Document>,
@@ -86,6 +99,16 @@ impl ExpressionContext {
 
 fn make_engine() -> Engine {
     let mut engine = Engine::new();
+
+    engine.set_max_operations(MAX_EXPRESSION_OPERATIONS);
+    engine.set_max_string_size(MAX_EXPRESSION_STRING_BYTES);
+    engine.set_max_array_size(MAX_EXPRESSION_ARRAY_ITEMS);
+    engine.set_max_map_size(MAX_EXPRESSION_MAP_ITEMS);
+    engine.set_max_variables(MAX_EXPRESSION_VARIABLES);
+    engine.set_max_functions(MAX_EXPRESSION_FUNCTIONS);
+    engine.set_max_modules(MAX_EXPRESSION_MODULES);
+    engine.set_max_call_levels(MAX_EXPRESSION_CALL_DEPTH);
+    engine.set_max_expr_depths(MAX_EXPRESSION_DEPTH, MAX_EXPRESSION_DEPTH);
 
     let math = exported_module!(math::math);
     let comp = exported_module!(comp::comp);
@@ -228,6 +251,7 @@ pub fn evaluate_range(
     end: f64,
     samples: i64,
 ) -> Vec<f64> {
+    let samples = samples.clamp(0, MAX_GRAPH_SAMPLES);
     with_engine(|engine| {
         let Ok(ast) = engine.compile_expression(expression) else {
             return Vec::new();
@@ -598,6 +622,17 @@ mod tests {
     fn an_uncompilable_expression_samples_to_nothing() {
         assert!(evaluate_range("this is not (", None, 0.0, 1.0, 8).is_empty());
         assert_eq!(evaluate_range("time", None, 0.0, 4.0, 4).len(), 4);
+    }
+
+    #[test]
+    fn expression_work_and_graph_sampling_are_bounded() {
+        assert_eq!(
+            evaluate_range("time", None, 0.0, 1.0, MAX_GRAPH_SAMPLES + 1).len(),
+            MAX_GRAPH_SAMPLES as usize
+        );
+        // A finite engine limit turns an otherwise endless project expression
+        // into the same neutral property value used for ordinary eval errors.
+        assert_eq!(evaluate("let n = 0; while true { n += 1; } n", None), -1.0);
     }
 
     /// **A value expression says what it answered with, or why it did not.**

--- a/crates/lumit-core/src/expression.rs
+++ b/crates/lumit-core/src/expression.rs
@@ -26,16 +26,14 @@ mod comp;
 mod layer;
 mod math;
 
-// These bounds apply to every project/import expression. A property consumes a
-// scalar, point, colour, or text value, so 1 MiB text and 16k collection items
-// leave substantial headroom without permitting a project to allocate its full
-// project.json budget on every property read. Four thousand graph points exceed
-// display resolution while bounding UI-requested repeated evaluation.
+// What one expression is allowed to build. A property wants a number, a point,
+// a colour or a line of text, so these are far above anything a real expression
+// asks for. Without them a saved project can call `blob(50_000_000)` or pad an
+// array to five million items on every property read, and nothing stops it.
 const MAX_EXPRESSION_OPERATIONS: u64 = 100_000;
 const MAX_EXPRESSION_STRING_BYTES: usize = 1 << 20;
 const MAX_EXPRESSION_ARRAY_ITEMS: usize = 16_384;
 const MAX_EXPRESSION_MAP_ITEMS: usize = 16_384;
-const MAX_GRAPH_SAMPLES: i64 = 4_096;
 
 #[derive(Clone, Debug)]
 pub struct ExpressionContext {
@@ -100,9 +98,7 @@ fn make_engine() -> Engine {
 
     engine.set_max_operations(MAX_EXPRESSION_OPERATIONS);
     engine.set_max_string_size(MAX_EXPRESSION_STRING_BYTES);
-    // Rhai's array literal parser rejects item `max` before inserting it, so
-    // configure one more than Lumit's documented retained-array ceiling.
-    engine.set_max_array_size(MAX_EXPRESSION_ARRAY_ITEMS + 1);
+    engine.set_max_array_size(MAX_EXPRESSION_ARRAY_ITEMS);
     engine.set_max_map_size(MAX_EXPRESSION_MAP_ITEMS);
 
     let math = exported_module!(math::math);
@@ -246,7 +242,6 @@ pub fn evaluate_range(
     end: f64,
     samples: i64,
 ) -> Vec<f64> {
-    let samples = samples.clamp(0, MAX_GRAPH_SAMPLES);
     with_engine(|engine| {
         let Ok(ast) = engine.compile_expression(expression) else {
             return Vec::new();
@@ -619,32 +614,22 @@ mod tests {
         assert_eq!(evaluate_range("time", None, 0.0, 4.0, 4).len(), 4);
     }
 
+    /// **One expression cannot build something enormous.**
+    ///
+    /// Loops do not parse in an expression, so the danger is never a long run.
+    /// It is one call that allocates: `blob(50_000_000)` and padding an array to
+    /// five million items both went through untouched before the ceilings, on
+    /// every property read. A refusal comes back as `-1` like any other.
     #[test]
-    fn expression_work_and_graph_sampling_are_bounded() {
-        let engine = make_engine();
-        assert_eq!(engine.max_operations(), MAX_EXPRESSION_OPERATIONS);
-        assert_eq!(engine.max_string_size(), MAX_EXPRESSION_STRING_BYTES);
-        assert_eq!(engine.max_array_size(), MAX_EXPRESSION_ARRAY_ITEMS + 1);
-        assert_eq!(engine.max_map_size(), MAX_EXPRESSION_MAP_ITEMS);
-
+    fn an_expression_cannot_build_something_enormous() {
         assert_eq!(evaluate("1 + 2 * 3", None), 7.0);
         assert_eq!(evaluate("if 2 > 1 { 9 } else { 0 }", None), 9.0);
-        assert_eq!(evaluate_text("\"frame \" + 7", None), "frame 7");
         assert_eq!(evaluate("[1, 2].len()", None), 2.0);
-        assert_eq!(evaluate_range("time", None, 0.0, 1.0, 16).len(), 16);
+        assert_eq!(evaluate_text("\"frame \" + 7", None), "frame 7");
 
-        assert_eq!(
-            evaluate_range("time", None, 0.0, 1.0, MAX_GRAPH_SAMPLES + 1).len(),
-            MAX_GRAPH_SAMPLES as usize
-        );
-        assert_eq!(
-            evaluate_range("time", None, 0.0, 1.0, MAX_GRAPH_SAMPLES).len(),
-            MAX_GRAPH_SAMPLES as usize
-        );
-        assert_eq!(
-            evaluate_range("time", None, 0.0, 1.0, 1_000_000).len(),
-            MAX_GRAPH_SAMPLES as usize
-        );
+        assert_eq!(evaluate("blob(50_000_000).len()", None), -1.0);
+        assert_eq!(evaluate("[0].pad(5_000_000, 0).len()", None), -1.0);
+        assert_eq!(evaluate("\"x\".pad(5_000_000, 'y').len()", None), -1.0);
 
         let string = |len| format!("\"{}\".len()", "x".repeat(len));
         assert_eq!(
@@ -656,12 +641,14 @@ mod tests {
             -1.0
         );
 
+        // Rhai's array literal refuses *at* the ceiling rather than above it,
+        // one item stricter than the same array built by `pad`.
         let array = |len| format!("[{}].len()", vec!["0"; len].join(","));
         assert_eq!(
-            evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS), None),
-            MAX_EXPRESSION_ARRAY_ITEMS as f64
+            evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS - 1), None),
+            (MAX_EXPRESSION_ARRAY_ITEMS - 1) as f64
         );
-        assert_eq!(evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS + 1), None), -1.0);
+        assert_eq!(evaluate(&array(MAX_EXPRESSION_ARRAY_ITEMS), None), -1.0);
 
         let map = |len| {
             format!(
@@ -678,16 +665,12 @@ mod tests {
         );
         assert_eq!(evaluate(&map(MAX_EXPRESSION_MAP_ITEMS + 1), None), -1.0);
 
-        assert_eq!(evaluate("1 + 1", None), 2.0);
-        assert_eq!(
-            evaluate(&string(MAX_EXPRESSION_STRING_BYTES + 1), None),
-            -1.0
-        );
-        assert!(evaluate_value(&string(MAX_EXPRESSION_STRING_BYTES + 1), None).is_err());
-        assert_eq!(evaluate("1 + 1", None), 2.0);
-
-        for _ in 0..10_000 {
-            assert_eq!(evaluate("time + 1", Some(at(2.0))), 3.0);
+        // An engine that refused one expression still answers the next, and the
+        // operation count resets per evaluation. Thirty of these cost more than
+        // one budget between them, so a count that carried over would refuse.
+        let heavy = array(5_000);
+        for _ in 0..30 {
+            assert_eq!(evaluate(&heavy, None), 5_000.0);
         }
     }
 

--- a/docs/12-PLUGINS.md
+++ b/docs/12-PLUGINS.md
@@ -405,6 +405,12 @@ and twice over, since the frame-cache key resolves them too.
   rather than one shared engine because expressions nest. The reasoning, and the three
   properties of it that are load-bearing, are in [impl/expressions.md](impl/expressions.md)
   §3.
+- **Work and allocation are capped, elapsed time is not.** One evaluation gets 100,000 Rhai
+  operations, 1 MiB of string, and 16,384 items of array or map. Loops do not parse in an
+  expression, so the runaway case is a single allocating call, and `blob(50_000_000)` or an
+  array padded to five million items both ran untouched before the caps went in. The
+  ceilings sit far above any real property expression, and one that trips a ceiling refuses
+  the way any other failure does.
 - Expression results participate in content hashing, so a property whose expression inputs
   are unchanged hashes identically and frames above it stay cached
   ([05-ARCHITECTURE.md](05-ARCHITECTURE.md) §4.2). A frame-varying expression keys per
@@ -412,8 +418,8 @@ and twice over, since the frame-cache key resolves them too.
 
 Specified but **not built**, each a real gap rather than a nicety:
 
-- **No evaluation budget.** A runaway expression is not interrupted, so it can stall a
-  render thread. The requirement stands: an evaluation MUST be stoppable, the property MUST
+- **No evaluation time budget.** A slow expression is not interrupted, so it can stall a
+  render thread. Capping the work does not cover this. The requirement stands: an evaluation MUST be stoppable, the property MUST
   hold its last good value, and an export MUST complete with the expression disabled and
   say so in the log — never a frozen UI, never a killed export. Rhai offers
   `Engine::on_progress` for exactly this; wiring it to the epoch token

--- a/docs/impl/expressions.md
+++ b/docs/impl/expressions.md
@@ -143,6 +143,13 @@ interrupted, so a pathological one can stall a render thread. Rhai supports this
 `Engine::on_progress`; wiring it to the epoch token
 ([playback-scheduler.md](playback-scheduler.md)) is the known gap.
 
+What *is* bounded is the work, not the clock. `make_engine` caps one evaluation at 100,000
+Rhai operations, 1 MiB of string, and 16,384 items of array or map
+(`an_expression_cannot_build_something_enormous`). Loops do not parse in an expression, so
+the case these catch is a single allocating call: `blob(50_000_000)` and
+`[0].pad(5_000_000, 0)` both ran to completion before the caps, on every property read.
+Rhai's array literal refuses *at* the ceiling while `pad` refuses above it, one item apart.
+
 ## 6. Where an expression is read from
 
 - **Numeric properties** — `Property::value_at_with_context`, in `anim.rs`. The plain
@@ -178,12 +185,16 @@ Implemented in `expression.rs`'s test module unless noted.
    the number asked for (`an_uncompilable_expression_samples_to_nothing`).
 7. **Text** — printing, clearing, the typed words surviving underneath, and the field being
    optional on disk.
+8. **Resource ceilings** — one expression cannot allocate without bound, and a pooled
+   engine's operation count resets per evaluation
+   (`an_expression_cannot_build_something_enormous`).
 
 ## 8. Known gaps
 
 Named so they are not rediscovered as bugs:
 
-- **No evaluation budget** (§5) — the one with real teeth.
+- **No evaluation time budget** (§5), the one with real teeth. The work one evaluation
+  may do is capped, the time it may take is not.
 - **No AST cache** (§3) — cheap to add, no longer the bottleneck.
 - **`-1.0` is the failure value** for numeric expressions, so a broken expression becomes a
   plausible-looking coordinate. Text got this right by printing nothing. Surfacing the error


### PR DESCRIPTION
Adds explicit resource limits around Rhai expression evaluation and bounds graph
sampling work.

The current expression engine allows very large strings, arrays, maps, and graph
sample requests to be evaluated without application-level limits. Expressions
stored in `.lum` projects are evaluated during normal property/render reads, so
large values can cause unnecessary CPU and memory pressure.

This change adds conservative limits for:

- Rhai operations per evaluation
- string size
- retained array items
- retained map items
- graph sampling count

The limits are intentionally set well above normal property-expression usage.