### PR TITLE
Fix 8K memory use and blank oversized footage

### DIFF
--- a/crates/lumit-bridge/src/media.rs
+++ b/crates/lumit-bridge/src/media.rs
@@ -71,10 +71,15 @@ impl MediaCache {
 /// helper ([`lumit_render::media_index`]), the same one the probe and the Viewer's
 /// decode use, then a decoder is opened for this one call — synchronous, and not
 /// yet pooled across calls (a later phase caches decoders per item).
+///
+/// `target_width` is handed to the decoder, which scales on the way out and
+/// keeps the aspect; it never upscales, so a width larger than the file's own
+/// decodes at the file's own size. `None` asks for the native width.
 #[cfg(feature = "media")]
 pub(crate) fn decode_frame(
     src: &lumit_media::MediaSource,
     frame: u64,
+    target_width: Option<u32>,
 ) -> Option<lumit_media::DecodedFrame> {
     if !src.on_disk().is_file() {
         return None;
@@ -86,7 +91,7 @@ pub(crate) fn decode_frame(
         return None;
     }
     let n = (frame as usize).min(count - 1);
-    decoder.frame_rgba(n, None).ok()
+    decoder.frame_rgba(n, target_width).ok()
 }
 
 /// A thumbnail already decoded, if there is one. Read-only, so a caller can
@@ -118,7 +123,10 @@ pub(crate) fn thumb_decode(
     frame: i64,
 ) -> Option<Thumb> {
     let max_edge = max_edge.clamp(1, 4096);
-    let decoded = decode_frame(src, frame.max(0).unsigned_abs())?;
+    // Ask the decoder for the small picture rather than the whole one: an 8K
+    // frame never lands in memory at full size. Portrait media comes back
+    // taller than `max_edge`, which the box filter below still trims.
+    let decoded = decode_frame(src, frame.max(0).unsigned_abs(), Some(max_edge))?;
     Some(downscale_to_max_edge(
         decoded.width,
         decoded.height,
@@ -193,4 +201,34 @@ fn downscale_to_max_edge(sw: u32, sh: u32, src: &[u8], max_edge: u32) -> (u32, u
         }
     }
     (dw, dh, out)
+}
+
+#[cfg(all(test, feature = "media"))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// A thumbnail is decoded at thumbnail size, not decoded whole and shrunk
+    /// afterwards, and it still comes back the size it always was. Needs an
+    /// ffmpeg on PATH to make the fixture; skips itself without one.
+    #[test]
+    fn a_thumbnail_is_decoded_small() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let Some(clip) = lumit_media::index::tests_support::fixture(dir.path()) else {
+            return; // no ffmpeg on this machine
+        };
+        let src = lumit_media::MediaSource::file(clip);
+
+        // The fixture is 320x240, so 64 across the long edge is 64x48.
+        let decoded = decode_frame(&src, 0, Some(64)).expect("the fixture decodes");
+        assert_eq!(
+            (decoded.width, decoded.height),
+            (64, 48),
+            "the decoder shrinks on the way out, so no full-size frame is made"
+        );
+
+        let (w, h, rgba) = thumb_decode(&src, 64, 0).expect("a thumbnail");
+        assert_eq!((w, h), (64, 48), "the thumbnail is the size it always was");
+        assert_eq!(rgba.len(), 64 * 48 * 4);
+    }
 }

--- a/crates/lumit-core/src/model.rs
+++ b/crates/lumit-core/src/model.rs
@@ -2721,6 +2721,10 @@ impl ColourDepth {
     }
 }
 
+/// The most texels a composition's multisample attachment may hold: a 4K
+/// frame at 8× ([`AntiAliasing::samples_for`]).
+pub const SAMPLE_BUDGET: u64 = 3840 * 2160 * 8;
+
 impl AntiAliasing {
     /// The sample count to hand the renderer.
     #[must_use]
@@ -2731,6 +2735,33 @@ impl AntiAliasing {
             Self::X4 => 4,
             Self::X8 => 8,
         }
+    }
+
+    /// The count a `width × height` composition may actually use: the
+    /// setting's own while its multisample attachment stays within
+    /// [`SAMPLE_BUDGET`], the largest count that does otherwise, and 1 where
+    /// none does. The attachment is `width × height × samples` texels of
+    /// the working format, and it is the one allocation in a frame that
+    /// grows with both the picture and the setting: 2.1 GB at 8K and 8×, four
+    /// times the rest of the frame put together, and every nested comp and
+    /// motion-blur sample allocates another.
+    ///
+    /// A rule about the comp's own size, never the preview scale, so a comp
+    /// gets the same count at every zoom and on export
+    /// (docs/impl/anti-aliasing.md §4). The frame name reads this rather
+    /// than [`Self::samples`], so a frame banked at one count is never served
+    /// for another.
+    #[must_use]
+    pub fn samples_for(self, width: u32, height: u32) -> u32 {
+        let requested = self.samples();
+        let pixels = u64::from(width) * u64::from(height);
+        if requested <= 1 || pixels == 0 {
+            return requested;
+        }
+        [8u32, 4, 2]
+            .into_iter()
+            .find(|&n| n <= requested && pixels * u64::from(n) <= SAMPLE_BUDGET)
+            .unwrap_or(1)
     }
 
     /// The setting a sample count corresponds to; anything not one of the four
@@ -4473,5 +4504,22 @@ mod tests {
         let unified = group.unified_axes(TransformPair::Scale);
         assert!(unified.is_empty(), "nothing to merge onto a constant");
         assert!(!group.scale_y.is_animated());
+    }
+
+    /// The anti-aliasing budget bites only above 4K, and only as far as it
+    /// must: 4K keeps 8×, 8K gets 2× (its attachment then costs what 4K's
+    /// does), and a setting that asked for less is never raised.
+    #[test]
+    fn anti_aliasing_steps_down_where_the_attachment_would_not_fit() {
+        use super::AntiAliasing::{Off, X2, X4, X8};
+        assert_eq!(X8.samples_for(1920, 1080), 8);
+        assert_eq!(X8.samples_for(3840, 2160), 8, "4K is the budget itself");
+        assert_eq!(X8.samples_for(5120, 2880), 4, "5K halves");
+        assert_eq!(X8.samples_for(7680, 4320), 2, "8K quarters");
+        assert_eq!(X4.samples_for(7680, 4320), 2, "a lower ask is capped too");
+        assert_eq!(X2.samples_for(7680, 4320), 2, "and kept where it fits");
+        assert_eq!(X8.samples_for(16384, 16384), 1, "nothing fits: off");
+        assert_eq!(Off.samples_for(7680, 4320), 1);
+        assert_eq!(X8.samples_for(0, 0), 8, "an empty comp is left alone");
     }
 }

