### PR TITLE
Add a Samples control to the shake's motion blur

### DIFF
--- a/crates/lumit-core/fx-reference.json
+++ b/crates/lumit-core/fx-reference.json
@@ -4096,6 +4096,17 @@
           "hard_max": 1.0
         },
         {
+          "id": "mb_samples",
+          "label": "Samples",
+          "kind": "float",
+          "unit": "raw",
+          "default": 9.0,
+          "slider_min": 2.0,
+          "slider_max": 64.0,
+          "hard_min": 2.0,
+          "hard_max": 64.0
+        },
+        {
           "id": "edge",
           "label": "Edges",
           "kind": "choice",
@@ -4208,7 +4219,8 @@
           "label": "Motion blur",
           "params": [
             "motion_blur",
-            "mb_amount"
+            "mb_amount",
+            "mb_samples"
           ],
           "collapsed": true
         }

--- a/crates/lumit-core/src/fx/effects/shake.rs
+++ b/crates/lumit-core/src/fx/effects/shake.rs
@@ -13,10 +13,11 @@
 //!   when a stack is reused at another raster size. The amplitude stays a
 //!   declared `Px` row, which does rescale, and the two are multiplied
 //!   together at dispatch in [`Shake::packed`].
-//! - **Its own motion blur** (T18) needs the same wobble at nine
-//!   sub-frame placements across the shutter. Each is four floats under one id
-//!   ([`Value::Vec4`]), which is what that kind exists for: forty flat
-//!   `derived.*` entries would have drowned the bag.
+//! - **Its own motion blur** (T18) needs the same wobble at every
+//!   sub-frame placement across the shutter, as many as the Samples row asks
+//!   for. Each is four floats under one id ([`Value::Vec4`]), which is what
+//!   that kind exists for: four flat `derived.*` entries per sub-frame would
+//!   have drowned the bag.
 //!
 //! [`Shake::packed`] reassembles [`ShakeWobble::at`](crate::fx::ShakeWobble::at)
 //! step for step — same association, same cast points — so a shake that has not
@@ -25,16 +26,24 @@
 use crate::fx::{
     cpu, shake_affine, shake_mb_offsets, shake_noise, transform_op, EdgesMode, EffectDef,
     EffectMetadata, EffectSchema, ParamGroup, ParamId, Params, ResolveCx, ShakeSample, Value,
-    NO_SKEW, SHAKE_MB_SAMPLES,
+    NO_SKEW, SHAKE_MB_DEFAULT_SAMPLES, SHAKE_MB_SAMPLES,
 };
 use crate::model::EffectValue;
 use lumit_fx_macros::Effect;
 
+/// `derived.mb_noise_<n>` for each listed n, as one const array.
+macro_rules! mb_noise_ids {
+    ($($n:literal),* $(,)?) => {
+        [$(ParamId::new(concat!("derived.mb_noise_", $n))),*]
+    };
+}
+
 /// Shake's twirls (P4): the per-axis wobble (FX-11) — the master
 /// Amplitude/Frequency drive x and y together while this group biases each axis
 /// and adds the z (depth/scale) shake that replaced the old Zoom pump — and the
-/// Motion blur group (T18), the shake's own inter-frame smear (toggle +
-/// amount). Each group's ids are a contiguous run of the schema's `params`.
+/// Motion blur group (T18), the shake's own inter-frame smear (toggle,
+/// shutter, samples). Each group's ids are a contiguous run of the schema's
+/// `params`.
 pub const SHAKE_GROUPS: &[ParamGroup] = &[
     ParamGroup {
         label: "Per-axis wobble",
@@ -45,7 +54,7 @@ pub const SHAKE_GROUPS: &[ParamGroup] = &[
     },
     ParamGroup {
         label: "Motion blur",
-        params: &["motion_blur", "mb_amount"],
+        params: &["motion_blur", "mb_amount", "mb_samples"],
         collapsed: true,
         visible_when: None,
         visible_when_lens_elements: None,
@@ -216,6 +225,22 @@ pub struct Shake {
     )]
     pub mb_amount: f32,
 
+    /// How many sub-frames the smear averages. A big amplitude at nine samples
+    /// shows the taps as ghosts; more samples fill the same shutter window more
+    /// densely. Defaults to what the smear always used, so an old shake
+    /// renders the bits it always did. Read by [`ShakeDef::resolve_derived`],
+    /// which is where the sub-frames are sampled.
+    #[slider(
+        label = "Samples",
+        min = 2.0,
+        max = 64.0,
+        default = 9.0,
+        hard_min = 2.0,
+        hard_max = 64.0,
+        unit = Raw
+    )]
+    pub mb_samples: f32,
+
     /// How the resample treats the border the wobble reveals (P3).
     /// Default Mirror (owner, 2026-07-19; was Repeat): the reflected border
     /// reads more naturally under the shake's own motion blur than a smeared
