### PR TITLE
Let Volume keyframes be deleted and edited in graph view

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -467,8 +467,6 @@ imported theme travels with the user rather than the machine's settings.
     wants a *smooth* follow and a setting to choose between them. `Shift+=` (zoom
     to the work area) is unbound for the same reason: neither was in TI-9's own
     sentence list.
-- **Volume keyframes draw no lane diamonds and no graph curve** - volume is not
-    in the comp read model; fold it into `BridgeLayerInfo` if either matters.
 
 **Render-time indicator follow-ups (the column landed).** What ships measures by
 *fencing* — the render waits for the card at each layer and each effect before reading

--- a/flutter_ui/lib/l10n/app_en.arb
+++ b/flutter_ui/lib/l10n/app_en.arb
@@ -7441,6 +7441,11 @@
     "description": "The unit rider beside an effect parameter's value when the number is a length of time in seconds. Abbreviated because it sits in a narrow column beside the number.",
     "type": "text"
   },
+  "unitSymbolDb": "dB",
+  "@unitSymbolDb": {
+    "description": "The unit rider beside a Volume value in the graph editor, decibels. Abbreviated because it sits in a narrow column beside the number.",
+    "type": "text"
+  },
   "unsavedChanges": "Unsaved changes",
   "@unsavedChanges": {
     "description": "Bottom strip: the project has edits that are not written to disk."

--- a/flutter_ui/lib/panels/graph_channels.dart
+++ b/flutter_ui/lib/panels/graph_channels.dart
@@ -106,6 +106,10 @@ class GraphChannel {
   /// property nor an effect parameter but reads and writes like both.
   final bool retime;
 
+  /// True for the layer's Volume channel, in dB, written back through
+  /// `setVolumeDb` the way the Retime goes through its own setter.
+  final bool volume;
+
   /// Set for one of a mask's values: the mask it belongs to, and which
   /// of its values this is.
   final BridgeMask? mask;
@@ -139,6 +143,7 @@ class GraphChannel {
     this.effect,
     this.param,
     this.retime = false,
+    this.volume = false,
     this.mask,
     this.maskValue,
     this.maskVertex = -1,
@@ -202,8 +207,8 @@ class GraphChannel {
 /// entirely from the read model, so building them costs no bridge calls.
 ///
 /// A transform row yields one channel per axis (Position → x and y, the AE
-/// red/green pair); a float effect parameter yields one. Volume is not in the
-/// read model (one of its deliberate exceptions) and is skipped — docs/TODO.md.
+/// red/green pair); a float effect parameter yields one, and so does the
+/// Volume row, off the same `volumeDb` the rubber band draws.
 List<GraphChannel> graphChannels({
   required List<BridgeLayerEntry> layers,
   required List<String> selected,
@@ -236,6 +241,22 @@ List<GraphChannel> graphChannels({
           retime: true,
         ));
       }
+      continue;
+    }
+
+    // Volume: one channel in dB. The lane's diamonds, the rubber band and
+    // this curve are three views of `volumeDb`, so a key deleted or eased
+    // here is gone from all of them.
+    if (path == '${audioPath(layerId)}/volume') {
+      out.add(GraphChannel(
+        path: path,
+        id: path,
+        label: '${entry.info.name} · ${l10n.volume}',
+        colourIndex: out.length,
+        scalar: entry.info.volumeDb,
+        entry: entry,
+        volume: true,
+      ));
       continue;
     }
 
@@ -424,6 +445,7 @@ String graphNumberText(double v) =>
 String? graphChannelUnit(GraphChannel channel) {
   if (channel.param case final param?) return unitRiderText(param.unit);
   if (channel.retime) return l10n.unitSymbolSeconds;
+  if (channel.volume) return l10n.unitSymbolDb;
   if (channel.maskValue case final value?) {
     return switch (value) {
       MaskValue.opacity => l10n.unitSymbolPercent,

--- a/flutter_ui/lib/panels/graph_edits.dart
+++ b/flutter_ui/lib/panels/graph_edits.dart
@@ -86,6 +86,8 @@ void commitChannelEdits(Map<GraphChannel, BridgeScalar> edits) {
       // One Retime per layer, so there is nothing to batch: the write is
       // already one op and therefore one undo step.
       channel.entry.layer.setRetimeProperty(value: next);
+    } else if (channel.volume) {
+      channel.entry.layer.setVolumeDb(value: next);
     } else if (channel.effect != null && channel.param != null) {
       final slot = effects[layerId] ??= (channel.entry.layer, {});
       (slot.$2[channel.effect!.id.toString()] ??= {})[channel.param!.id] = next;

--- a/flutter_ui/test/graph_channels_test.dart
+++ b/flutter_ui/test/graph_channels_test.dart
@@ -1,0 +1,127 @@
+// Which curve a selected property row resolves to on the graph. The Volume
+// row used to resolve to nothing: its keys drew as lane diamonds and on the
+// rubber band, but the graph had no channel for them, so Delete, the eases
+// and the block tools all fell through with the keys still there. Pure, so it
+// is checked against a stub entry rather than the engine.
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lumit_flutter/panels/graph_channels.dart';
+import 'package:lumit_flutter/panels/layer_fold_frb.dart';
+import 'package:lumit_flutter/src/rust/api/composition.dart';
+import 'package:lumit_flutter/src/rust/api/effect.dart';
+import 'package:lumit_flutter/src/rust/api/layer.dart';
+import 'package:uuid/uuid.dart';
+
+BridgeKeyframe key(int seconds, double value) => BridgeKeyframe(
+      time: BridgeRational(num: seconds, den: 1),
+      value: value,
+      interpIn: const BridgeSideInterp.linear(),
+      interpOut: const BridgeSideInterp.linear(),
+    );
+
+/// A layer entry with only the fields the channel builder reads filled in.
+BridgeLayerEntry entry({required BridgeScalar volumeDb}) {
+  final id = UuidValue.fromString(const Uuid().v4());
+  return BridgeLayerEntry(
+    layer: LayerReference(
+      internalprojectId: id,
+      internalcompId: id,
+      internallayerId: id,
+    ),
+    info: BridgeLayerInfo(
+      volumeDb: volumeDb,
+      pan: const BridgeScalar.static_(0),
+      wired: false,
+      textAnimators: const [],
+      name: 'Music',
+      kind: BridgeLayerKind.audio,
+      switches: const BridgeLayerSwitches(
+        visible: true,
+        audible: true,
+        locked: false,
+        solo: false,
+        threeD: false,
+        fx: true,
+        motionBlur: false,
+        collapse: false,
+        shy: false,
+        acceptsLights: true,
+      ),
+      blend: 0,
+      span: const BridgeSpan(
+        inPoint: BridgeRational(num: 0, den: 1),
+        outPoint: BridgeRational(num: 1, den: 1),
+        startOffset: BridgeRational(num: 0, den: 1),
+      ),
+      inFrame: 0,
+      outFrame: 10,
+      clipFrames: Int64List(0),
+      clips: const [],
+      transform: BridgeTransform(
+        anchorX: const BridgeScalar.static_(0),
+        anchorY: const BridgeScalar.static_(0),
+        positionX: const BridgeScalar.static_(0),
+        positionY: const BridgeScalar.static_(0),
+        positionZ: const BridgeScalar.static_(0),
+        scaleX: const BridgeScalar.static_(100),
+        scaleY: const BridgeScalar.static_(100),
+        rotation: const BridgeScalar.static_(0),
+        rotationX: const BridgeScalar.static_(0),
+        rotationY: const BridgeScalar.static_(0),
+        opacity: const BridgeScalar.static_(100),
+      ),
+      axisModes: const BridgeAxisModes(
+        anchor: BridgeAxisMode.combined,
+        position: BridgeAxisMode.combined,
+        scale: BridgeAxisMode.linked,
+      ),
+      effects: const [],
+      styles: const [],
+      label: 0,
+      masks: const [],
+      paint: const [],
+      shapeContents: const [],
+      markers: const [],
+      flow: false,
+      flowInputRate: const BridgeScalar.static_(0),
+      trackCorrected: false,
+    ),
+  );
+}
+
+void main() {
+  group('the Volume row resolves to a graph channel', () {
+    final keyed = BridgeScalar.keyframed([key(0, 0), key(2, -12)]);
+    final music = entry(volumeDb: keyed);
+    final id = music.layer.internallayerId.toString();
+    final path = '${audioPath(id)}/volume';
+
+    test('carrying the same keys the lane diamonds draw', () {
+      final channels = graphChannels(layers: [music], selected: [path]);
+      expect(channels, hasLength(1));
+      final channel = channels.single;
+      expect(channel.volume, isTrue);
+      expect(channel.path, path);
+      expect(channel.scalar, keyed);
+      expect([for (final k in channel.keys) k.value], [0.0, -12.0]);
+    });
+
+    test('in decibels', () {
+      final channel = graphChannels(layers: [music], selected: [path]).single;
+      expect(graphChannelUnit(channel), 'dB');
+    });
+
+    test('a static Volume is a channel too, as a static transform is', () {
+      final still = entry(volumeDb: const BridgeScalar.static_(-6));
+      final channels = graphChannels(
+        layers: [still],
+        selected: [
+          '${audioPath(still.layer.internallayerId.toString())}/volume'
+        ],
+      );
+      expect(channels.single.isStatic, isTrue);
+      expect(channels.single.staticValue, -6);
+    });
+  });
+}


### PR DESCRIPTION
Volume keyframes could not be deleted. They drew on the lane and on the rubber band, but the graph had no curve for them, so selecting them and pressing Delete did nothing, and the eases and the block tools fell through the same way.

The Volume row now resolves to a graph channel in dB and writes back through the same setter the band uses, so a key deleted in either view is gone from both.

To test, put a couple of Volume keys on an audio layer, switch to graph view, select them and press Delete. They should go, and undo should bring them back in one step. The eases and the block tools should work on them now as well.

New strings for the translation page: unitSymbolDb.