--- a/crates/lumit-eval/src/lib.rs
+++ b/crates/lumit-eval/src/lib.rs
@@ -179,7 +179,11 @@ fn feed_comp(
     // comp, so it belongs in the name of every frame: without it a frame banked
     // before the setting moved would be handed back after it, and the picture
     // would silently disagree with the setting.
-    h.update(&doc.anti_aliasing.samples().to_le_bytes());
+    h.update(
+        &doc.anti_aliasing
+            .samples_for(comp.width, comp.height)
+            .to_le_bytes(),
+    );
     for c in comp.background.0 {
         h.update(&c.to_le_bytes());
     }

--- a/crates/lumit-gpu/src/fx/common.rs
+++ b/crates/lumit-gpu/src/fx/common.rs
@@ -3,22 +3,28 @@
 //! reading a working texture back to linear f32, and the fp16 conversions the
 //! oracle tests round-trip through.
 
+use half::slice::{HalfBitsSliceExt, HalfFloatSliceExt};
+
 use crate::{GpuContext, GpuError};
 
-use super::work_texture;
+use super::new_work_texture;
 
 /// Upload a linear f32 RGBA image as a working (fp16) texture — test and
 /// tooling support for effect kernels.
 pub fn upload_linear_f32(ctx: &GpuContext, rgba: &[f32], w: u32, h: u32) -> wgpu::Texture {
-    let halfs: Vec<u16> = rgba.iter().map(|v| f16_bits(*v)).collect();
-    upload_linear_f16(ctx, &halfs, w, h)
+    // The whole plane in one call. `half` narrows eight values an instruction
+    // where the card's host has F16C, and rounds to nearest even either way, so
+    // the bits are the ones the per-value loop gave. At 8K the loop was 294 ms.
+    let mut halfs = vec![half::f16::ZERO; rgba.len()];
+    halfs.convert_from_f32_slice(rgba);
+    upload_linear_f16(ctx, halfs.reinterpret_cast(), w, h)
 }
 
 /// The same upload, for a caller that already holds the fp16 bits — one that
 /// can produce them without an f32 plane in between. `halfs` is RGBA, four
 /// per pixel.
 pub fn upload_linear_f16(ctx: &GpuContext, halfs: &[u16], w: u32, h: u32) -> wgpu::Texture {
-    let tex = work_texture(ctx, w, h, "fx-upload");
+    let tex = new_work_texture(ctx, w, h, "fx-upload");
     ctx.queue.write_texture(
         wgpu::TexelCopyTextureInfo {
             texture: &tex,
@@ -268,12 +274,21 @@ pub fn readback_linear_f32(
         .map_err(|e| GpuError::Readback(e.to_string()))?
         .map_err(|e| GpuError::Readback(e.to_string()))?;
     let data = slice.get_mapped_range();
-    let mut out = Vec::with_capacity((w * h * 4) as usize);
-    for y in 0..h {
-        let row = &data[(y * padded) as usize..(y * padded + row_bytes) as usize];
-        for c in row.chunks_exact(2) {
-            out.push(f16_to_f32(u16::from_le_bytes([c[0], c[1]])));
-        }
+    // A row at a time, straight out of the mapped bytes: same widening, eight
+    // values an instruction where the host has F16C. The chunk is the padded
+    // row and the slice is the real one, so the padding is skipped rather than
+    // converted. At 8K the per-value loop was 237 ms.
+    let bits: &[u16] =
+        bytemuck::try_cast_slice(&data).map_err(|e| GpuError::Readback(e.to_string()))?;
+    let halfs: &[half::f16] = bits.reinterpret_cast();
+    let mut out = vec![0f32; (w * h * 4) as usize];
+    for (row, dst) in halfs
+        .chunks_exact((padded / 2) as usize)
+        .zip(out.chunks_mut(row_bytes as usize / 2))
+    {
+        row.get(..dst.len())
+            .ok_or_else(|| GpuError::Readback("short readback row".into()))?
+            .convert_to_f32_slice(dst);
     }
     Ok(out)
 }
@@ -286,4 +301,41 @@ pub fn f16_bits(v: f32) -> u16 {
 /// IEEE 754 half bits → f32.
 pub fn f16_to_f32(bits: u16) -> f32 {
     half::f16::from_bits(bits).to_f32()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    /// Upload a plane of the awkward values and read it straight back: the
+    /// largest half, both zeroes, a float too small to be a half at all, and
+    /// negatives of each. Every channel returns the bits the per-value
+    /// narrowing gives, and a width whose row is 264 bytes, not a multiple of
+    /// 256, says the padding at the end of a row is skipped and not read as
+    /// picture.
+    #[test]
+    fn a_padded_row_round_trips_to_the_same_bits() {
+        let Some(ctx) = crate::test_support::lease() else {
+            crate::no_adapter();
+            return;
+        };
+        let (w, h) = (33u32, 5u32);
+        let awkward = [
+            65504.0f32, -65504.0, 0.0, -0.0, 1e-8, -1e-8, 1.0, -1.0, 6.1e-5, 0.333, -0.333, 1024.5,
+        ];
+        let src: Vec<f32> = (0..(w * h * 4) as usize)
+            .map(|i| awkward[i % awkward.len()])
+            .collect();
+        let tex = upload_linear_f32(&ctx, &src, w, h);
+        let out = readback_linear_f32(&ctx, &tex, w, h).unwrap();
+        assert_eq!(out.len(), src.len());
+        for (i, (got, want)) in out.iter().zip(&src).enumerate() {
+            assert_eq!(
+                got.to_bits(),
+                f16_to_f32(f16_bits(*want)).to_bits(),
+                "channel {i}: {want}"
+            );
+        }
+    }
 }

--- a/crates/lumit-gpu/src/fx/mod.rs
+++ b/crates/lumit-gpu/src/fx/mod.rs
@@ -638,7 +638,34 @@ pub fn fit_centred(ctx: &GpuContext, tex: wgpu::Texture, nw: u32, nh: u32) -> wg
     out
 }
 
+/// A pass's output texture: one an earlier pass in this frame has finished
+/// with, or a new one.
+///
+/// The reuse is what keeps a stack of effects from holding one frame-sized
+/// texture per effect for the whole frame (`GpuContext::pool`). A texture only
+/// comes back if it matches in size and format, and it arrives cleared, so the
+/// caller cannot tell which it got.
 fn work_texture(ctx: &GpuContext, w: u32, h: u32, label: &str) -> wgpu::Texture {
+    let format = ctx.working();
+    let mut pool = ctx.pool.borrow_mut();
+    if let Some(i) = pool
+        .iter()
+        .position(|t| t.width() == w && t.height() == h && t.format() == format)
+    {
+        return pool.swap_remove(i);
+    }
+    drop(pool);
+    new_work_texture(ctx, w, h, label)
+}
+
+/// A work texture of its own, never one from the pool.
+///
+/// One caller, and it is a rule rather than a preference: `queue.write_texture`
+/// is staged and runs at the head of the next submission, not where it was
+/// asked for. A recycled texture is only safe because the commands that read it
+/// were recorded first, and a queue write would jump every one of them.
+fn new_work_texture(ctx: &GpuContext, w: u32, h: u32, label: &str) -> wgpu::Texture {
+    ctx.work_made.set(ctx.work_made.get().saturating_add(1));
     ctx.device.create_texture(&wgpu::TextureDescriptor {
         label: Some(label),
         size: wgpu::Extent3d {
@@ -650,11 +677,7 @@ fn work_texture(ctx: &GpuContext, w: u32, h: u32, label: &str) -> wgpu::Texture 
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format: ctx.working(),
-        usage: wgpu::TextureUsages::TEXTURE_BINDING
-            | wgpu::TextureUsages::STORAGE_BINDING
-            | wgpu::TextureUsages::COPY_SRC
-            | wgpu::TextureUsages::COPY_DST
-            | wgpu::TextureUsages::RENDER_ATTACHMENT,
+        usage: crate::WORK_USAGE,
         view_formats: &[],
     })
 }

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -15714,3 +15714,81 @@ fn a_readback_inside_a_batch_waits_for_what_is_still_batched() {
         read.len()
     );
 }
+
+/// The frame's work-texture pool: a pass gets the texture an earlier pass in
+/// the same frame was done with, as long as the shape matches, and the pool
+/// ends with the frame.
+///
+/// This is the whole of the memory claim. Without it a stack of effects holds
+/// one frame-sized texture per effect for the length of the frame, which on an
+/// 8K layer is a quarter of a gigabyte apiece.
+#[test]
+fn a_frame_hands_a_finished_work_texture_to_the_pass_after_it() {
+    let Some(ctx) = crate::test_support::lease() else {
+        crate::no_adapter();
+        return;
+    };
+    let made_before = ctx.work_textures_made();
+    ctx.begin_frame();
+
+    let a = work_texture(&ctx, 64, 36, "pool-a");
+    let b = work_texture(&ctx, 64, 36, "pool-b");
+    assert_ne!(a, b, "two textures in hand at once are two textures");
+
+    ctx.recycle(a.clone());
+    assert_eq!(
+        work_texture(&ctx, 64, 36, "pool-again"),
+        a,
+        "the pass after it writes into the one just given back"
+    );
+
+    // A different size asks for its own.
+    ctx.recycle(a.clone());
+    let wider = work_texture(&ctx, 128, 36, "pool-wider");
+    assert_ne!(wider, a, "a wider pass cannot be given a narrower texture");
+    assert_eq!(
+        work_texture(&ctx, 64, 36, "pool-back"),
+        a,
+        "and the one it would not take is still there for the pass that fits"
+    );
+
+    // So does a different format.
+    let other = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("pool-eight-bit"),
+        size: wgpu::Extent3d {
+            width: 64,
+            height: 36,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: crate::WORK_USAGE,
+        view_formats: &[],
+    });
+    ctx.recycle(other.clone());
+    assert_ne!(
+        work_texture(&ctx, 64, 36, "pool-after"),
+        other,
+        "a pass working in one depth is never given another's texture"
+    );
+
+    assert_eq!(
+        ctx.work_textures_made() - made_before,
+        4,
+        "four shapes were asked for, so four textures were made"
+    );
+
+    ctx.end_frame();
+
+    // Outside a batch nothing orders the passes, so nothing is kept: the pool
+    // is only safe inside the one command buffer that puts its writes in order.
+    let solo = work_texture(&ctx, 64, 36, "pool-solo");
+    ctx.recycle(solo.clone());
+    assert_ne!(
+        work_texture(&ctx, 64, 36, "pool-solo-again"),
+        solo,
+        "a texture given back outside a frame is not handed out again"
+    );
+}

--- a/crates/lumit-gpu/src/lib.rs
+++ b/crates/lumit-gpu/src/lib.rs
@@ -87,6 +87,23 @@ pub struct GpuContext {
     /// sample — so the batch is closed by the *outermost* caller, not the first
     /// one to finish.
     frame_depth: std::cell::Cell<u32>,
+    /// Work textures an earlier pass in this frame has finished with, waiting
+    /// to be handed out again.
+    ///
+    /// A frame is one command buffer, so nothing a pass allocates comes back
+    /// until the frame ends: three effects on an 8K layer held six frame-sized
+    /// textures at once, about a gigabyte above the plain frame. The commands
+    /// on one queue run in the order they were recorded, so a pass may safely
+    /// write into a texture an earlier recorded pass read. [`Self::recycle`]
+    /// puts one here and `fx::work_texture` takes it back.
+    ///
+    /// A `RefCell` beside the frame batch and for the batch's own reason: a
+    /// context is used by one thread at a time. Emptied at the outermost
+    /// [`Self::end_frame`], so nothing outlives the frame that ordered it.
+    pool: std::cell::RefCell<Vec<wgpu::Texture>>,
+    /// How many work textures this context has created rather than taken from
+    /// the pool ([`Self::work_textures_made`]).
+    work_made: std::cell::Cell<u64>,
     /// How many command buffers **this context** has handed to the driver
     /// ([`Self::submits_so_far`]).
     ///
@@ -436,6 +453,8 @@ impl GpuContext {
             sample_flags: wgpu::TextureFormatFeatureFlags::empty(),
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),
+            pool: std::cell::RefCell::new(Vec::new()),
+            work_made: std::cell::Cell::new(0),
             submits: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             // No callback is installed on a device somebody else opened, so
             // this stays down: a context built this way does not know when its
@@ -501,6 +520,8 @@ impl GpuContext {
             sample_flags: self.sample_flags,
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),
+            pool: std::cell::RefCell::new(Vec::new()),
+            work_made: std::cell::Cell::new(0),
             submits: std::sync::Arc::clone(&self.submits),
             lost: std::sync::Arc::clone(&self.lost),
         }
@@ -650,13 +671,68 @@ impl GpuContext {
     }
 
     /// Close one [`Self::begin_frame`]. On the outermost one, submit whatever
-    /// the batch holds.
+    /// the batch holds and empty the work-texture pool.
     pub fn end_frame(&self) {
         let depth = self.frame_depth.get().saturating_sub(1);
         self.frame_depth.set(depth);
         if depth == 0 {
             self.flush();
+            // The pool is only safe because one command buffer orders it, so it
+            // ends with that command buffer. What is dropped here the driver
+            // hands back on the next `reclaim` (§7.0.2).
+            self.pool.borrow_mut().clear();
         }
+    }
+
+    /// Offer a work texture back to the frame's pool, for a later pass in the
+    /// same frame to write into (see [`Self::pool`]).
+    ///
+    /// The caller promises that nothing recorded from here on reads it. Outside
+    /// a frame batch this does nothing, which is what keeps the pool inside the
+    /// one command buffer whose order makes it safe.
+    ///
+    /// The texture is cleared on the way in, so no pass can tell a reused one
+    /// from a fresh one: wgpu zeroes a new texture before its first use, and an
+    /// effect that loads its target instead of overwriting it would otherwise
+    /// read the last picture.
+    pub fn recycle(&self, tex: wgpu::Texture) {
+        if self.frame_depth.get() == 0
+            || tex.usage() != WORK_USAGE
+            || tex.dimension() != wgpu::TextureDimension::D2
+            || tex.sample_count() != 1
+            || tex.mip_level_count() != 1
+            || tex.depth_or_array_layers() != 1
+        {
+            return;
+        }
+        let view = tex.create_view(&Default::default());
+        let mut enc = self.encoder("recycle");
+        let _ = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("work-texture-clear"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        drop(enc);
+        // ponytail: one flat list, scanned by shape. A frame holds a handful of
+        // spare textures, so the scan is shorter than a hash of the key would
+        // be; key it by (size, format) if a frame ever holds dozens.
+        self.pool.borrow_mut().push(tex);
+    }
+
+    /// How many work textures this context has created rather than taken from
+    /// the pool. The reuse gate reads it; nothing else does.
+    #[must_use]
+    pub fn work_textures_made(&self) -> u64 {
+        self.work_made.get()
     }
 
     /// Submit whatever the batch holds right now and leave it open.
@@ -857,6 +933,8 @@ impl GpuContext {
             sample_flags,
             frame: std::cell::RefCell::new(None),
             frame_depth: std::cell::Cell::new(0),
+            pool: std::cell::RefCell::new(Vec::new()),
+            work_made: std::cell::Cell::new(0),
             submits: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             lost,
         })
@@ -1054,6 +1132,14 @@ struct ViewParamsRaw {
 /// reason `ColourDepth::Sixteen` is: it is what the effect catalogue was
 /// written against.
 pub const WORKING_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Float;
+
+/// What every effect pass's output texture is made with. One set, so a
+/// texture handed back to [`GpuContext::pool`] fits whatever asks next.
+pub(crate) const WORK_USAGE: wgpu::TextureUsages = wgpu::TextureUsages::TEXTURE_BINDING
+    .union(wgpu::TextureUsages::STORAGE_BINDING)
+    .union(wgpu::TextureUsages::COPY_SRC)
+    .union(wgpu::TextureUsages::COPY_DST)
+    .union(wgpu::TextureUsages::RENDER_ATTACHMENT);
 
 /// The working format for a project colour depth in bits (8, 16 or 32).
 ///

--- a/crates/lumit-gpu/src/test_support.rs
+++ b/crates/lumit-gpu/src/test_support.rs
@@ -59,6 +59,8 @@ impl SharedGpu {
         // test starts on a closed one.
         self.ctx.frame.replace(None);
         self.ctx.frame_depth.set(0);
+        // The pool belongs to the frame that was open, and that frame is gone.
+        self.ctx.pool.borrow_mut().clear();
         self.fx.reset_for_tests();
     }
 }

--- a/crates/lumit-media/src/decode.rs
+++ b/crates/lumit-media/src/decode.rs
@@ -116,18 +116,44 @@ fn open_codec_ctx(
 ) -> Result<(AVCodecContext, bool), MediaError> {
     let mut ctx = AVCodecContext::new(codec);
     ctx.apply_codecpar(par)?;
-    // Library-default libav is SINGLE-threaded (unlike the ffmpeg CLI); 0 asks
-    // for automatic frame/slice threading across the machine's cores, which is
-    // the difference between one core grinding 4K H.264 and all of them.
+    // Library-default libav is SINGLE-threaded (unlike the ffmpeg CLI), so this
+    // asks for threads: 0 for one a core, fewer where a frame is big enough
+    // that a picture in flight per thread costs more than the speed is worth.
     // SAFETY: plain field write on the owned, not-yet-opened context — the
     // same pattern rsmpeg's own setters use.
     #[allow(unsafe_code)]
     unsafe {
-        ctx.deref_mut().thread_count = 0;
+        ctx.deref_mut().thread_count = thread_cap(par.width, par.height);
     }
     let hardware = try_hw && attach_d3d11va(codec, &mut ctx);
     ctx.open(None)?;
     Ok((ctx, hardware))
+}
+
+/// How many decode threads a frame this size may have, or 0 to leave it to
+/// libav (a thread a core, up to its own ceiling of sixteen).
+///
+/// Frame threading keeps a picture in flight per thread, and the hardware
+/// decoder's surface pool grows by one frame per thread with it. At 8K a frame
+/// is fifty megabytes, so sixteen threads cost about a gigabyte before the
+/// first picture comes back, and the graphics card is no quicker for them.
+/// Measured at 8K: sixty frames in 397 ms on sixteen threads, 391 ms on five,
+/// and a gigabyte of working set against six hundred megabytes. Bounding the
+/// pictures in flight at 256 MB leaves 1080p and 4K exactly as they were and
+/// gives 8K five threads.
+fn thread_cap(width: i32, height: i32) -> i32 {
+    const BUDGET: i64 = 256 * 1024 * 1024;
+    // NV12: the shape a hardware surface and an ordinary eight-bit software
+    // frame both arrive in, twelve bits a pixel.
+    let per_frame = i64::from(width.max(1)) * i64::from(height.max(1)) * 3 / 2;
+    let cap = BUDGET / per_frame.max(1);
+    // Sixteen is libav's own ceiling for automatic threading, so any cap at or
+    // above it is already what asking for 0 gets.
+    if cap >= 16 {
+        0
+    } else {
+        i32::try_from(cap.max(1)).unwrap_or(1)
+    }
 }
 
 /// Attach a D3D11VA hardware device to `ctx` when this codec supports
@@ -1029,5 +1055,152 @@ mod tests {
         ];
         let out = copy_tight_rows(&data, 6, 4, 2).unwrap();
         assert_eq!(out, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    // ---- thread_cap: pure arithmetic, no ffmpeg required ----------------
+
+    /// A frame whose pictures in flight fit the budget keeps a thread a core;
+    /// one big enough that sixteen of them would cost a gigabyte gets fewer.
+    /// Without the cap every one of these answers 0.
+    #[test]
+    fn a_big_frame_asks_for_fewer_decode_threads() {
+        assert_eq!(thread_cap(1920, 1080), 0, "1080p keeps a thread a core");
+        assert_eq!(thread_cap(3840, 2160), 0, "4K keeps a thread a core");
+        assert_eq!(thread_cap(7680, 4320), 5, "8K gets five");
+        assert_eq!(thread_cap(15360, 8640), 1, "16K gets one");
+        // A stream whose header never carried a size must still open.
+        assert_eq!(thread_cap(0, 0), 0);
+        assert_eq!(thread_cap(-1, -1), 0);
+    }
+
+    // ---- what a clip costs to decode (run by hand) ----------------------
+
+    /// The process working set, in bytes. Windows only; everywhere else this
+    /// reports nothing and the report below prints zeroes.
+    #[cfg(windows)]
+    fn working_set() -> u64 {
+        #[repr(C)]
+        #[derive(Default)]
+        struct Counters {
+            cb: u32,
+            page_faults: u32,
+            peak_working_set: usize,
+            working_set: usize,
+            peak_paged_pool: usize,
+            paged_pool: usize,
+            peak_nonpaged_pool: usize,
+            nonpaged_pool: usize,
+            pagefile: usize,
+            peak_pagefile: usize,
+        }
+        #[link(name = "kernel32")]
+        extern "system" {
+            fn K32GetProcessMemoryInfo(process: isize, out: *mut Counters, cb: u32) -> i32;
+        }
+        let mut c = Counters {
+            cb: u32::try_from(std::mem::size_of::<Counters>()).unwrap_or(0),
+            ..Counters::default()
+        };
+        // SAFETY: -1 is the pseudo-handle for this process, and the struct is
+        // the one the call expects with its own size written into `cb`.
+        #[allow(unsafe_code)]
+        unsafe {
+            K32GetProcessMemoryInfo(-1, &mut c, c.cb);
+        }
+        c.working_set as u64
+    }
+
+    #[cfg(not(windows))]
+    fn working_set() -> u64 {
+        0
+    }
+
+    fn mb(bytes: u64) -> f64 {
+        bytes as f64 / (1024.0 * 1024.0)
+    }
+
+    /// What one clip costs to decode, in memory and in time. Kept out of the
+    /// suite because it wants a big file and a quiet machine.
+    ///
+    /// Point it at a clip with `LUMIT_DECODE_MEM_CLIP`, or let it make a 1080p
+    /// one:
+    /// `cargo test -p lumit-media --release decode_working_set_report -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn decode_working_set_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let clip = match std::env::var("LUMIT_DECODE_MEM_CLIP") {
+            Ok(p) => std::path::PathBuf::from(p),
+            Err(_) => {
+                let Some(bin) = crate::index::tests_support::ffmpeg_bin() else {
+                    eprintln!("skipping: no ffmpeg CLI available");
+                    return;
+                };
+                let out = dir.path().join("clip_1080.mp4");
+                let ok = std::process::Command::new(bin)
+                    .args([
+                        "-v",
+                        "error",
+                        "-y",
+                        "-f",
+                        "lavfi",
+                        "-i",
+                        "testsrc2=duration=2:size=1920x1080:rate=30",
+                        "-c:v",
+                        "libx264",
+                        "-g",
+                        "30",
+                        "-pix_fmt",
+                        "yuv420p",
+                    ])
+                    .arg(&out)
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false);
+                assert!(ok, "fixture encode failed");
+                out
+            }
+        };
+
+        let index = build_frame_index(&clip).unwrap();
+        let base = working_set();
+        let mut dec = VideoDecoder::open(&clip, index).unwrap();
+        println!(
+            "clip {}, working set {:.0} MB before open, {:.0} MB after",
+            clip.display(),
+            mb(base),
+            mb(working_set())
+        );
+
+        let mut digest = String::new();
+        let whole = std::time::Instant::now();
+        for n in 0..12 {
+            let t = std::time::Instant::now();
+            let frame = dec.frame_rgba(n, None).unwrap();
+            let ms = t.elapsed().as_secs_f64() * 1000.0;
+            if n == 3 {
+                digest = frame_hash(&frame);
+            }
+            let (w, h) = (frame.width, frame.height);
+            drop(frame);
+            println!(
+                "  frame {n} {w}x{h} {ms:.1} ms, working set {:.0} MB",
+                mb(working_set())
+            );
+        }
+        // `pix_fmt` only tells the truth once a frame has been through: it is
+        // the format libav actually chose, where `is_hardware` is only what was
+        // asked for.
+        println!(
+            "  12 frames in {:.0} ms, pix_fmt {}, threads {}",
+            whole.elapsed().as_secs_f64() * 1000.0,
+            dec.decoder.pix_fmt,
+            dec.decoder.thread_count
+        );
+        drop(dec);
+        println!(
+            "closed, working set {:.0} MB; frame 3 digest {digest}",
+            mb(working_set())
+        );
     }
 }

--- a/crates/lumit-ofx/src/image.rs
+++ b/crates/lumit-ofx/src/image.rs
@@ -35,6 +35,7 @@
 //! could not have freed itself, and a leak is a number a test can read.
 
 use half::f16;
+use half::slice::HalfFloatSliceExt;
 use serde::{Deserialize, Serialize};
 
 use crate::status::Status;
@@ -149,11 +150,13 @@ impl Frame16 {
     ///
     /// As [`Frame16::from_pixels`].
     pub fn from_f32(width: usize, height: usize, pixels: &[f32]) -> Result<Self, Status> {
-        Self::from_pixels(
-            width,
-            height,
-            pixels.iter().copied().map(f16::from_f32).collect(),
-        )
+        // The whole plane in one call. `half` narrows eight values an
+        // instruction where the CPU has F16C, and rounds to nearest even
+        // either way, so the bits are the ones the per-value loop gave. At 8K
+        // the loop was 269 ms.
+        let mut narrowed = vec![f16::ZERO; pixels.len()];
+        narrowed.convert_from_f32_slice(pixels);
+        Self::from_pixels(width, height, narrowed)
     }
 
     #[must_use]
@@ -257,12 +260,14 @@ impl Image {
             let ofx_y = frame.height() - 1 - y;
             let source_start = y * frame.width() * CHANNELS;
             let row = image.row_mut(ofx_y).ok_or(Status::ErrFatal)?;
-            for (index, slot) in row.iter_mut().enumerate() {
-                *slot = frame
-                    .pixels()
-                    .get(source_start + index)
-                    .map_or(0.0, |value| value.to_f32());
-            }
+            // A row at a time, the same widening eight values an instruction.
+            // A frame always holds exactly its own pixels, so a short row is a
+            // broken invariant rather than an edge to pad.
+            frame
+                .pixels()
+                .get(source_start..source_start + row.len())
+                .ok_or(Status::ErrFatal)?
+                .convert_to_f32_slice(row);
         }
         Ok(image)
     }
@@ -275,11 +280,15 @@ impl Image {
     /// [`Status::ErrValue`] if the image is empty.
     pub fn to_frame(&self) -> Result<Frame16, Status> {
         let (width, height) = (self.bounds.width(), self.bounds.height());
-        let mut pixels = Vec::with_capacity(pixel_count(width, height)?);
+        let mut pixels = vec![f16::ZERO; pixel_count(width, height)?];
         for y in 0..height {
             let ofx_y = height - 1 - y;
             let row = self.row(ofx_y).ok_or(Status::ErrFatal)?;
-            pixels.extend(row.iter().copied().map(f16::from_f32));
+            let start = y * width * CHANNELS;
+            pixels
+                .get_mut(start..start + row.len())
+                .ok_or(Status::ErrFatal)?
+                .convert_from_f32_slice(row);
         }
         Frame16::from_pixels(width, height, pixels)
     }
@@ -434,6 +443,39 @@ mod tests {
             assert_eq!(bottom[1], 2.0, "{order:?}");
             let top = image.row(2).unwrap();
             assert_eq!(top[1], 0.0, "{order:?}");
+        }
+    }
+
+    /// The plane narrowing and the per-value narrowing are the same answer,
+    /// bit for bit, over a few thousand values that include the ends of the
+    /// half range and floats too small to be halves at all.
+    #[test]
+    fn narrowing_a_plane_matches_the_per_value_answer() {
+        let (width, height) = (64, 17);
+        let awkward = [
+            65504.0f32,
+            -65504.0,
+            0.0,
+            -0.0,
+            1e-8,
+            -1e-8,
+            6.1e-5,
+            1.0 / 3.0,
+        ];
+        let floats: Vec<f32> = (0..width * height * CHANNELS)
+            .map(|i| {
+                if i % 3 == 0 {
+                    awkward[i % awkward.len()]
+                } else {
+                    (i as f32).mul_add(0.001, -2.0)
+                }
+            })
+            .collect();
+        let frame = Frame16::from_f32(width, height, &floats).unwrap();
+        let scalar: Vec<f16> = floats.iter().copied().map(f16::from_f32).collect();
+        assert_eq!(frame.pixels().len(), scalar.len());
+        for (i, (got, want)) in frame.pixels().iter().zip(&scalar).enumerate() {
+            assert_eq!(got.to_bits(), want.to_bits(), "value {i}: {}", floats[i]);
         }
     }
 

--- a/crates/lumit-render/src/build.rs
+++ b/crates/lumit-render/src/build.rs
@@ -38,7 +38,7 @@ use uuid::Uuid;
 /// One layer's own picture: the bytes, the decoded size, the native source
 /// size, and how wide the bytes' samples are. Everything but a float footage
 /// source is `Srgb8`, which is what it has always been.
-pub type LayerPixels = (Vec<u8>, u32, u32, (f32, f32), lumit_media::PixelFormat);
+pub type LayerPixels = (Arc<Vec<u8>>, u32, u32, (f32, f32), lumit_media::PixelFormat);
 
 /// The map of already-decoded pixels a build reads, keyed by layer id.
 pub type PixelsByLayer<'a> = HashMap<Uuid, &'a CompLayerPixels>;
@@ -141,7 +141,7 @@ fn warp_puppet(
         lumit_media::PixelFormat::Srgb8 => lumit_core::puppet::apply_puppet,
     };
     warp(
-        pixels.0.as_mut_slice(),
+        Arc::make_mut(&mut pixels.0).as_mut_slice(),
         w,
         h,
         f64::from(natural.0),
@@ -997,7 +997,7 @@ pub fn build_comp_draws_at(
                     && !layer.styles.iter().any(|e| e.enabled);
                 let (tw, th) = if plain { (8, 8) } else { (sd.width, sd.height) };
                 (
-                    px_tile(&px, tw, th),
+                    Arc::new(px_tile(&px, tw, th)),
                     tw,
                     th,
                     (sd.width as f32, sd.height as f32),
@@ -1045,7 +1045,12 @@ pub fn build_comp_draws_at(
                         lumit_text::rasterise_line_animated(&line, size, document.fill, &xforms)
                     }
                 };
-                (r.rgba, r.width, r.height, (r.width as f32, r.height as f32))
+                (
+                    Arc::new(r.rgba),
+                    r.width,
+                    r.height,
+                    (r.width as f32, r.height as f32),
+                )
             }),
             // Vector art: rasterised at the size the frame is being drawn at,
             // into its own bounding box, which is also the layer's natural
@@ -1063,7 +1068,9 @@ pub fn build_comp_draws_at(
                     let w = natural_w.round().max(1.0) as u32;
                     let h = natural_h.round().max(1.0) as u32;
                     (
-                        lumit_core::shape::rasterise_contents(contents, w, h, x0, y0, x1, y1, lt),
+                        Arc::new(lumit_core::shape::rasterise_contents(
+                            contents, w, h, x0, y0, x1, y1, lt,
+                        )),
                         w,
                         h,
                         (natural_w as f32, natural_h as f32),
@@ -1084,43 +1091,51 @@ pub fn build_comp_draws_at(
             _ => lumit_media::PixelFormat::Srgb8,
         };
         raw.map(|(mut rgba, w, h, natural)| {
-            // Paint first, masks second: a stroke is part of the layer's
-            // picture, and a mask gates the picture (docs/06 render
-            // order). Painting after the mask would let a brush draw outside
-            // the shape the mask cut.
-            //
-            // Both stages come in a width to match the plate, so a float layer
-            // stays float through either of them.
-            let strokes = match format {
-                lumit_media::PixelFormat::LinearF32 => lumit_core::paint::apply_strokes_f32,
-                lumit_media::PixelFormat::Srgb8 => lumit_core::paint::apply_strokes,
-            };
-            strokes(
-                &mut rgba,
-                w,
-                h,
-                f64::from(natural.0),
-                f64::from(natural.1),
-                &layer.paint,
-                // The layer's own clock, as a mask's keys are read on:
-                // a stroke keyed to draw itself on travels with the layer.
-                lt,
-            );
-            // A mask only ever touches alpha, so both widths keep their colour
-            // exactly as it arrived — a masked OpenEXR is still an OpenEXR.
-            let gate = match format {
-                lumit_media::PixelFormat::LinearF32 => lumit_core::mask::apply_masks_f32,
-                lumit_media::PixelFormat::Srgb8 => lumit_core::mask::apply_masks,
-            };
-            gate(
-                &mut rgba,
-                w,
-                h,
-                f64::from(natural.0),
-                f64::from(natural.1),
-                &layer.masks,
-                lt,
-            );
+            // Nothing to stamp in is the ordinary layer, and it keeps the
+            // bytes it arrived with: both stages return on an empty list
+            // anyway, and asking for them by name is what lets a decoded frame
+            // travel to the draw shared rather than copied.
+            if !layer.paint.is_empty() || !layer.masks.is_empty() {
+                let rgba = Arc::make_mut(&mut rgba);
+                // Paint first, masks second: a stroke is part of the layer's
+                // picture, and a mask gates the picture (docs/06 render
+                // order). Painting after the mask would let a brush draw
+                // outside the shape the mask cut.
+                //
+                // Both stages come in a width to match the plate, so a float
+                // layer stays float through either of them.
+                let strokes = match format {
+                    lumit_media::PixelFormat::LinearF32 => lumit_core::paint::apply_strokes_f32,
+                    lumit_media::PixelFormat::Srgb8 => lumit_core::paint::apply_strokes,
+                };
+                strokes(
+                    rgba,
+                    w,
+                    h,
+                    f64::from(natural.0),
+                    f64::from(natural.1),
+                    &layer.paint,
+                    // The layer's own clock, as a mask's keys are read on:
+                    // a stroke keyed to draw itself on travels with the layer.
+                    lt,
+                );
+                // A mask only ever touches alpha, so both widths keep their
+                // colour exactly as it arrived — a masked OpenEXR is still an
+                // OpenEXR.
+                let gate = match format {
+                    lumit_media::PixelFormat::LinearF32 => lumit_core::mask::apply_masks_f32,
+                    lumit_media::PixelFormat::Srgb8 => lumit_core::mask::apply_masks,
+                };
+                gate(
+                    rgba,
+                    w,
+                    h,
+                    f64::from(natural.0),
+                    f64::from(natural.1),
+                    &layer.masks,
+                    lt,
+                );
+            }
             (rgba, w, h, natural, format)
         })
     };
@@ -1291,7 +1306,7 @@ pub fn build_comp_draws_at(
             Default::default()
         };
         Some(DofInputDraw {
-            rgba,
+            rgba: rgba.to_vec(),
             tex_w,
             tex_h,
             format,
@@ -1866,7 +1881,7 @@ pub fn build_comp_draws_at(
             // masks keep them.
             let (m_rgba, m_w, m_h, m_nat, m_fmt) = if let Some(n) = &nested {
                 (
-                    Vec::new(),
+                    Arc::new(Vec::new()),
                     n.width,
                     n.height,
                     (n.width as f32, n.height as f32),
@@ -1916,7 +1931,7 @@ pub fn build_comp_draws_at(
                 Default::default()
             };
             Some(MatteDraw {
-                rgba: m_rgba,
+                rgba: m_rgba.to_vec(),
                 tex_w: m_w,
                 tex_h: m_h,
                 format: m_fmt,
@@ -2871,7 +2886,8 @@ pub fn accumulation_mb_below(
 /// (docs/08 §3.26): the clip averaged over its own shutter moments, which the
 /// decode planner fetched onto [`CompLayerPixels::shutter`] for exactly this.
 /// The frame-time pixels unchanged when the layer carries no live copy of the
-/// effect, which is every ordinary layer.
+/// effect, which is every ordinary layer, and that case hands back the decode's
+/// own allocation rather than a copy of it.
 ///
 /// A plain carrier has nothing beneath it to re-render, so this is what the
 /// effect means there: the motion inside the footage, averaged the way a Blend
@@ -2884,15 +2900,19 @@ pub fn accumulation_mb_below(
 /// ponytail: a scalar byte average, N reads of the frame on the CPU each
 /// render. Sum the moments on the card if a profile ever shows it; the
 /// planner and worker need not change.
-fn own_shutter_average(layer: &lumit_core::model::Layer, lp: &CompLayerPixels, lt: f64) -> Vec<u8> {
+fn own_shutter_average(
+    layer: &lumit_core::model::Layer,
+    lp: &CompLayerPixels,
+    lt: f64,
+) -> Arc<Vec<u8>> {
     let offsets = match lumit_core::fx::stack_accumulation_mb(&layer.effects, layer.switches.fx, lt)
     {
         Some(p) if !layer.is_adjustment() => (p.sample_offsets(), p.mix),
-        _ => return lp.rgba.clone(),
+        _ => return Arc::clone(&lp.rgba),
     };
     let (offsets, mix) = offsets;
     if offsets.is_empty() {
-        return lp.rgba.clone();
+        return Arc::clone(&lp.rgba);
     }
     let n = lp.rgba.len();
     let mut sum = vec![0u32; n];
@@ -2913,11 +2933,11 @@ fn own_shutter_average(layer: &lumit_core::model::Layer, lp: &CompLayerPixels, l
         .iter()
         .map(|&s| ((s + count / 2) / count) as u8)
         .collect();
-    if mix >= 1.0 {
+    Arc::new(if mix >= 1.0 {
         average
     } else {
         lumit_core::pixels::blend_rgba(&lp.rgba, &average, mix as f32)
-    }
+    })
 }
 
 /// The neighbour below-stacks a flow-consuming effect on an **adjustment**

--- a/crates/lumit-render/src/build/build_tests.rs
+++ b/crates/lumit-render/src/build/build_tests.rs
@@ -73,7 +73,7 @@ fn footage_geometry_uses_native_size_not_decoded_size() {
         layer: layer.id,
         width: 480,
         height: 270,
-        rgba: vec![0u8; 480 * 270 * 4],
+        rgba: vec![0u8; 480 * 270 * 4].into(),
         format: lumit_media::PixelFormat::Srgb8,
         natural_w: 1920,
         natural_h: 1080,
@@ -355,7 +355,7 @@ fn patch_layer_prop_overrides_the_previewed_value() {
         layer: layer.id,
         width: 1920,
         height: 1080,
-        rgba: vec![0u8; 16],
+        rgba: vec![0u8; 16].into(),
         format: lumit_media::PixelFormat::Srgb8,
         natural_w: 1920,
         natural_h: 1080,
@@ -1452,7 +1452,7 @@ fn a_matte_from_tagged_footage_carries_its_own_colour_space() {
         layer: l.id,
         width: 640,
         height: 360,
-        rgba: vec![0u8; 640 * 360 * 4],
+        rgba: vec![0u8; 640 * 360 * 4].into(),
         format: lumit_media::PixelFormat::Srgb8,
         natural_w: 640,
         natural_h: 360,
@@ -1796,7 +1796,7 @@ fn float_layer_comp(
         layer: layer.id,
         width: 4,
         height: 4,
-        rgba,
+        rgba: rgba.into(),
         format: lumit_media::PixelFormat::LinearF32,
         natural_w: 4,
         natural_h: 4,
@@ -1868,5 +1868,39 @@ fn colour_tables_fill_one_slot_per_table_effect_in_stack_order() {
                 inverse: false,
             })),
         ]
+    );
+}
+
+/// The picture an ordinary footage layer draws is the decode's own allocation,
+/// not a copy of it: at 8K a copy is 133 MB a layer a frame, and it was the
+/// whole of the build stage. Accumulation motion blur on the layer is the one
+/// case that averages the clip's own moments, so that one owns its buffer.
+#[test]
+fn a_plain_footage_draw_shares_the_decoded_bytes() {
+    let (mut comp, layer_id, mut lp) = float_layer_comp(Vec::new(), Vec::new());
+    lp.format = lumit_media::PixelFormat::Srgb8;
+    lp.rgba = vec![128u8; 4 * 4 * 4].into();
+    let mut map: HashMap<Uuid, &CompLayerPixels> = HashMap::new();
+    map.insert(layer_id, &lp);
+    let doc = std::sync::Arc::new(Document::new());
+    let drawn = |comp: &Composition| {
+        let mut visited = vec![comp.id];
+        let draws = build_comp_draws(&doc, comp, 0.0, &map, &mut visited);
+        assert_eq!(draws.len(), 1);
+        match &draws[0].source {
+            DrawSource::Pixels { rgba, .. } => rgba.as_ptr(),
+            _ => panic!("a footage layer draws pixels"),
+        }
+    };
+
+    assert!(
+        std::ptr::eq(drawn(&comp), lp.rgba.as_ptr()),
+        "a layer with nothing stamped into it draws the decoded bytes themselves"
+    );
+
+    comp.layers[0].effects = vec![lumit_core::fx::instantiate("accumulation_mb").unwrap()];
+    assert!(
+        !std::ptr::eq(drawn(&comp), lp.rgba.as_ptr()),
+        "the average of the shutter moments is a buffer of its own"
     );
 }

--- a/crates/lumit-render/src/decode.rs
+++ b/crates/lumit-render/src/decode.rs
@@ -123,7 +123,10 @@ pub struct CompLayerPixels {
     pub layer: Uuid,
     pub width: u32,
     pub height: u32,
-    pub rgba: Vec<u8>,
+    /// The decoded frame, held behind a handle so the build can share it
+    /// rather than copy it: an ordinary layer's draw carries this same
+    /// allocation, which at 8K is 133 MB a layer a frame.
+    pub rgba: Arc<Vec<u8>>,
     /// How wide `rgba`'s samples are, and those of every neighbour in
     /// `temporal` beside it — they come from the one decoder, so they agree.
     /// Float here is a source (OpenEXR) that kept its range and precision.
@@ -1053,7 +1056,7 @@ fn decode_comp(
                         layer: job.layer,
                         width,
                         height,
-                        rgba,
+                        rgba: Arc::new(rgba),
                         format,
                         natural_w: job.natural_w,
                         natural_h: job.natural_h,
@@ -1088,7 +1091,7 @@ fn decode_comp(
             layer: job.layer,
             width,
             height,
-            rgba,
+            rgba: Arc::new(rgba),
             format,
             natural_w: job.natural_w,
             natural_h: job.natural_h,

--- a/crates/lumit-render/src/draw.rs
+++ b/crates/lumit-render/src/draw.rs
@@ -156,7 +156,10 @@ pub struct NestedInputDraw {
 /// comp realised recursively on the GPU (Precomp layers).
 pub enum DrawSource {
     Pixels {
-        rgba: Vec<u8>,
+        /// The picture itself. A decoded layer with nothing stamped into it
+        /// shares the decode's own allocation rather than copying it, which is
+        /// why this is a handle (`build`'s `own_shutter_average`).
+        rgba: std::sync::Arc<Vec<u8>>,
         tex_w: u32,
         tex_h: u32,
         /// How wide `rgba`'s samples are. `Srgb8` is uploaded and then

--- a/crates/lumit-render/src/fxops.rs
+++ b/crates/lumit-render/src/fxops.rs
@@ -667,6 +667,13 @@ pub fn run_ops_with_roto(
             }
         }
     }
+    // Whether the pictures this walk makes are going into the cache. One that
+    // is filed is read again on a later frame, so it is never handed back to
+    // the frame's texture pool; one that is not is dead the moment the op after
+    // it has read it.
+    let filing = cache.is_some_and(|(store, _)| store.borrow().keep);
+    // The picture the op before this one made, once nothing can read it again.
+    let mut spent: Option<Tex> = None;
     // Outputs made this walk, filed at the end rather than as they are made:
     // a flare bake queued *during* the walk means a picture of the previous
     // lens, which must not be filed under the name of the new one.
@@ -772,6 +779,11 @@ pub fn run_ops_with_roto(
             }
             continue;
         }
+        // The picture this op is handed, kept for the recycling below: an op
+        // that passes its input straight through has made nothing, and the one
+        // texture must not be offered to the pool while the chain still holds
+        // it.
+        let given = tex.clone();
         // Only a bound matte costs anything: the input texture is held (a
         // cheap handle clone) so the dissolve below has something to lerp
         // back towards, and nothing at all happens when the row is unset.
@@ -981,8 +993,23 @@ pub fn run_ops_with_roto(
             tex = fx.matte_mix(ctx, &input, &tex, m, w, h, invert);
         }
 
-        if let Some(key) = keys.get(i).copied().flatten() {
+        let named = keys.get(i).copied().flatten();
+        if let Some(key) = named {
             made.push((key, tex.clone()));
+        }
+
+        // The picture the op before this one made has now been read, so hand it
+        // back for a later pass to write into. Only what this walk made itself
+        // is ever offered: never the layer's source, never one the cache gave us
+        // or is about to take, and never one an op passed straight through.
+        let done_with = spent.take();
+        if !(filing && named.is_some()) && tex != given {
+            spent = Some(tex.clone());
+        }
+        if let Some(done_with) = done_with {
+            if done_with != tex {
+                ctx.recycle(done_with);
+            }
         }
 
         if let (Some(started), Some(into)) = (started, timings.as_mut()) {
@@ -1963,5 +1990,85 @@ mod tests {
             to: "anything".into(),
         });
         assert!(cache.get_or_bake(&ctx, engine, &edge, None).is_none());
+    }
+
+    // ----- The frame's texture pool -----
+
+    /// The chain, batched, with every side list empty and no cache.
+    fn chain(fx: &FxEngine, ctx: &GpuContext, ops: &lumit_core::fx::ResolvedStack) -> Vec<f32> {
+        let out = run_ops(
+            fx,
+            ctx,
+            source(ctx),
+            W,
+            H,
+            ops,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+        );
+        lumit_gpu::fx::readback_linear_f32(ctx, &out, W, H).expect("readback")
+    }
+
+    /// Three effects on one layer make two work textures, not three: the third
+    /// op writes into the picture the second one read. The pixels do not move,
+    /// and a cache that is keeping outputs gets its own textures back.
+    ///
+    /// A frame is one command buffer, so before this every effect in a stack
+    /// held a frame-sized texture until the frame ended.
+    #[test]
+    fn a_chain_writes_into_the_texture_the_op_before_it_finished_with() {
+        let Some(ctx) = lumit_gpu::test_support::lease() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let fx = ctx.fx();
+        let ops = stack(&[
+            ("saturation", "saturation", 20.0),
+            ("exposure", "stops", 1.0),
+            ("exposure", "stops", -0.5),
+        ]);
+
+        // The pool lives inside a frame batch, so a walk outside one is the
+        // same chain with nothing reused.
+        let before = ctx.work_textures_made();
+        let plain = chain(fx, &ctx, &ops);
+        let alone = ctx.work_textures_made() - before;
+        assert_eq!(
+            alone, 4,
+            "the source and one texture an op, with nothing to reuse"
+        );
+
+        ctx.begin_frame();
+        let pooled = chain(fx, &ctx, &ops);
+        let batched = ctx.work_textures_made() - before - alone;
+        ctx.end_frame();
+        assert_eq!(pooled, plain, "the same picture, whosever texture it is in");
+        assert_eq!(
+            batched, 3,
+            "the source and two textures for three ops, the third writing into the first"
+        );
+
+        // A cache that is taking outputs reads them on a later frame, so none
+        // of them may be written into.
+        let cache = warm_cache();
+        let before = ctx.work_textures_made();
+        ctx.begin_frame();
+        let kept = run(fx, &ctx, &ops, &cache, 11);
+        let made = ctx.work_textures_made() - before;
+        ctx.end_frame();
+        assert_eq!(kept, plain, "and the cached walk draws the same picture");
+        assert_eq!(made, alone, "a filed picture is never handed back");
+        ctx.begin_frame();
+        let again = run(fx, &ctx, &ops, &cache, 11);
+        ctx.end_frame();
+        assert_eq!(again, plain, "which the walk after it reads unharmed");
     }
 }

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -8390,7 +8390,17 @@ surfaces:
         let (cw, ch) = (32u32, 16u32);
         let (mut doc, comp_id, _) = matrix_base(cw, ch, LinearColour([0.8, 0.1, 0.1, 1.0]));
         for _ in 0..15 {
-            matrix_top(&mut doc, comp_id, LinearColour([0.1, 0.2, 0.9, 1.0]));
+            let (_, id) = matrix_top(&mut doc, comp_id, LinearColour([0.1, 0.2, 0.9, 1.0]));
+            // An effect apiece. The property is about work being handed over
+            // layer by layer, and a layer with nothing on it has none to hand:
+            // its picture goes straight from its upload to the composite.
+            if let Some(l) = doc
+                .comp_mut(comp_id)
+                .and_then(|c| c.layers.iter_mut().find(|l| l.id == id))
+            {
+                l.effects
+                    .push(lumit_core::fx::instantiate("exposure").expect("a built-in"));
+            }
         }
         let store = DocumentStore::new(doc);
         let doc = store.snapshot();

--- a/crates/lumit-render/src/headless.rs
+++ b/crates/lumit-render/src/headless.rs
@@ -1195,7 +1195,7 @@ impl HeadlessRenderer {
                     return false;
                 };
                 let scale = composite_scale(quality);
-                let samples = self.gpu.sample_count(doc.anti_aliasing.samples());
+                let samples = self.gpu.sample_count(doc.anti_aliasing.samples_for(cw, ch));
                 parts
                     .fx_cache
                     .borrow_mut()
@@ -1272,7 +1272,7 @@ impl HeadlessRenderer {
                 // will actually give. Preview and export both read the
                 // same document field — unlike `render_scale`, which is a
                 // preview-only reduction — so the two stay the same picture.
-                samples: self.gpu.sample_count(doc.anti_aliasing.samples()),
+                samples: self.gpu.sample_count(doc.anti_aliasing.samples_for(cw, ch)),
                 profiler: watcher.as_ref(),
                 colour_inputs: inputs.as_ref(),
                 colour_config: self.colour.loaded().filter(|l| l.usable()),

--- a/crates/lumit-render/src/plan.rs
+++ b/crates/lumit-render/src/plan.rs
@@ -32,6 +32,29 @@ use uuid::Uuid;
 /// moment they stop). Chosen to keep even 4K sources instant to draft.
 pub const DRAFT_MAX_WIDTH: u32 = 640;
 
+/// The widest and tallest a decoded frame may be. 8 192 is `wgpu`'s
+/// guaranteed `max_texture_dimension_2d`, and the context asks for no more:
+/// a 9 000-pixel photograph uploaded at its own size is a validation error
+/// on every pass that touches it, and the layer comes out blank. Shrunk to
+/// fit, it is a picture.
+pub const MAX_TEXTURE_SIDE: u32 = 8192;
+
+/// A decode width that also fits the texture limit. `target` is what the
+/// quality policy asked for (`None` for native); the answer is the same
+/// unless the source at that width would still be wider or taller than
+/// [`MAX_TEXTURE_SIDE`], in which case it is the widest that fits, aspect
+/// kept. Applied after the policy, and to the native path too, so no
+/// footage is ever asked for at a size the card cannot hold.
+#[must_use]
+pub fn fit_texture(target: Option<u32>, natural_w: u32, natural_h: u32) -> Option<u32> {
+    let side = natural_w.max(natural_h);
+    if side <= MAX_TEXTURE_SIDE {
+        return target;
+    }
+    let widest = (u64::from(natural_w) * u64::from(MAX_TEXTURE_SIDE) / u64::from(side)) as u32;
+    Some(target.map_or(widest, |t| t.min(widest)).max(16))
+}
+
 /// How coarsely to decode this preview — the quality axis of both the decode
 /// plan and the frame-cache key. Keeping the two in one type is deliberate: if
 /// they could disagree, a frame decoded at one width could be served from a
@@ -332,6 +355,7 @@ pub fn collect_comp_jobs(
                     } else {
                         quality.target_width(nat_w)
                     };
+                    let target_width = fit_texture(target_width, nat_w, nat_h);
                     let (source_frame, blend) =
                         lumit_core::pixels::frame_pick(st, fps, src_frames, blend_on, sample_fps);
                     jobs.push(CompJob {
@@ -456,6 +480,7 @@ pub fn collect_comp_jobs(
                 } else {
                     quality.target_width(nat_w)
                 };
+                let target_width = fit_texture(target_width, nat_w, nat_h);
                 let (source_frame, blend) = lumit_core::pixels::frame_pick(
                     source_time,
                     fps,
@@ -752,6 +777,30 @@ mod tests {
         // And a step that IS a step still separates them.
         assert_ne!(at(0.42).tag(), at(0.43).tag());
         assert_ne!(at(0.42).target_width(1920), at(0.43).target_width(1920));
+    }
+
+    /// A source wider or taller than the texture limit decodes shrunk to fit,
+    /// whatever the quality asked for; anything that fits is left alone.
+    #[test]
+    fn oversize_footage_decodes_within_the_texture_limit() {
+        assert_eq!(fit_texture(None, 7680, 4320), None, "8K fits");
+        assert_eq!(fit_texture(Some(960), 7680, 4320), Some(960));
+        assert_eq!(fit_texture(None, 9000, 5000), Some(8192), "wide: capped");
+        assert_eq!(
+            fit_texture(None, 5000, 9000),
+            Some(4551),
+            "tall: the height caps"
+        );
+        assert_eq!(
+            fit_texture(Some(4000), 9000, 5000),
+            Some(4000),
+            "smaller ask kept"
+        );
+        assert_eq!(
+            fit_texture(Some(8500), 9000, 5000),
+            Some(8192),
+            "larger ask capped"
+        );
     }
 
     /// Full quality decodes at native width; a divisor and Auto both shrink it,

--- a/crates/lumit-render/src/realise.rs
+++ b/crates/lumit-render/src/realise.rs
@@ -1012,6 +1012,24 @@ impl Realiser<'_> {
                     tex_h,
                     format,
                     colour_space,
+                } if straight_to_composite(l)
+                    && matches!(format, lumit_media::PixelFormat::Srgb8)
+                    && self.input_transform(colour_space).is_none() =>
+                {
+                    // Nothing between here and the composite draw, so the
+                    // eight-bit upload goes there as it arrived. The sampler
+                    // decodes sRGB in hardware, which is the decode the
+                    // linearise pass was asking it for anyway, so the picture
+                    // is the same one and the working-format copy is never
+                    // made.
+                    self.engine.upload_srgb8(&self.ctx, rgba, *tex_w, *tex_h)
+                }
+                DrawSource::Pixels {
+                    rgba,
+                    tex_w,
+                    tex_h,
+                    format,
+                    colour_space,
                 } => self.upload_source(rgba, *tex_w, *tex_h, *format, colour_space),
                 DrawSource::Nested {
                     width,
@@ -1410,6 +1428,20 @@ fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
     ]
 }
 
+/// Whether this layer's picture goes straight from its upload to the composite
+/// draw, with nothing in between that wants the linear working format.
+///
+/// **In plain terms.** The composite samples a layer through a sampler, so an
+/// eight-bit sRGB texture reads as the same linear values the linearise pass
+/// would have written into a working-format copy of it. Everything else that
+/// touches a layer's picture wants the working format: an effect stack, the
+/// lighting pass, and the motion-blur average, whose fp32 accumulation is what
+/// keeps a still layer bit-exact (docs/06 §4). One of those and the layer
+/// linearises as it always did.
+fn straight_to_composite(l: &CompLayerDraw) -> bool {
+    l.fx.is_empty() && l.lights.is_empty() && l.mb.is_empty()
+}
+
 /// Whether a region of interest can be applied to this draw list, or
 /// whether the whole frame has to be composited and cropped instead.
 ///
@@ -1459,4 +1491,232 @@ fn upload_roto_matte(ctx: &lumit_gpu::GpuContext, m: &crate::draw::RotoMatteDraw
         halfs.extend_from_slice(&[a, a, a, a]);
     }
     lumit_gpu::fx::upload_linear_f16(ctx, &halfs, m.width, m.height)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    const W: u32 = 64;
+    const H: u32 = 64;
+
+    /// An sRGB plate with a value in every part of the curve, so a missed or
+    /// doubled decode shows up as a difference rather than as rounding.
+    fn plate() -> std::sync::Arc<Vec<u8>> {
+        let mut px = Vec::with_capacity((W * H * 4) as usize);
+        for y in 0..H {
+            for x in 0..W {
+                px.extend_from_slice(&[(x * 4) as u8, (y * 4) as u8, ((x + y) * 2) as u8, 255]);
+            }
+        }
+        std::sync::Arc::new(px)
+    }
+
+    /// One footage-shaped draw at the comp's own size, centred: eight-bit
+    /// pixels, no colour space, nothing on it.
+    fn draw(rgba: &std::sync::Arc<Vec<u8>>) -> CompLayerDraw {
+        CompLayerDraw {
+            layer: uuid::Uuid::now_v7(),
+            source: DrawSource::Pixels {
+                rgba: rgba.clone(),
+                tex_w: W,
+                tex_h: H,
+                format: lumit_media::PixelFormat::Srgb8,
+                colour_space: None,
+            },
+            natural_size: (W as f32, H as f32),
+            position: (W as f32 / 2.0, H as f32 / 2.0),
+            anchor: (W as f32 / 2.0, H as f32 / 2.0),
+            scale: (100.0, 100.0),
+            rotation_deg: 0.0,
+            opacity: 100.0,
+            z: 0.0,
+            rotation_x_deg: 0.0,
+            rotation_y_deg: 0.0,
+            three_d: false,
+            matte: None,
+            blend: lumit_gpu::Blend::Normal,
+            mask_cov: None,
+            pre: None,
+            fx: lumit_core::fx::ResolvedStack::new(),
+            fx_ids: Vec::new(),
+            neighbours: Vec::new(),
+            flow_fields: Vec::new(),
+            colour_tables: Vec::new(),
+            dof_inputs: Vec::new(),
+            mattes: Vec::new(),
+            mask_paths: Vec::new(),
+            roto_mattes: Vec::new(),
+            points_schedules: Vec::new(),
+            flare_lens_files: Vec::new(),
+            fx_ref_width: None,
+            fx_input_key: None,
+            mb: Vec::new(),
+            lights: Vec::new(),
+            temporal_below: None,
+            accumulation_below: None,
+            flow_below: Vec::new(),
+        }
+    }
+
+    /// The placement `realise_segment` gives that draw, so the hand-built
+    /// reference below composites the same rectangle in the same place.
+    fn placed<'a>(l: &CompLayerDraw, texture: &'a wgpu::Texture) -> lumit_gpu::CompositeLayer<'a> {
+        lumit_gpu::CompositeLayer {
+            texture,
+            size: l.natural_size,
+            position: l.position,
+            anchor: l.anchor,
+            scale: l.scale,
+            rotation_deg: l.rotation_deg,
+            opacity: l.opacity,
+            matte: None,
+            blend: l.blend,
+            z: l.z,
+            rotation_x_deg: l.rotation_x_deg,
+            rotation_y_deg: l.rotation_y_deg,
+            three_d: l.three_d,
+            layer_mask: None,
+            pre: None,
+        }
+    }
+
+    /// Run `f` with the driver's texture count read either side of it, and
+    /// hand back its picture and how many textures it made.
+    ///
+    /// The batch is held open around it so nothing is submitted while it runs:
+    /// a submission is where wgpu hands back what a render has finished with,
+    /// and the question here is what the render made, not what survived it.
+    /// The lease is exclusive, so nothing else is allocating on this device.
+    fn made(ctx: &lumit_gpu::GpuContext, f: impl Fn() -> wgpu::Texture) -> (Vec<f32>, u64) {
+        // Two throwaway renders first, each followed by a command buffer of its
+        // own and a wait. A render's dropped textures come back only when a
+        // LATER submission finishes, so without something behind them they sit
+        // pending and are handed back in the middle of the count instead.
+        for _ in 0..2 {
+            drop(f());
+            drop(ctx.encoder("settling"));
+            ctx.settle();
+        }
+        let before = ctx.live_objects().0;
+        ctx.begin_frame();
+        let out = f();
+        let after = ctx.live_objects().0;
+        ctx.end_frame();
+        let px = lumit_gpu::fx::readback_linear_f32(ctx, &out, W, H).expect("the comp reads back");
+        drop(out);
+        ctx.settle();
+        (px, after.saturating_sub(before))
+    }
+
+    /// A realiser on the shared device, with everything a plain footage layer
+    /// never asks for left out.
+    fn realiser<'a>(
+        shared: &'a lumit_gpu::test_support::Lease,
+        lut_cache: &'a std::cell::RefCell<crate::fxops::LutCache>,
+        fx_cache: &'a std::cell::RefCell<crate::fxops::FxCache>,
+    ) -> Realiser<'a> {
+        Realiser {
+            ctx: shared.clone_handle(),
+            engine: shared.colour(),
+            compositor: shared.compositor(),
+            fx: shared.fx(),
+            lut_cache,
+            fx_cache,
+            render_scale: 1.0,
+            samples: 1,
+            profiler: None,
+            colour_inputs: None,
+            colour_config: None,
+            flow: None,
+        }
+    }
+
+    /// **A plain eight-bit layer skips the linearise pass.** Its picture is
+    /// the one the upload-linearise-composite route drew, to the byte, and it
+    /// costs one texture fewer: at 8K that texture is a quarter of a gigabyte
+    /// and a full-frame pass, per layer, per frame.
+    #[test]
+    fn a_plain_footage_layer_goes_straight_to_the_composite() {
+        let Some(ctx) = lumit_gpu::test_support::lease() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let lut_cache = std::cell::RefCell::new(crate::fxops::LutCache::default());
+        let fx_cache = std::cell::RefCell::new(crate::fxops::FxCache::default());
+        let realiser = realiser(&ctx, &lut_cache, &fx_cache);
+        let rgba = plate();
+        let l = draw(&rgba);
+
+        let (got, short) = made(&ctx, || {
+            realiser.realise(None, W, H, [0.0; 4], std::slice::from_ref(&l))
+        });
+        // The route this replaced, by hand: the sRGB upload, a working-format
+        // copy of it, and the same composite draw over the same background.
+        let (want, long) = made(&ctx, || {
+            let src = ctx.colour().upload_srgb8(&ctx, &rgba, W, H);
+            let linear = ctx.colour().linearise(&ctx, &src);
+            ctx.compositor().composite_seeded(
+                &ctx,
+                W,
+                H,
+                [0.0; 4],
+                &[placed(&l, &linear)],
+                None,
+                None,
+                1.0,
+                1,
+                None,
+            )
+        });
+
+        assert_eq!(got, want, "the hardware decode is the decode the pass did");
+        assert_eq!(
+            short + 1,
+            long,
+            "the working-format copy is the texture that is no longer made (short {short} long {long})"
+        );
+    }
+
+    /// **A layer with an effect keeps the linearise pass**: its stack runs in
+    /// the working format, so it still pays for the copy the plain layer above
+    /// no longer makes. The picture is the plain layer's, because the effect
+    /// is an Exposure sitting at zero stops.
+    #[test]
+    fn a_layer_with_an_effect_still_linearises() {
+        let Some(ctx) = lumit_gpu::test_support::lease() else {
+            lumit_gpu::no_adapter();
+            return;
+        };
+        let lut_cache = std::cell::RefCell::new(crate::fxops::LutCache::default());
+        let fx_cache = std::cell::RefCell::new(crate::fxops::FxCache::default());
+        let realiser = realiser(&ctx, &lut_cache, &fx_cache);
+        let rgba = plate();
+        let plain = draw(&rgba);
+        let mut with_fx = draw(&rgba);
+        with_fx.fx = lumit_core::fx::resolve_stack(
+            &[lumit_core::fx::instantiate("exposure").expect("a built-in")],
+            0.0,
+            1000.0,
+            1.0,
+            &lumit_core::fx::MarkerContext::NONE,
+            std::sync::Arc::new(lumit_core::expression::ExpressionContext::detached()),
+        );
+        assert!(!with_fx.fx.is_empty(), "the stack really holds an op");
+
+        let (plain_px, plain_made) = made(&ctx, || {
+            realiser.realise(None, W, H, [0.0; 4], std::slice::from_ref(&plain))
+        });
+        let (fx_px, fx_made) = made(&ctx, || {
+            realiser.realise(None, W, H, [0.0; 4], std::slice::from_ref(&with_fx))
+        });
+
+        assert_eq!(fx_px, plain_px, "zero stops changes nothing");
+        assert_eq!(
+            fx_made,
+            plain_made + 2,
+            "the linear copy the plain layer skips, and the texture the op writes (plain {plain_made} fx {fx_made})"
+        );
+    }
 }

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -370,7 +370,7 @@ One job per crate.
 | `lumit-project` | The `.lum` container, the operation journal, autosave and crash recovery |
 | `lumit-eval` | The evaluator: content-hash frame keys, the graph compiler, epochs, the worker pool, the scheduler core |
 | `lumit-render` | The pixel pass: the decode worker, draw lists, the compositor, effect dispatch, cache tiers, export, the headless renderer |
-| `lumit-gpu` | The one wgpu device, the WGSL effect kernels, the compositor, the colour engine, readback |
+| `lumit-gpu` | The one wgpu device, the frame batch and its work-texture pool, the WGSL effect kernels, the compositor, the colour engine, readback |
 | `lumit-cache` | The frame cache (Nebula): byte-budgeted RAM and disk tiers |
 | `lumit-flow` | Optical flow (DIS): a CPU oracle and its WGSL twin, for Retime interpolation and flow motion blur |
 | `lumit-media` | FFmpeg through rsmpeg: probing, the frame index, exact seeking, hardware decode, encode |

--- a/docs/impl/anti-aliasing.md
+++ b/docs/impl/anti-aliasing.md
@@ -176,6 +176,13 @@ always meant.
   rather than copying it (trap 1). `motion_blur_average` takes the same count (trap 4).
 - **The walk.** `Realiser::samples`, beside `render_scale` — but read from the project by
   both the preview and the export path, which is what makes §4 hold.
+- **The budget.** `AntiAliasing::samples_for` caps the count by the comp's own size
+  before the adapter check: the multisample attachment is `width × height × samples`
+  texels, 2.1 GB at 8K and 8×, and every nested comp and motion-blur sample allocates
+  another. The line is a 4K frame at 8× (`SAMPLE_BUDGET`), so 4K keeps the project's count,
+  5K gets at most 4× and 8K at most 2×. A rule about the comp, never the preview scale, so
+  §4 still holds: the same count at every zoom, and on export. The frame name folds in
+  the capped count, so a frame banked under one count is never served for another.
 - **The cache.** The count is fed into `comp_frame_key`, and `ALGO_VERSION` went to 3: every
   frame banked before this was made without anti-aliasing and may not be served again.
 - **The interface.** The **Project settings** window (`File ▸ Project settings…`,

--- a/docs/impl/gpu-foundation.md
+++ b/docs/impl/gpu-foundation.md
@@ -35,6 +35,12 @@ anywhere is at the two ends:
   egui's own expectations is the classic double-gamma bug; one explicit encode in one
   named shader (`display_transform.wgsl`) is auditable.
 
+An eight-bit layer with nothing to run on it never gets a working-format copy. It goes to
+the composite as the `Rgba8UnormSrgb` texture it was uploaded as, and the composite's own
+sampler does the decode the linearise pass was asking the hardware for anyway. The moment
+anything else reads that layer, an effect, the lighting pass or a motion-blur average, it
+linearises first, because those all work in the format above.
+
 Rule for every WGSL effect: sample premultiplied linear, write premultiplied linear. The
 host wraps unpremultiply/premultiply around the few effects that declare they need straight
 alpha ([08-EFFECTS.md](../08-EFFECTS.md)).

--- a/docs/impl/media-io.md
+++ b/docs/impl/media-io.md
@@ -83,7 +83,11 @@ GpuFrame }` with the CPU path as the always-working fallback:
     `hardware_and_software_decode_agree_on_the_pixels` regression test.
   - Also shipped with it: `thread_count = 0` on every codec context — library-default libav
     is single-threaded (unlike the ffmpeg CLI), so the software fallback was grinding one
-    core.
+    core. Since 2026-09-09 the count is bounded by frame size (`thread_cap`): every thread
+    keeps a picture in flight, and the hardware surface pool grows with it, so 8K on
+    sixteen threads held a gigabyte before the first frame. The pictures in flight stay
+    under 256 MB, which leaves 1080p and 4K at libav's own count and gives 8K five threads
+    at the same speed.
 - **v1 target (the "one copy")**, Windows: create the decoder with a D3D11 hw device ctx;
   frames arrive as `AV_PIX_FMT_D3D11` (ID3D11Texture2D array slices). Copy the slice into
   a **shared** `ID3D11Texture2D` (created with `D3D11_RESOURCE_MISC_SHARED_NTHANDLE |


### PR DESCRIPTION
## What

Three changes to how Lumit handles high resolution footage, from a report of 8K
feeling sluggish, failing and sometimes crashing.

Footage wider or taller than 8192 pixels came out blank, since that is the
texture limit the card is opened with, and every pass on the layer failed. It
now decodes shrunk to fit. The anti-aliasing target grows with both the comp
and the sample count, so an 8K comp at 8x held 2.1GB on its own and every
precomp and motion blur sample allocated another, so the count now steps down
above 4K. On top of those, six smaller things that were copying or holding more
than they needed to: decoded frames are shared with the draw list rather than
copied, thumbnails decode at thumbnail size, an effect pass reuses a texture an
earlier pass in the same frame has finished with, the conversions to and from a
plugin's floats do a whole plane at a time, a plain 8-bit layer goes to the
composite as it was uploaded, and 8K decode asks for five threads instead of
sixteen.

On a plain 8K layer a frame now takes 103ms instead of 118ms, the card holds
4.3GB instead of 5.1GB, and memory 1.6GB instead of 1.9GB. 4K goes from 31ms to
27ms. 1080p is unchanged apart from being a little quicker.

## Testing

Drop an 8K clip and a photo bigger than 8192 pixels into a comp and scrub. The
photo should draw rather than come back blank, and the frame should arrive
quicker than before with Settings, Performance, Memory reading lower both on
the card and in memory. Every change has a test that fails without it.

## Still to do

I tried a seventh change, drawing a composite at one sample when no layer has
an off-pixel edge for the samples to touch. It saved 14ms on a single 4K layer
but cost 15ms a frame on the reference comp, reproducibly and for no reason I
could find, so it is not in here.