@@ -247,9 +272,12 @@ pub struct Shake {
 pub struct ShakeDerived {
     /// The frame's noise sample, `(x, y, rotation, z)`, each −1..1.
     pub noise: [f32; 4],
-    /// The same, at each motion-blur sub-frame across the shutter — `Some` only
-    /// when the smear is on, which is the one place that decision is taken.
-    pub mb_noise: Option<[[f32; 4]; SHAKE_MB_SAMPLES]>,
+    /// The same, at each motion-blur sub-frame across the shutter. The first
+    /// `mb_count` entries are live; the rest are zeros.
+    pub mb_noise: [[f32; 4]; SHAKE_MB_SAMPLES],
+    /// How many sub-frames the smear averages. 0 is the smear off, which is the
+    /// one place that decision is taken.
+    pub mb_count: usize,
     /// Depth (z) scale-pump magnitude, 0..1: the Z amount row as a fraction,
     /// or an old project's `zoom_pump`.
     pub z_amp: f32,
@@ -265,7 +293,12 @@ pub struct ShakeDerived {
 /// affine per sub-frame — exactly as RGB split's Wavelength is. One enum
 /// keeps the fork in one place, so the CPU reference and the GPU wrapper cannot
 /// disagree about which one an instance is in.
+///
+/// The smeared variant carries its sub-frames inline, so the enum is as wide as
+/// the widest smear (a kilobyte). It is built once per dispatch, never per
+/// pixel, and boxing it would cost the `Copy` both render paths read it through.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Shaken {
     /// The plain single resample through the Transform kernel.
     Plain {
@@ -276,12 +309,15 @@ pub enum Shaken {
         /// 0..1.
         mix: f32,
     },
-    /// The shake's own motion blur (T18): the wobble at
-    /// [`SHAKE_MB_SAMPLES`] sub-frame placements, resampled and averaged in
-    /// premultiplied linear space. The centre sample is the frame itself.
+    /// The shake's own motion blur (T18): the wobble at `count` sub-frame
+    /// placements, resampled and averaged in premultiplied linear space. An
+    /// odd count's centre sample is the frame itself.
     Blurred {
-        /// One wobble per sub-frame, in shutter order.
+        /// One wobble per sub-frame, in shutter order; only the first `count`
+        /// are live.
         samples: [ShakeSample; SHAKE_MB_SAMPLES],
+        /// Live sub-frames, `2..=SHAKE_MB_SAMPLES`.
+        count: usize,
         /// [`EdgesMode`] wire code for the revealed border.
         edge: u32,
         /// 0..1.
@@ -294,20 +330,14 @@ impl Shake {
     /// row: it is what the seed, the frequencies and the clock produce.
     pub const DERIVED_NOISE: ParamId = ParamId::new("derived.noise");
 
-    /// The same at each motion-blur sub-frame, present only when the smear is
-    /// on. Fixed ids rather than a counted list, so the bag stays a flat
-    /// key/value set.
-    pub const DERIVED_MB_NOISE: [ParamId; SHAKE_MB_SAMPLES] = [
-        ParamId::new("derived.mb_noise_0"),
-        ParamId::new("derived.mb_noise_1"),
-        ParamId::new("derived.mb_noise_2"),
-        ParamId::new("derived.mb_noise_3"),
-        ParamId::new("derived.mb_noise_4"),
-        ParamId::new("derived.mb_noise_5"),
-        ParamId::new("derived.mb_noise_6"),
-        ParamId::new("derived.mb_noise_7"),
-        ParamId::new("derived.mb_noise_8"),
-    ];
+    /// The same at each motion-blur sub-frame, the first Samples of them
+    /// present only when the smear is on. Fixed ids rather than a counted list,
+    /// so the bag stays a flat key/value set.
+    pub const DERIVED_MB_NOISE: [ParamId; SHAKE_MB_SAMPLES] = mb_noise_ids!(
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63
+    );
 
     /// The depth (z) pump as a 0..1 magnitude, with an old project's
     /// `zoom_pump` folded in.
@@ -320,16 +350,25 @@ impl Shake {
     /// resolved bag — so no caller has to know the ids.
     ///
     /// The motion-blur set is read by *presence*: [`ShakeDef::resolve_derived`]
-    /// pushes it only when the toggle is on and the shutter is non-zero, which
-    /// is the one place that decision is taken (the old arm took it in `f64`, on
-    /// the stored value, and it still does).
+    /// pushes the first Samples of it only when the toggle is on and the
+    /// shutter is non-zero, which is the one place that decision is taken (the
+    /// old arm took it in `f64`, on the stored value, and it still does).
+    /// The set runs from the front and stops at the first id the resolver did
+    /// not push, so a plain shake reads one absent id and no more.
     pub fn derived_of(p: Params<'_>) -> ShakeDerived {
+        let mut mb_noise = [[0.0f32; 4]; SHAKE_MB_SAMPLES];
+        let mut mb_count = 0;
+        for (slot, id) in mb_noise.iter_mut().zip(Self::DERIVED_MB_NOISE) {
+            match p.get(id) {
+                Some(_) => *slot = p.vec4(id, [0.0; 4]),
+                None => break,
+            }
+            mb_count += 1;
+        }
         ShakeDerived {
             noise: p.vec4(Self::DERIVED_NOISE, [0.0; 4]),
-            mb_noise: p
-                .get(Self::DERIVED_MB_NOISE[0])
-                .is_some()
-                .then(|| Self::DERIVED_MB_NOISE.map(|id| p.vec4(id, [0.0; 4]))),
+            mb_noise,
+            mb_count,
             z_amp: p.float(Self::DERIVED_Z_AMP, 0.0),
             edge: p.choice(Self::DERIVED_EDGE, EdgesMode::Repeat.code()),
         }
@@ -357,13 +396,14 @@ impl Shake {
             rotation_deg: rot_amount * n[2],
             zoom: 1.0 + d.z_amp * n[3],
         };
-        match d.mb_noise {
-            Some(noise) => Shaken::Blurred {
-                samples: noise.map(at),
+        match d.mb_count {
+            count if count >= 2 => Shaken::Blurred {
+                samples: d.mb_noise.map(at),
+                count,
                 edge: d.edge,
                 mix,
             },
-            None => Shaken::Plain {
+            _ => Shaken::Plain {
                 wobble: at(d.noise),
                 edge: d.edge,
                 mix,
@@ -444,10 +484,13 @@ impl EffectDef for ShakeDef {
         // frame-time wobble exactly.
         let motion_blur = e.bool_of("motion_blur").unwrap_or(false);
         let mb_amount = fl("mb_amount").unwrap_or(0.5);
+        // A shake saved before the Samples row keeps the nine it was made with.
+        let mb_samples =
+            fl("mb_samples").map_or(SHAKE_MB_DEFAULT_SAMPLES, |s| s.round().max(0.0) as usize);
         if motion_blur && mb_amount > 0.0 {
             for (id, db) in Shake::DERIVED_MB_NOISE
                 .iter()
-                .zip(shake_mb_offsets(mb_amount))
+                .zip(shake_mb_offsets(mb_amount, mb_samples))
             {
                 push(*id, noise(base + db));
             }
@@ -469,7 +512,12 @@ impl EffectDef for ShakeDef {
                     rgba, w, h, anchor, position, scale, rot, NO_SKEW, edge, 1.0, mix,
                 );
             }
-            Shaken::Blurred { samples, edge, mix } => {
+            Shaken::Blurred {
+                samples,
+                count,
+                edge,
+                mix,
+            } => {
                 let mut ops = [([1.0f32, 0.0, 0.0, 1.0], [0.0f32, 0.0]); SHAKE_MB_SAMPLES];
                 for (op, s) in ops.iter_mut().zip(samples.iter()) {
                     let (anchor, position, scale, rot) =
@@ -477,7 +525,7 @@ impl EffectDef for ShakeDef {
                     let (m, o, _opacity) = transform_op(anchor, position, scale, rot, NO_SKEW, 1.0);
                     *op = (m, o);
                 }
-                cpu::transform_average(rgba, w, h, &ops, edge, mix);
+                cpu::transform_average(rgba, w, h, &ops[..count], edge, mix);
             }
         }
     }

--- a/crates/lumit-core/src/fx/maths.rs
+++ b/crates/lumit-core/src/fx/maths.rs
@@ -278,11 +278,16 @@ impl ShakeSample {
     };
 }
 
-/// The fixed number of sub-frame samples the shake's own motion blur averages
-/// (T18): odd, so the centre sample lands exactly on the frame time.
-/// A fixed count and order keep the smear deterministic (docs/14 §3), and the
-/// value is small because a shake moves little — a Cheap effect stays cheap.
-pub const SHAKE_MB_SAMPLES: usize = 9;
+/// The most sub-frame samples the shake's own motion blur averages (T18).
+/// The Samples row picks the count, 2 up to this; the default of 9 is odd, so
+/// its centre sample lands exactly on the frame time. The count and order keep
+/// the smear deterministic (docs/14 §3). This is also the uniform array's
+/// length in the averaging kernel, so it is a compile-time size everywhere.
+pub const SHAKE_MB_SAMPLES: usize = 64;
+
+/// The sub-frame count the shake's own motion blur uses when the Samples row is
+/// absent: what every shake made before the row had.
+pub const SHAKE_MB_DEFAULT_SAMPLES: usize = 9;
 
 /// The motion-blur shutter's full width in the noise base domain at amount 1
 /// (T18). The wobble is a pure function of time, so its motion blur
@@ -294,17 +299,16 @@ pub const SHAKE_MB_SAMPLES: usize = 9;
 /// smears more — the shake's own inter-frame movement, scaled by amount.
 pub const SHAKE_MB_SPAN_BASE: f64 = 1.0;
 
-/// The signed base offsets of the motion-blur sub-frames across the shutter
-/// (T18), symmetric about 0 so the centre sample is the frame itself.
-/// `amount` is the shutter fraction, clamped to 0..1.
-pub fn shake_mb_offsets(amount: f64) -> [f64; SHAKE_MB_SAMPLES] {
+/// The signed base offsets of `count` motion-blur sub-frames across the shutter
+/// (T18), symmetric about 0 so an odd count's centre sample is the frame
+/// itself. `amount` is the shutter fraction, clamped to 0..1; `count` is
+/// clamped to `2..=SHAKE_MB_SAMPLES`. More samples fill the same window more
+/// densely; the ends stay put.
+pub fn shake_mb_offsets(amount: f64, count: usize) -> impl Iterator<Item = f64> {
     let window = amount.clamp(0.0, 1.0) * SHAKE_MB_SPAN_BASE;
-    let last = (SHAKE_MB_SAMPLES - 1) as f64;
-    let mut out = [0.0f64; SHAKE_MB_SAMPLES];
-    for (k, o) in out.iter_mut().enumerate() {
-        *o = (k as f64 / last - 0.5) * window;
-    }
-    out
+    let count = count.clamp(2, SHAKE_MB_SAMPLES);
+    let last = (count - 1) as f64;
+    (0..count).map(move |k| (k as f64 / last - 0.5) * window)
 }
 
 /// A 32-bit avalanche mixer, in the same five-line-portability spirit as

--- a/crates/lumit-core/src/fx/tests.rs
+++ b/crates/lumit-core/src/fx/tests.rs
@@ -4089,7 +4089,10 @@ fn shake_instantiates_with_a_per_instance_seed_and_resolves() {
     );
     assert_eq!(schema.groups[1].label, "Motion blur");
     assert!(schema.groups[1].collapsed);
-    assert_eq!(schema.groups[1].params, &["motion_blur", "mb_amount"]);
+    assert_eq!(
+        schema.groups[1].params,
+        &["motion_blur", "mb_amount", "mb_samples"]
+    );
 
     // Resolving is deterministic: the same instance at the same time
     // yields the identical wobble, twice.
@@ -4278,6 +4281,55 @@ fn shake_with_mb(amount: f64) -> crate::model::EffectInstance {
     e
 }
 
+/// The Samples row sets how many sub-frames the smear averages. The shutter
+/// ends stay where they are; only the density between them changes. Absent
+/// (a shake saved before the row), the count is the nine it was made with.
+#[test]
+fn shake_samples_row_sets_the_sub_frame_count_without_moving_the_shutter_ends() {
+    use effects::shake::Shaken;
+
+    // One instance, so one seed and one noise curve: only the row moves.
+    let base = shake_with_mb(0.5);
+    let with_samples = |n: f64| {
+        let mut e = base.clone();
+        for p in &mut e.params {
+            if p.id == "mb_samples" {
+                p.value = EffectValue::Float(crate::anim::Property::fixed(n));
+            }
+        }
+        e
+    };
+    let blurred = |e: &crate::model::EffectInstance| {
+        let Shaken::Blurred { samples, count, .. } = shake_packed(e, 0.4, 1000.0) else {
+            panic!("motion blur on carries sub-frames");
+        };
+        (samples, count)
+    };
+
+    let (nine, n9) = blurred(&with_samples(9.0));
+    let (thirty_two, n32) = blurred(&with_samples(32.0));
+    let (two, n2) = blurred(&with_samples(2.0));
+    assert_eq!((n9, n32, n2), (9, 32, 2));
+    assert_eq!(nine[0], thirty_two[0], "the first sub-frame stays put");
+    assert_eq!(nine[8], thirty_two[31], "the last sub-frame stays put");
+    assert_eq!(two[0], nine[0]);
+    assert_eq!(two[1], nine[8]);
+    assert!(
+        thirty_two[1..31].iter().any(|s| !nine.contains(s)),
+        "more samples land between the old ones"
+    );
+
+    // Out of range rounds and clamps rather than failing.
+    assert_eq!(blurred(&with_samples(1.0)).1, 2);
+    assert_eq!(blurred(&with_samples(500.0)).1, SHAKE_MB_SAMPLES);
+    assert_eq!(blurred(&with_samples(15.6)).1, 16);
+
+    // A shake saved before the row has no `mb_samples` and keeps its nine.
+    let mut old = base.clone();
+    old.params.retain(|p| p.id != "mb_samples");
+    assert_eq!(blurred(&old), (nine, 9));
+}
+
 #[test]
 fn resolve_shake_motion_blur_samples_the_shutter_and_centres_on_the_frame() {
     use effects::shake::Shaken;
@@ -4294,10 +4346,10 @@ fn resolve_shake_motion_blur_samples_the_shutter_and_centres_on_the_frame() {
     // wobble exactly, and the samples actually differ across the shutter.
     let on = shake_with_mb(0.5);
     let packed = shake_packed(&on, 0.4, 1000.0);
-    let Shaken::Blurred { samples, .. } = packed else {
+    let Shaken::Blurred { samples, count, .. } = packed else {
         panic!("motion blur on carries sub-frames");
     };
-    assert_eq!(samples.len(), SHAKE_MB_SAMPLES);
+    assert_eq!(count, crate::fx::SHAKE_MB_DEFAULT_SAMPLES);
     // The frame-time wobble is what the same instance packs to with the smear
     // taken away — the centre sub-frame lands on offset 0, so the two are one
     // sample of one noise curve.
@@ -4310,14 +4362,10 @@ fn resolve_shake_motion_blur_samples_the_shutter_and_centres_on_the_frame() {
     let Shaken::Plain { wobble, .. } = shake_packed(&off_by_hand, 0.4, 1000.0) else {
         panic!("the smear is off now");
     };
-    assert_eq!(
-        samples[SHAKE_MB_SAMPLES / 2],
-        wobble,
-        "centre sample is the frame"
-    );
+    assert_eq!(samples[count / 2], wobble, "centre sample is the frame");
     assert_ne!(
         samples[0].offset_px,
-        samples[SHAKE_MB_SAMPLES - 1].offset_px,
+        samples[count - 1].offset_px,
         "the wobble moves across the shutter"
     );
 
@@ -4533,9 +4581,11 @@ fn shake_packs_the_wobble_the_old_arm_resolved() {
     let Shaken::Blurred { samples, .. } = shake_packed(&e, lt, diag_px) else {
         panic!("the smear is on");
     };
-    for (i, db) in shake_mb_offsets(fl("mb_amount").unwrap())
-        .into_iter()
-        .enumerate()
+    for (i, db) in shake_mb_offsets(
+        fl("mb_amount").unwrap(),
+        crate::fx::SHAKE_MB_DEFAULT_SAMPLES,
+    )
+    .enumerate()
     {
         assert_eq!(samples[i], old(base + db), "sub-frame {i}");
     }

--- a/crates/lumit-gpu/src/fx/stylise.rs
+++ b/crates/lumit-gpu/src/fx/stylise.rs
@@ -243,12 +243,13 @@ struct TransformParams {
     _pad2: f32,
 }
 
-/// The number of Shake motion-blur sub-frame taps (T18): the fixed-size
-/// end of the uniform array and the WGSL kernel's `array<Tap, 9>` / `MAX_TAPS`.
+/// The most Shake motion-blur sub-frame taps (T18): the fixed-size end of the
+/// uniform array and the WGSL kernel's `array<Tap, 64>` / `MAX_TAPS`. The
+/// Samples row picks how many of them are live.
 /// Must equal `lumit_core::fx::SHAKE_MB_SAMPLES` — the GPU crate can't name that
 /// const (lumit-core is a dev-dependency only), so the oracle tests assert the
 /// two agree, and the WGSL literal is kept in step by the same tests.
-pub const SHAKE_MB_SAMPLES: usize = 9;
+pub const SHAKE_MB_SAMPLES: usize = 64;
 
 /// One resolved Shake motion blur (docs/08 §3.4, T18): the shake's own
 /// inter-frame smear. Each tap is a host-computed inverse affine (the same

--- a/crates/lumit-gpu/src/fx/tests.rs
+++ b/crates/lumit-gpu/src/fx/tests.rs
@@ -2218,8 +2218,12 @@ fn wgsl_shake_matches_the_cpu_oracle_through_the_transform_kernel() {
 #[test]
 fn wgsl_shake_motion_blur_matches_the_cpu_oracle() {
     // The GPU crate can't name lumit-core's const (dev-dependency only), so pin
-    // the two — and the WGSL `array<Tap, 9>` literal — in agreement here.
+    // the two — and the WGSL `array<Tap, 64>` literal — in agreement here.
     assert_eq!(SHAKE_MB_SAMPLES, lumit_core::fx::SHAKE_MB_SAMPLES);
+    assert!(
+        include_str!("../fx_shake_mb.wgsl").contains(&format!("array<Tap, {SHAKE_MB_SAMPLES}>")),
+        "the WGSL tap array is sized to SHAKE_MB_SAMPLES"
+    );
 
     let Some(ctx) = crate::test_support::lease() else {
         crate::no_adapter();
@@ -2245,7 +2249,7 @@ fn wgsl_shake_motion_blur_matches_the_cpu_oracle() {
         z_freq: 0.7,
     };
     let base = 2.0f64;
-    let offsets = lumit_core::fx::shake_mb_offsets(0.8);
+    let offsets = lumit_core::fx::shake_mb_offsets(0.8, SHAKE_MB_SAMPLES);
     let mut samples = [lumit_core::fx::ShakeSample::IDENTITY; SHAKE_MB_SAMPLES];
     for (s, db) in samples.iter_mut().zip(offsets) {
         let (offset_px, rotation_deg, zoom) = wobble.at(base + db);

--- a/crates/lumit-gpu/src/fx_shake_mb.wgsl
+++ b/crates/lumit-gpu/src/fx_shake_mb.wgsl
@@ -16,7 +16,7 @@
 
 // Must match lumit_core::fx::SHAKE_MB_SAMPLES (a compile-time assert in
 // stylise.rs pins the two together).
-const MAX_TAPS: u32 = 9u;
+const MAX_TAPS: u32 = 64u;
 
 struct Tap {
     m: vec4<f32>,   // row-major inverse linear 2×2: (m00, m01, m10, m11)
@@ -24,7 +24,7 @@ struct Tap {
 };
 
 struct Params {
-    taps: array<Tap, 9>,
+    taps: array<Tap, 64>,
     count: u32,     // active taps, 1..=MAX_TAPS
     edge: u32,      // 0 transparent, 1 repeat, 2 mirror
     mix_amt: f32,   // 0..1, blended against the unprocessed input

--- a/crates/lumit-render/src/gpufx.rs
+++ b/crates/lumit-render/src/gpufx.rs
@@ -3133,7 +3133,12 @@ impl GpuEffect for Shake {
                     },
                 )
             }
-            Shaken::Blurred { samples, edge, mix } => {
+            Shaken::Blurred {
+                samples,
+                count,
+                edge,
+                mix,
+            } => {
                 let mut taps = [lumit_gpu::fx::ShakeMbTap {
                     m: [1.0, 0.0, 0.0, 1.0],
                     off: [0.0, 0.0],
@@ -3159,7 +3164,7 @@ impl GpuEffect for Shake {
                     aux.matte(),
                     &lumit_gpu::fx::ShakeMbOp {
                         taps,
-                        count: samples.len() as u32,
+                        count: count as u32,
                         edge,
                         mix,
                     },
@@ -7005,10 +7010,11 @@ mod tests {
     ///
     /// Shake is the one migrated effect whose dispatch forks: plain, it is the
     /// Transform kernel; with its own motion blur on, it is the averaging one,
-    /// fed nine affines. Nothing but this test joins the fork to the bag — a
-    /// wrapper that read the sub-frames and still called `transform` would
-    /// render a picture, just not a smeared one — so both modes run end to end
-    /// against the CPU reference, and the two must differ from each other.
+    /// fed one affine per sub-frame. Nothing but this test joins the fork to
+    /// the bag — a wrapper that read the sub-frames and still called
+    /// `transform` would render a picture, just not a smeared one — so both
+    /// modes run end to end against the CPU reference, and the two must differ
+    /// from each other.
     #[test]
     fn shake_renders_through_run_ops_in_both_modes() {
         let Some(ctx) = lumit_gpu::test_support::lease() else {

--- a/docs/08-EFFECTS.md
+++ b/docs/08-EFFECTS.md
@@ -892,6 +892,7 @@ exponentially over Decay seconds, so shakes hit on the beat and settle.
 | *Motion blur* (twirl) | | |
 | — Motion blur | boolean | off |
 | — Shutter | 0–1 | 0.5 |
+| — Samples | 2–64 | 9 |
 | Edges | Transparent / Repeat / Mirror | Mirror |
 | Mode | Continuous / Triggered | Continuous |
 | Trigger source | marker-trigger | comp beat markers |
@@ -911,8 +912,10 @@ the wobble is a pure function of time, so with the toggle on it is sampled at se
 sub-frame placements across the shutter and the resamples are averaged — translation,
 rotation and zoom smear together, along the shake's own inter-frame movement, and only this
 effect's output is affected (not the layer or comp motion blur). The Shutter (0–1) sets how
-far across the shutter window the samples spread; off, or Shutter 0, is the plain single
-resample. This is the streak the S_Shake feature wiggle expressions never had.
+far across the shutter window the samples spread, and Samples (2–64) how many there are: a
+wide amplitude at few samples shows each tap as a ghost, more samples fill the same window
+smoothly. Off, or Shutter 0, is the plain single resample. This is the streak the S_Shake
+feature wiggle expressions never had.
 
 **Status (v1, continuous form, shipped):** Amplitude, Frequency, Rotation amount and
 Rotation frequency, the
@@ -925,10 +928,11 @@ at local time × frequency — deterministic and hop-free per §2.4. Resolved ho
 affine and dispatched through the §3.5 Transform kernel (which now carries the Edges
 policy): no kernel of its own, and the zero-wobble state is a bit-exact passthrough (pinned
 by test). **Motion blur (T18):** with the twirl on, the resolver samples the wobble at
-a fixed, odd number of sub-frame placements (host-side — the noise lattice needs 64-bit
-integers the GPU has not got) and a dedicated averaging kernel resamples the input through
-each and takes the premultiplied-linear mean; off, or Shutter 0, is the exact single
-resample. The shutter window is measured in the shake's own phase (local time × frequency),
+Samples sub-frame placements, 2 to 64 and 9 by default (host-side — the noise lattice needs
+64-bit integers the GPU has not got) and a dedicated averaging kernel resamples the input
+through each and takes the premultiplied-linear mean; off, or Shutter 0, is the exact single
+resample. A shake saved before the Samples row keeps the nine it was made with.
+The shutter window is measured in the shake's own phase (local time × frequency),
 not seconds, so the effect resolver stays frame-rate-agnostic and the smear is frame-rate
 independent. **Migration (FX-11):** this reshape replaced the old Zoom
 pump and Auto-scale bool — a project saved before it maps its Zoom pump to the Z amount, and

--- a/web-docs/src/content/docs/effects/distortion/shake.mdx
+++ b/web-docs/src/content/docs/effects/distortion/shake.mdx
@@ -35,6 +35,7 @@ Wobbles the layer as though the camera were handheld.
 | **Z frequency** | Slider | 0 to 4; higher | 1 | - |
 | **Motion blur** | Checkbox | On or off | Off | - |
 | **Shutter** | Slider | 0 to 1 | 0.5 | - |
+| **Samples** | Slider | 2 to 64 | 9 | - |
 | **Edges** | Dropdown | Transparent · Repeat · Mirror | Mirror | - |
 | **Seed** | Seed | Any whole number | A fresh random seed per instance | - |
 | **Mix** | Slider | 0 to 100 | 100 | Per cent |
@@ -46,7 +47,7 @@ Wobbles the layer as though the camera were handheld.
 In the Effect Controls panel:
 
 - **Per-axis wobble** groups **X amount**, **X frequency**, **Y amount**, **Y frequency**, **Z amount**, **Z frequency**, and starts closed.
-- **Motion blur** groups **Motion blur**, **Shutter**, and starts closed.
+- **Motion blur** groups **Motion blur**, **Shutter**, **Samples**, and starts closed.
 - **Matte** scales the shake's displacement per pixel, read where the pixel lands: white moves it the full Amplitude and Rotation amount, grey less, black leaves it still, so a soft matte turns the shove into a warp. **Invert** reads that matte inverted.
 
 {/* END GENERATED */}
@@ -73,6 +74,8 @@ The **Motion blur** group adds the shake's own smear:
 - **Motion blur**: samples the wobble several times across the shutter and
   averages the results.
 - **Shutter**: how far across the shutter window those samples spread.
+- **Samples**: how many of them there are. A big amplitude at few samples
+  shows each one as a ghost; more samples make a smooth smear at more cost.
 
 ## Related
 


### PR DESCRIPTION
The shake's own motion blur always averaged nine sub-frames, so a big amplitude showed each one as a separate ghost rather than a smear. Samples now picks how many it averages, from 2 to 64. The shutter ends stay where they are, so only the density between them changes.

It defaults to 9, which is what every shake made before this used, and a project saved without the row keeps its nine.

To test, drop a Shake on a layer, turn Amplitude up to around 200, open the Motion blur twirl and turn it on. At Samples 2 you should see the taps separately, and winding it up to 64 should fill them in without the smear getting any longer.

No new strings, Samples was already on the translation page.
