### PR TITLE
Fix OFX at high resolutions and hidden parameters

### DIFF
--- a/crates/lumit-bridge/src/api/effect.rs
+++ b/crates/lumit-bridge/src/api/effect.rs
@@ -1709,6 +1709,11 @@ pub struct BridgeEffectInstanceInfo {
     /// fact about the instance. The two concatenated are what
     /// [`BridgeEffectInstance::list_parameters`] answers in one piece.
     pub derived_params: Vec<BridgeParamInfo>,
+    /// The rows this instance is not showing right now, by id: a plugin's
+    /// own hidden controls, read off its last render (docs/12 §2.2). Empty for
+    /// every built-in. Here for the same reason as the rest: the panel draws
+    /// on every rebuild and may not call.
+    pub hidden_rows: Vec<String>,
 }
 
 /// Every value [`BridgeEffectInstanceInfo::badge_reason`] can take.
@@ -2106,7 +2111,21 @@ pub(crate) fn read_instance_info(
         badge_reason,
         badge_detail,
         derived_params: derived_params_of(effect),
+        hidden_rows: hidden_rows_of(effect),
     }
+}
+
+/// The rows the instance's plugin is hiding, or nothing for a built-in.
+#[frb(ignore)]
+fn hidden_rows_of(effect: &EffectInstance) -> Vec<String> {
+    lumit_core::fx::def(effect.effect.match_name.as_str())
+        .map(|def| {
+            def.hidden_rows(effect)
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 impl BridgeEffectInstance {

--- a/crates/lumit-bridge/src/api/tests.rs
+++ b/crates/lumit-bridge/src/api/tests.rs
@@ -11515,6 +11515,7 @@ fn pressing_a_plugins_button_writes_what_it_did_into_the_document() {
             lumit_ofx::Rendering {
                 frame: source,
                 error: None,
+                secret: None,
             }
         }
 
@@ -11857,11 +11858,13 @@ fn a_plugin_that_fails_a_frame_badges_its_layer_and_the_next_frame_clears_it() {
                 return lumit_ofx::Rendering {
                     frame: source,
                     error: Some(self.why.clone()),
+                    secret: None,
                 };
             }
             lumit_ofx::Rendering {
                 frame: source,
                 error: None,
+                secret: None,
             }
         }
 

--- a/crates/lumit-bridge/src/frb_generated.rs
+++ b/crates/lumit-bridge/src/frb_generated.rs
@@ -14392,6 +14392,7 @@ impl SseDecode for crate::api::effect::BridgeEffectInstanceInfo {
         let mut var_badgeDetail = <Option<String>>::sse_decode(deserializer);
         let mut var_derivedParams =
             <Vec<crate::api::effect::BridgeParamInfo>>::sse_decode(deserializer);
+        let mut var_hiddenRows = <Vec<String>>::sse_decode(deserializer);
         return crate::api::effect::BridgeEffectInstanceInfo {
             id: var_id,
             name: var_name,
@@ -14402,6 +14403,7 @@ impl SseDecode for crate::api::effect::BridgeEffectInstanceInfo {
             badge_reason: var_badgeReason,
             badge_detail: var_badgeDetail,
             derived_params: var_derivedParams,
+            hidden_rows: var_hiddenRows,
         };
     }
 }
@@ -19966,6 +19968,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::effect::BridgeEffectInstanceI
             self.badge_reason.into_into_dart().into_dart(),
             self.badge_detail.into_into_dart().into_dart(),
             self.derived_params.into_into_dart().into_dart(),
+            self.hidden_rows.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -24056,6 +24059,7 @@ impl SseEncode for crate::api::effect::BridgeEffectInstanceInfo {
         <Option<String>>::sse_encode(self.badge_reason, serializer);
         <Option<String>>::sse_encode(self.badge_detail, serializer);
         <Vec<crate::api::effect::BridgeParamInfo>>::sse_encode(self.derived_params, serializer);
+        <Vec<String>>::sse_encode(self.hidden_rows, serializer);
     }
 }
 

--- a/crates/lumit-core/src/fx/registry.rs
+++ b/crates/lumit-core/src/fx/registry.rs
@@ -318,6 +318,16 @@ pub trait EffectDef: Sync + Send + 'static {
         &[]
     }
 
+    /// The rows **this instance** is not showing right now, by id.
+    ///
+    /// Empty for every built-in, whose conditional rows are declared on the
+    /// schema (`visible_when`). A plugin hides and shows its own controls
+    /// from inside its code, so the answer is a fact about the instance, read
+    /// off its last render, and the panel skips these rows.
+    fn hidden_rows(&self, _inst: &EffectInstance) -> Vec<&'static str> {
+        Vec::new()
+    }
+
     /// Whether this effect has an image operation at all. `false` for the
     /// orchestration-only effects, which the render path skips and the
     /// registry-agreement test excuses from needing a GPU entry.

--- a/crates/lumit-ofx-broker/src/main.rs
+++ b/crates/lumit-ofx-broker/src/main.rs
@@ -315,8 +315,13 @@ impl Session {
 
         let rendered =
             render_with_prefetch(plugin, &live.instance, &request, &token, &mut prefetch);
-        let (frame, frames_needed, identity_of) = match rendered {
-            Ok(rendered) => (rendered.frame, rendered.frames_needed, rendered.identity_of),
+        let (frame, frames_needed, identity_of, secret) = match rendered {
+            Ok(rendered) => (
+                rendered.frame,
+                rendered.frames_needed,
+                rendered.identity_of,
+                rendered.secret,
+            ),
             Err(error) => return self.failed("render", &error.to_string()),
         };
 
@@ -331,6 +336,7 @@ impl Session {
             slot: output,
             frames_needed,
             identity_of,
+            secret,
         })
     }
 

--- a/crates/lumit-ofx-broker/tests/broker.rs
+++ b/crates/lumit-ofx-broker/tests/broker.rs
@@ -458,3 +458,41 @@ fn a_press_comes_back_with_what_the_plugin_wrote() {
         "a press that came back is not a strike"
     );
 }
+
+/// The ring is built for the scan's frame size. A bigger frame regrows it
+/// before the render rather than failing with "does not fit a ring slot",
+/// which is what a 3840 by 1620 clip in a 1080p comp reported.
+#[test]
+fn a_frame_bigger_than_the_ring_regrows_it() {
+    let Ok(root) = tempfile::tempdir() else {
+        return;
+    };
+    let Some((mut broker, plugin)) = a_broker(root.path(), &[]) else {
+        skipped("a_frame_bigger_than_the_ring_regrows_it");
+        return;
+    };
+    let instance = broker
+        .create_instance(plugin, Context::Filter, ParamSnapshot::new())
+        .expect("an instance");
+
+    let (width, height) = (FRAME.0 * 4, FRAME.1 * 3);
+    let pixels = vec![0.5_f32; width * height * 4];
+    let big = Frame16::from_f32(width, height, &pixels).expect("a frame");
+    let rendered = broker
+        .render(instance, &RenderRequest::filter(0.0, big), &|_, _| None)
+        .expect("the ring grew to fit");
+    assert!(!rendered.errored, "{:?}", rendered.error);
+    assert_eq!(rendered.frame.width(), width);
+    assert!((first(&rendered.frame) - 0.5).abs() < 1e-2);
+
+    // The small frame still fits the bigger ring.
+    let rendered = broker
+        .render(
+            instance,
+            &RenderRequest::filter(1.0, a_flat_frame(0.25)),
+            &|_, _| None,
+        )
+        .expect("a frame back");
+    assert!(!rendered.errored, "{:?}", rendered.error);
+    assert!((first(&rendered.frame) - 0.25).abs() < 1e-2);
+}

--- a/crates/lumit-ofx/src/def.rs
+++ b/crates/lumit-ofx/src/def.rs
@@ -44,12 +44,13 @@
 //! rather than the string, so a plugin's path parameter keeps whatever the
 //! plugin defaulted it to until the panel path that edits one lands.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use lumit_core::anim::{Animation, Property};
 use lumit_core::fx::{
     EffectDef, EffectSchema, ParamId, Params, PressFrame, Pressed, ResolveCx, Value,
 };
@@ -75,6 +76,9 @@ pub struct Rendering {
     pub frame: Frame16,
     /// What went wrong, in a sentence, or `None` when nothing did.
     pub error: Option<String>,
+    /// The controls the plugin is hiding after this render, by parameter
+    /// name, or `None` when no render happened to ask.
+    pub secret: Option<BTreeSet<String>>,
 }
 
 /// Where a plugin effect's frames actually come from.
@@ -152,6 +156,17 @@ thread_local! {
 pub struct OfxEffectDef {
     schema: &'static EffectSchema,
     routes: Vec<ValueRoute>,
+    /// One bag id per route, set by [`EffectDef::resolve_derived`] while that
+    /// row is keyframed or driven by an expression, so the snapshot can say
+    /// which values are the playhead's rather than a person's.
+    quiet_ids: Vec<ParamId>,
+    /// The rows hidden before any render has said otherwise: the describe-time
+    /// secret flags, through the same groups and pages a live answer goes
+    /// through.
+    initial_hidden: Vec<&'static str>,
+    /// Each parameter's group or page, by name, so a hidden group hides its
+    /// rows.
+    owners: BTreeMap<String, String>,
     /// The values the plugin declared, which is what a row Lumit cannot carry
     /// (a path, a vendor blob) keeps.
     defaults: ParamSnapshot,
@@ -171,9 +186,20 @@ impl OfxEffectDef {
         schema: &'static EffectSchema,
         host: Arc<dyn PluginHost>,
     ) -> Self {
+        let routes = value_routes(descriptor);
+        let quiet_ids = routes
+            .iter()
+            .map(|route| ParamId::new(&format!("derived.quiet.{}", route.row)))
+            .collect();
+        let owners = crate::schema::owner_names(descriptor);
+        let initial_hidden =
+            hidden_rows_of(&routes, &owners, &crate::schema::secret_names(descriptor));
         Self {
             schema,
-            routes: value_routes(descriptor),
+            routes,
+            quiet_ids,
+            initial_hidden,
+            owners,
             defaults: ParamSnapshot::from_defaults(descriptor),
             host,
         }
@@ -194,7 +220,13 @@ impl OfxEffectDef {
 
     /// The bag, as the values the plugin reads.
     fn snapshot(&self, p: Params<'_>) -> ParamSnapshot {
-        self.assemble(|route| p.get(route.id))
+        let mut snapshot = self.assemble(|route| p.get(route.id));
+        for (route, id) in self.routes.iter().zip(&self.quiet_ids) {
+            if p.get(*id) == Some(Value::Bool(true)) {
+                snapshot.quiet.insert(route.name.clone());
+            }
+        }
+        snapshot
     }
 
     /// The document's own rows at `lt`, with the plugin's memory laid over
@@ -415,6 +447,40 @@ fn remember(inst: &EffectInstance) -> i32 {
     hash as i32
 }
 
+/// The rows each instance's plugin is hiding, as its last render reported.
+/// An instance with no entry is at `OfxEffectDef::initial_hidden`.
+// ponytail: never pruned, a few strings per instance the document has ever
+// rendered; prune with the memory table if it ever shows.
+static HIDDEN: Mutex<BTreeMap<Uuid, Vec<&'static str>>> = Mutex::new(BTreeMap::new());
+
+/// The rows hidden when these parameters are secret: the row's own parameter,
+/// or any group or page above it.
+fn hidden_rows_of(
+    routes: &[ValueRoute],
+    owners: &BTreeMap<String, String>,
+    secret: &BTreeSet<String>,
+) -> Vec<&'static str> {
+    let hidden = |name: &str| {
+        let mut name = name;
+        // Bounded, so a plugin whose groups name each other cannot spin.
+        for _ in 0..16 {
+            if secret.contains(name) {
+                return true;
+            }
+            match owners.get(name) {
+                Some(parent) => name = parent,
+                None => return false,
+            }
+        }
+        false
+    };
+    routes
+        .iter()
+        .filter(|route| hidden(&route.name))
+        .map(|route| route.row)
+        .collect()
+}
+
 /// Lay a plugin's memory over a snapshot.
 fn recall(snapshot: &mut ParamSnapshot, memory: &ParamSnapshot) {
     for (name, value) in memory.iter() {
@@ -506,6 +572,11 @@ impl EffectDef for OfxEffectDef {
             .render(inst, frame_in_bag(p, lt), &snapshot, source, &frames);
         let failed = rendered.error.is_some();
         LAST_ERROR.with(|slot| *slot.borrow_mut() = rendered.error);
+        if let Some(secret) = &rendered.secret {
+            HIDDEN
+                .lock()
+                .insert(inst, hidden_rows_of(&self.routes, &self.owners, secret));
+        }
         if failed {
             // **Identity, byte for byte**. A failed render hands back the
             // input, and the input is already in `rgba` — writing it again
@@ -532,6 +603,14 @@ impl EffectDef for OfxEffectDef {
         LAST_ERROR.with(|slot| slot.borrow_mut().take())
     }
 
+    fn hidden_rows(&self, inst: &EffectInstance) -> Vec<&'static str> {
+        HIDDEN
+            .lock()
+            .get(&inst.id)
+            .cloned()
+            .unwrap_or_else(|| self.initial_hidden.clone())
+    }
+
     /// The plugin's memory reaches the render from here: this is the one hook
     /// that sees the document's instance every frame, so it files the memory
     /// for `apply_cpu_temporal` and puts its hash in the bag for the frame key.
@@ -546,6 +625,17 @@ impl EffectDef for OfxEffectDef {
             .map(|comp| comp.frame_rate.fps());
         if let Some(fps) = fps {
             push(DERIVED_FRAME, Value::Int((cx.lt * fps).round() as i32));
+        }
+        for (route, id) in self.routes.iter().zip(&self.quiet_ids) {
+            let moving = cx
+                .inst
+                .params
+                .iter()
+                .find(|param| param.id == route.row)
+                .is_some_and(|param| moves(&param.value));
+            if moving {
+                push(*id, Value::Bool(true));
+            }
         }
     }
 
@@ -572,6 +662,18 @@ impl EffectDef for OfxEffectDef {
 }
 
 // ----------------------------------------------------------- the two hosts --
+
+/// Whether a row's value changes with time on its own: keyframes or an
+/// expression on any of its properties.
+fn moves(value: &EffectValue) -> bool {
+    let moving = |property: &Property| !matches!(property.animation, Animation::Static(_));
+    match value {
+        EffectValue::Float(property) => moving(property),
+        EffectValue::Point(x, y) => moving(x) || moving(y),
+        EffectValue::Colour(channels) => channels.iter().any(moving),
+        _ => false,
+    }
+}
 
 /// The frame offsets an OFX absolute frame range comes to, relative to `time`.
 ///
@@ -642,7 +744,7 @@ impl LocalHost {
         &self,
         instance: Uuid,
         request: &RenderRequest,
-        params: &ParamSnapshot,
+        params: Option<&ParamSnapshot>,
     ) -> Result<Rendered, String> {
         self.with_instance(instance, params, |plugin, live| {
             let token = lumit_eval::epoch::Epoch::new().token();
@@ -652,10 +754,13 @@ impl LocalHost {
 
     /// The plugin and the live instance, made on first use and holding
     /// `params`, handed to `call`.
+    /// `None` leaves the values as they are: a question about frames, not a
+    /// render, and handing the defaults over would tell the plugin every
+    /// value had changed and then changed back.
     fn with_instance<T>(
         &self,
         instance: Uuid,
-        params: &ParamSnapshot,
+        params: Option<&ParamSnapshot>,
         call: impl FnOnce(&PluginRef, &Instance) -> Result<T, String>,
     ) -> Result<T, String> {
         let plugin = self
@@ -671,15 +776,23 @@ impl LocalHost {
         // the plugin, which is docs/14 §7's rule.
         let mut pool = self.instances.lock();
         if let std::collections::btree_map::Entry::Vacant(slot) = pool.entry(instance) {
-            let made = Instance::create(plugin, &self.descriptor, self.context, params)
-                .map_err(|status| format!("the plugin refused an instance ({status:?})"))?;
+            let empty = ParamSnapshot::new();
+            let made = Instance::create(
+                plugin,
+                &self.descriptor,
+                self.context,
+                params.unwrap_or(&empty),
+            )
+            .map_err(|status| format!("the plugin refused an instance ({status:?})"))?;
             slot.insert(made);
         }
         let live = pool
             .get(&instance)
             .ok_or_else(|| "the instance vanished".to_owned())?;
-        live.set_params(params.clone())
-            .map_err(|status| format!("the values would not go in ({status:?})"))?;
+        if let Some(params) = params {
+            live.set_params(params.clone())
+                .map_err(|status| format!("the values would not go in ({status:?})"))?;
+        }
         call(plugin, live)
     }
 }
@@ -695,25 +808,32 @@ impl PluginHost for LocalHost {
     ) -> Rendering {
         let mut request = RenderRequest::filter(time, source.clone());
         request.neighbours = neighbours.to_vec();
-        match self.attempt(instance, &request, params) {
+        match self.attempt(instance, &request, Some(params)) {
             Ok(rendered) => Rendering {
                 frame: rendered.frame,
                 error: None,
+                secret: Some(rendered.secret),
             },
             Err(why) => Rendering {
                 frame: source,
                 error: Some(why),
+                secret: None,
             },
         }
     }
 
-    fn frames_needed(&self, instance: Uuid, time: f64, params: &ParamSnapshot) -> Option<Vec<i32>> {
+    fn frames_needed(
+        &self,
+        instance: Uuid,
+        time: f64,
+        _params: &ParamSnapshot,
+    ) -> Option<Vec<i32>> {
         // A one-pixel frame: the question is which *times* the plugin wants, and
         // it is answered before any picture is looked at. The pixels that come
         // back are thrown away.
         let source = Frame16::black(1, 1).ok()?;
         let request = RenderRequest::filter(time, source);
-        let rendered = self.attempt(instance, &request, params).ok()?;
+        let rendered = self.attempt(instance, &request, None).ok()?;
         offsets_of(&rendered.frames_needed, time)
     }
 
@@ -725,7 +845,7 @@ impl PluginHost for LocalHost {
         name: &str,
         source: Frame16,
     ) -> Result<ParamSnapshot, String> {
-        self.with_instance(instance, params, |plugin, live| {
+        self.with_instance(instance, Some(params), |plugin, live| {
             live.press(plugin, name, time, &source)
                 .map_err(|status| format!("the plugin refused the press ({status:?})"))
         })
@@ -851,12 +971,14 @@ impl PluginHost for BrokerHost {
             return Rendering {
                 frame: source,
                 error: Some(BUSY.to_owned()),
+                secret: None,
             };
         };
         let Some(id) = self.instance_of(&mut broker, instance, params) else {
             return Rendering {
                 frame: source,
                 error: Some("the plugin would not make an instance".to_owned()),
+                secret: None,
             };
         };
         let _ = broker.set_params(id, params.clone());
@@ -873,10 +995,12 @@ impl PluginHost for BrokerHost {
             Ok(answer) => Rendering {
                 frame: answer.frame,
                 error: answer.error,
+                secret: answer.secret,
             },
             Err(error) => Rendering {
                 frame: source,
                 error: Some(error.to_string()),
+                secret: None,
             },
         }
     }

--- a/crates/lumit-ofx/src/discover.rs
+++ b/crates/lumit-ofx/src/discover.rs
@@ -54,13 +54,10 @@ use crate::schema::schema_of;
 /// The frame size the shared-memory ring is built for when a bundle's broker is
 /// spawned at scan time.
 ///
-/// The ring is sized **once per broker** (docs/impl/ofx-host.md §4) and the scan
-/// happens before any composition is open, so there is no comp size to size it
-/// from. 1080p is the honest guess: it is the commonest delivery and it leaves
-/// the ring fifteen slots deep.
-// ponytail: a 4K comp then renders through a three-slot ring, which the note
-// already names as the floor. The upgrade is a broker respawned at the comp's
-// size when the first frame is asked for, not a different design.
+/// The scan happens before any composition is open, so there is no comp size
+/// to size the ring from. 1080p is the honest guess: it is the commonest
+/// delivery and it leaves the ring fifteen slots deep. The first bigger frame
+/// regrows it (docs/impl/ofx-host.md §4).
 pub const SCAN_FRAME: (usize, usize) = (1920, 1080);
 
 /// Which side of a process boundary a discovered plugin runs on.
@@ -206,6 +203,7 @@ impl PluginHost for Gated {
             return Rendering {
                 frame: source,
                 error: Some(DISABLED_REASON.to_owned()),
+                secret: None,
             };
         }
         self.inner.render(inst, time, params, source, neighbours)
@@ -363,6 +361,7 @@ impl PluginHost for Absent {
     ) -> Rendering {
         Rendering {
             frame: source,
+            secret: None,
             error: Some("the plugin's bundle could not be opened".to_owned()),
         }
     }

--- a/crates/lumit-ofx/src/ffi.rs
+++ b/crates/lumit-ofx/src/ffi.rs
@@ -608,6 +608,7 @@ pub mod prop_keys {
     pub const PARAM_HINT: &str = "OfxParamPropHint";
     pub const PARAM_ANIMATES: &str = "OfxParamPropAnimates";
     pub const PARAM_GROUP_OPEN: &str = "OfxParamPropGroupOpen";
+    pub const PARAM_SECRET: &str = "OfxParamPropSecret";
 
     pub const CLIP_OPTIONAL: &str = "OfxImageClipPropOptional";
     pub const CLIP_IS_MASK: &str = "OfxImageClipPropIsMask";

--- a/crates/lumit-ofx/src/instance.rs
+++ b/crates/lumit-ofx/src/instance.rs
@@ -32,7 +32,7 @@
 //! Claiming more safety than it has is the plugin's bug, but obeying a claim of
 //! less is the host's job, and docs/12 §2.3 spells out all three answers.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -149,6 +149,12 @@ pub(crate) enum HeldGuard<'a> {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ParamSnapshot {
     values: BTreeMap<String, PropValue>,
+    /// The controls whose value moves with time, by keyframes or an
+    /// expression. A change in one of these is the playhead, not a person, so
+    /// the plugin is not told and reads it at `paramGetValue`, which is what
+    /// every other host does with an animated control.
+    #[serde(default)]
+    pub quiet: BTreeSet<String>,
 }
 
 impl ParamSnapshot {
@@ -168,7 +174,10 @@ impl ParamSnapshot {
                 values.insert(param.name.clone(), default.clone());
             }
         }
-        Self { values }
+        Self {
+            values,
+            quiet: BTreeSet::new(),
+        }
     }
 
     /// Set one control's value, replacing whatever was there.
@@ -201,6 +210,12 @@ pub struct InstanceState {
     pub context: Context,
     /// What every control reads.
     pub params: ParamSnapshot,
+    /// What the host last handed over. A value that differs from this next
+    /// time is one the host changed, and the plugin is told so; a value that
+    /// matches leaves whatever the plugin itself wrote in [`Self::params`].
+    pub sent: ParamSnapshot,
+    /// The controls the host changed since the plugin was last told.
+    pub pending: Vec<String>,
     /// What the plugin said about running two renders at once.
     pub thread_safety: ThreadSafety,
     /// The pictures for the render **currently in flight**, by clip name.
@@ -224,6 +239,21 @@ pub struct InstanceState {
     pub lock: Arc<Mutex<()>>,
 }
 
+impl InstanceState {
+    /// Take the host's values, and note which ones it changed.
+    fn absorb(&mut self, params: &ParamSnapshot) {
+        for (name, value) in params.iter() {
+            if self.sent.get(name) != Some(value) {
+                self.params.set(name, value.clone());
+                self.sent.set(name, value.clone());
+                if !params.quiet.contains(name) {
+                    self.pending.push(name.clone());
+                }
+            }
+        }
+    }
+}
+
 /// One live instance of one plugin.
 ///
 /// Destroying it is [`Instance::destroy`] and not a `Drop`: the plugin has to
@@ -241,9 +271,11 @@ impl Instance {
     ///
     /// The order here is the order in the module note: property sets, then
     /// parameters at their defaults, then clips, then the action. `values`
-    /// overrides the defaults for the controls the host has values for, and is
-    /// applied **before** `kOfxActionCreateInstance` so the plugin's first read
-    /// is the real number.
+    /// goes in straight after `kOfxActionCreateInstance` and is told to the
+    /// plugin before its first render ([`Instance::tell_changes`]), which is
+    /// how Resolve restores a saved project. It is not in place for the create
+    /// action on purpose: spektrafilm ignores a change to a value it was
+    /// created with, so a stock saved in a project rendered as the default.
     ///
     /// # Errors
     ///
@@ -267,16 +299,11 @@ impl Instance {
         seed_instance_properties(&mut props, descriptor, context, thread_safety);
         let handle = new_descriptor(props)?;
 
-        let mut snapshot = ParamSnapshot::from_defaults(descriptor);
-        for param in &descriptor.params {
-            if let Some(value) = values.get(&param.name) {
-                snapshot.set(&param.name, value.clone());
-            }
-        }
+        let defaults = ParamSnapshot::from_defaults(descriptor);
 
         // Everything below can fail, and a half-built instance must not be left
         // in the registry, so the one failure path releases it.
-        let built = build(handle, descriptor, context, snapshot, thread_safety);
+        let built = build(handle, descriptor, context, defaults, thread_safety);
         if built.is_err() {
             release_descriptor(handle);
         }
@@ -286,6 +313,9 @@ impl Instance {
         if !matches!(status, Status::Ok | Status::ReplyDefault) {
             release_descriptor(handle);
             return Err(status);
+        }
+        if let Some(instance) = state().effects.get_mut(handle)?.instance.as_mut() {
+            instance.absorb(values);
         }
         Ok(Self {
             handle,
@@ -311,16 +341,24 @@ impl Instance {
         render_lock(self.thread_safety, &self.lock)
     }
 
-    /// Replace every control's value **without** telling the plugin.
+    /// Take the host's values, and note which ones it changed.
     ///
-    /// This is a scrub, an undo, or a keyframe moving under a playhead: the
-    /// values are the host's and the plugin reads them at its next
-    /// `paramGetValue` (docs/12 §2.2). `kOfxActionInstanceChanged` is for a
-    /// person turning a knob, which is [`Instance::changed`].
+    /// The values are the host's and the plugin reads them at its next
+    /// `paramGetValue` (docs/12 §2.2). The plugin is not told here, because
+    /// this is called with a render about to start and
+    /// `kOfxActionInstanceChanged` may not happen inside one; the render
+    /// driver tells it first thing ([`Instance::tell_changes`]). A value the
+    /// host has not changed since last time is left as the plugin holds it,
+    /// so what a plugin writes into its own controls from `instanceChanged`
+    /// (spektrafilm sets its film profile from its stock choice) stays until
+    /// the host has something new to say.
     ///
     /// # Errors
     ///
     /// [`Status::ErrBadHandle`] if the instance is gone.
+    // ponytail: a keyframed control changes every frame and is told every
+    // frame; telling animated rows apart is the upgrade if a plugin is slow
+    // in instanceChanged.
     pub fn set_params(&self, params: ParamSnapshot) -> Result<(), Status> {
         let mut state = state();
         let instance = state
@@ -329,8 +367,54 @@ impl Instance {
             .instance
             .as_mut()
             .ok_or(Status::ErrBadHandle)?;
-        instance.params = params;
+        instance.absorb(&params);
         Ok(())
+    }
+
+    /// The controls the plugin is hiding right now: every parameter, groups
+    /// and pages included, whose secret flag it has set on the live instance.
+    /// A plugin shows and hides rows from inside `instanceChanged`, so this is
+    /// read after every render and the panel follows it.
+    ///
+    /// # Errors
+    ///
+    /// [`Status::ErrBadHandle`] if the instance is gone.
+    pub fn secret_names(&self) -> Result<BTreeSet<String>, Status> {
+        let state = state();
+        let effect = state.effects.get(self.handle)?;
+        let mut names = BTreeSet::new();
+        for param in &effect.params {
+            if state.props.get(param.props)?.get_int(keys::PARAM_SECRET, 0) == Ok(1) {
+                names.insert(param.name.clone());
+            }
+        }
+        Ok(names)
+    }
+
+    /// Tell the plugin about every control the host changed since it was last
+    /// told, in one `kOfxActionBeginInstanceChanged` to
+    /// `kOfxActionEndInstanceChanged` bracket. Called by the render driver
+    /// before its first question, with the pictures already staged, so the
+    /// plugin may read its clip while it reacts.
+    ///
+    /// # Errors
+    ///
+    /// The plugin's own failure status; the values stand either way.
+    pub fn tell_changes(&self, plugin: &PluginRef, time: f64) -> Result<(), Status> {
+        let pending = {
+            let mut state = state();
+            let instance = state
+                .effects
+                .get_mut(self.handle)?
+                .instance
+                .as_mut()
+                .ok_or(Status::ErrBadHandle)?;
+            std::mem::take(&mut instance.pending)
+        };
+        if pending.is_empty() {
+            return Ok(());
+        }
+        self.notify(plugin, &pending, values::CHANGE_USER_EDITED, time)
     }
 
     /// Every control's value as the plugin last left it. After a press this is
@@ -377,55 +461,64 @@ impl Instance {
                 .instance
                 .as_mut()
                 .ok_or(Status::ErrBadHandle)?;
-            instance.params.set(name, value);
+            instance.params.set(name, value.clone());
+            instance.sent.set(name, value);
         }
+        self.notify(plugin, &[name.to_owned()], reason, time)
+    }
 
+    /// The bracket itself: begin, one `kOfxActionInstanceChanged` per name,
+    /// end.
+    fn notify(
+        &self,
+        plugin: &PluginRef,
+        names: &[String],
+        reason: &str,
+        time: f64,
+    ) -> Result<(), Status> {
         let mut wrapper = PropertySet::new();
         if let Ok(reason) = PropValue::string(reason) {
             wrapper.seed(keys::CHANGE_REASON, reason);
         }
         let wrapper = state().props.insert(wrapper)?;
 
-        let mut in_args = PropertySet::new();
-        if let Ok(kind) = PropValue::string(values::TYPE_PARAMETER) {
-            in_args.seed(keys::TYPE, kind);
-        }
-        if let Ok(name) = PropValue::string(name) {
-            in_args.seed(keys::NAME, name);
-        }
-        if let Ok(reason) = PropValue::string(reason) {
-            in_args.seed(keys::CHANGE_REASON, reason);
-        }
-        in_args.seed(keys::TIME, PropValue::double(time));
-        in_args.seed(keys::RENDER_SCALE, PropValue::Double(vec![1.0, 1.0]));
-        let in_args = state().props.insert(in_args)?;
-
-        let begin = plugin.action(
+        let mut statuses = vec![plugin.action(
             actions::BEGIN_INSTANCE_CHANGED,
             Some(self.handle),
             Some(wrapper),
             None,
-        );
-        let changed = plugin.action(
-            actions::INSTANCE_CHANGED,
-            Some(self.handle),
-            Some(in_args),
-            None,
-        );
-        let end = plugin.action(
+        )];
+        for name in names {
+            let mut in_args = PropertySet::new();
+            if let Ok(kind) = PropValue::string(values::TYPE_PARAMETER) {
+                in_args.seed(keys::TYPE, kind);
+            }
+            if let Ok(name) = PropValue::string(name) {
+                in_args.seed(keys::NAME, name);
+            }
+            if let Ok(reason) = PropValue::string(reason) {
+                in_args.seed(keys::CHANGE_REASON, reason);
+            }
+            in_args.seed(keys::TIME, PropValue::double(time));
+            in_args.seed(keys::RENDER_SCALE, PropValue::Double(vec![1.0, 1.0]));
+            let in_args = state().props.insert(in_args)?;
+            statuses.push(plugin.action(
+                actions::INSTANCE_CHANGED,
+                Some(self.handle),
+                Some(in_args),
+                None,
+            ));
+            let _ = state().props.remove(in_args);
+        }
+        statuses.push(plugin.action(
             actions::END_INSTANCE_CHANGED,
             Some(self.handle),
             Some(wrapper),
             None,
-        );
+        ));
+        let _ = state().props.remove(wrapper);
 
-        {
-            let mut state = state();
-            let _ = state.props.remove(in_args);
-            let _ = state.props.remove(wrapper);
-        }
-
-        for status in [begin, changed, end] {
+        for status in statuses {
             if !matches!(status, Status::Ok | Status::ReplyDefault) {
                 return Err(status);
             }
@@ -479,6 +572,14 @@ impl Instance {
         // Off again whatever the plugin did, so the next render starts clean.
         let _ = take_images(self.handle);
         outcome?;
+        // What the plugin wrote goes back to the document, which will hand it
+        // over again next frame; that is not a change to tell it about.
+        {
+            let mut state = state();
+            if let Some(instance) = state.effects.get_mut(self.handle)?.instance.as_mut() {
+                instance.sent = instance.params.clone();
+            }
+        }
         self.params()
     }
 
@@ -548,6 +649,8 @@ fn build(
 
     state.effects.get_mut(handle)?.instance = Some(InstanceState {
         context,
+        sent: params.clone(),
+        pending: Vec::new(),
         params,
         thread_safety,
         images: BTreeMap::new(),

--- a/crates/lumit-ofx/src/ipc/broker.rs
+++ b/crates/lumit-ofx/src/ipc/broker.rs
@@ -33,7 +33,7 @@
 //! back as its own input, with `errored` set, and the caller puts a calm badge
 //! on the layer.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -51,7 +51,7 @@ use crate::ipc::pipe::{self, PipeError};
 use crate::ipc::proto::{
     BrokerMessage, FrameRef, FrameWanted, HostMessage, InstanceId, Slot, PROTOCOL_VERSION,
 };
-use crate::ipc::shm::{Ring, ShmError};
+use crate::ipc::shm::{slot_bytes_for, Ring, ShmError};
 use crate::quirks::Quirks;
 use crate::render::{RenderRequest, SOURCE_CLIP};
 
@@ -190,8 +190,8 @@ pub struct BrokerConfig {
     pub bundle: PathBuf,
     /// The deadlines and workarounds for this bundle.
     pub quirks: Quirks,
-    /// The comp's frame size. The ring is sized from this **once**, when the
-    /// broker is spawned, and never again.
+    /// The frame size the ring starts at. A bigger frame regrows the ring
+    /// when it arrives ([`Broker::fit`]).
     pub frame: (usize, usize),
     /// Where the broker executable is, if not beside Lumit's own.
     pub exe: Option<PathBuf>,
@@ -238,6 +238,9 @@ pub struct BrokerRender {
     pub frames_needed: BTreeMap<String, (f64, f64)>,
     /// The clip the plugin said this frame simply is, if it said so.
     pub identity_of: Option<String>,
+    /// The controls the plugin is hiding after this render, or `None` when
+    /// no render happened to ask.
+    pub secret: Option<BTreeSet<String>>,
 }
 
 /// The live connection to one broker process.
@@ -276,6 +279,22 @@ pub struct Broker {
 /// A counter, so two brokers in one process never pick the same pipe name.
 static PIPE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// A name no other pipe or ring in this process has had.
+fn fresh_identifier() -> String {
+    format!(
+        "{}-{}",
+        std::process::id(),
+        PIPE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Where the ring with this name lives.
+fn ring_path(identifier: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("lumit-ofx-{identifier}.ring"));
+    path
+}
+
 impl Broker {
     /// Start a broker for one bundle, and describe what is in it.
     ///
@@ -284,14 +303,8 @@ impl Broker {
     /// [`BrokerError`] — the executable, the pipe, the ring, or a broker that
     /// speaks another protocol.
     pub fn spawn(config: BrokerConfig) -> Result<Self, BrokerError> {
-        let identifier = format!(
-            "{}-{}",
-            std::process::id(),
-            PIPE_COUNTER.fetch_add(1, Ordering::Relaxed)
-        );
-        let mut ring_path = std::env::temp_dir();
-        ring_path.push(format!("lumit-ofx-{identifier}.ring"));
-        let ring = Ring::create(&ring_path, config.frame.0, config.frame.1)?;
+        let identifier = fresh_identifier();
+        let ring = Ring::create(&ring_path(&identifier), config.frame.0, config.frame.1)?;
 
         let mut broker = Self {
             config,
@@ -500,6 +513,7 @@ impl Broker {
             i32::try_from(source.width()).unwrap_or(0),
             i32::try_from(source.height()).unwrap_or(0),
         );
+        self.fit(source.width(), source.height())?;
         let slot = self.take_slot();
         self.ring.write_frame(slot, source, bounds, true)?;
         let message = HostMessage::Press {
@@ -558,6 +572,7 @@ impl Broker {
         if self.disabled {
             return Ok(errored(identity, "the plugin is disabled for this session"));
         }
+        self.fit(request.bounds.width(), request.bounds.height())?;
 
         // Every input, plus one for the answer. The slots are taken before the
         // message goes out, because the message names them.
@@ -604,6 +619,7 @@ impl Broker {
                 slot,
                 frames_needed,
                 identity_of,
+                secret,
             }) => {
                 let (_, frame) = self.ring.read_frame(slot)?;
                 Ok(BrokerRender {
@@ -612,6 +628,7 @@ impl Broker {
                     error: None,
                     frames_needed,
                     identity_of,
+                    secret: Some(secret),
                 })
             }
             Ok(_) => Ok(errored(identity, "the broker answered out of turn")),
@@ -804,6 +821,21 @@ impl Broker {
         }
     }
 
+    /// Make room for a frame of this size. The ring is built for the scan's
+    /// 1080p, and the first 4K layer, or a 3840 by 1620 clip in a 1080p comp,
+    /// is bigger than a slot. A new ring at the bigger size replaces it, and
+    /// the broker is handed the new one the way it was handed the first. Only
+    /// ever called between renders, when neither side is reading a slot.
+    fn fit(&mut self, width: usize, height: usize) -> Result<(), BrokerError> {
+        if slot_bytes_for(width, height) <= self.ring.spec().slot_bytes {
+            return Ok(());
+        }
+        self.ring = Ring::create(&ring_path(&fresh_identifier()), width, height)?;
+        self.next_slot = 0;
+        let spec = self.ring.spec().clone();
+        self.send(&HostMessage::Open { ring: spec })
+    }
+
     /// The next slot, round-robin. A slot is not reused until every other slot
     /// has been, which is what keeps the one being written away from the one
     /// being read.
@@ -833,12 +865,7 @@ impl Broker {
     fn restart(&mut self) -> Result<(), BrokerError> {
         self.kill();
         self.restarts = self.restarts.saturating_add(1);
-        let identifier = format!(
-            "{}-{}",
-            std::process::id(),
-            PIPE_COUNTER.fetch_add(1, Ordering::Relaxed)
-        );
-        self.start(&identifier)?;
+        self.start(&fresh_identifier())?;
 
         let control = self.config.quirks.control_timeout;
         if let Ok(BrokerMessage::Described { plugins }) =
@@ -910,6 +937,7 @@ fn errored(frame: Frame16, why: &str) -> BrokerRender {
         error: Some(why.to_owned()),
         frames_needed: BTreeMap::new(),
         identity_of: None,
+        secret: None,
     }
 }
 

--- a/crates/lumit-ofx/src/ipc/proto.rs
+++ b/crates/lumit-ofx/src/ipc/proto.rs
@@ -19,7 +19,7 @@
 //! [`PROTOCOL_VERSION`] ends the conversation with a sentence the user can read
 //! rather than a struct deserialised out of somebody else's layout.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +29,7 @@ use crate::instance::ParamSnapshot;
 
 /// The version both sides must agree on. Bump it whenever a message changes
 /// shape: an old broker beside a new host is a mismatch, not a crash.
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Which instance a message is about. The host mints these; the broker only
 /// ever quotes one back.
@@ -58,8 +58,8 @@ pub struct FrameWanted {
     pub time: f64,
 }
 
-/// How the ring is laid out. Sent once, after the handshake, because the ring
-/// is sized once per bundle and never again ([`crate::ipc::shm`]).
+/// How the ring is laid out. Sent after the handshake, and again whenever a
+/// bigger frame than the ring holds arrives ([`crate::ipc::shm`]).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RingSpec {
     /// The backing file both processes map.
@@ -92,9 +92,9 @@ pub enum HostMessage {
         /// Every control's value.
         params: ParamSnapshot,
     },
-    /// Replace an instance's values without telling the plugin. This is a
-    /// scrub or an undo landing: the plugin reads the new numbers at its next
-    /// `paramGetValue` (docs/12 §2.2).
+    /// Replace an instance's values. The plugin reads the new numbers at its
+    /// next `paramGetValue` (docs/12 §2.2), and is told which ones changed
+    /// through `kOfxActionInstanceChanged` just before its next render.
     ParamSnapshot {
         /// Which instance.
         instance: InstanceId,
@@ -193,6 +193,8 @@ pub enum BrokerMessage {
         frames_needed: BTreeMap<String, (f64, f64)>,
         /// The clip the plugin said this frame simply is, if it said so.
         identity_of: Option<String>,
+        /// The controls the plugin is hiding now, by parameter name.
+        secret: BTreeSet<String>,
     },
     /// Something went wrong, as a sentence rather than a status code: the host
     /// puts it on a badge and the user reads it.

--- a/crates/lumit-ofx/src/ipc/shm.rs
+++ b/crates/lumit-ofx/src/ipc/shm.rs
@@ -12,9 +12,10 @@
 //! The note asks for triple buffering, and that is the floor: at least three
 //! slots, so that the slot being written is never the slot being read, with
 //! one spare between them. A small frame gets many more, because the ring is
-//! sized by a byte budget rather than by a slot count, and it is sized
-//! **once per bundle** — at the moment the broker is spawned, from the comp's
-//! frame size — never per frame.
+//! sized by a byte budget rather than by a slot count. It is sized when the
+//! broker is spawned, and again only when a frame arrives that is bigger than
+//! a slot: the broker then gets a new ring the way it got the first, never a
+//! ring per frame.
 //!
 //! Every slot begins with a header, and the header is the whole contract for
 //! the bytes after it: what rectangle they are, how far apart the rows are,
@@ -70,8 +71,8 @@ pub enum ShmError {
     /// A slot number that is not in the ring.
     #[error("slot {0} is not in the frame ring")]
     NoSuchSlot(u32),
-    /// A frame bigger than a slot. The ring is sized once, so this is a comp
-    /// whose frame size changed under a live broker.
+    /// A frame bigger than a slot. The broker regrows its ring before a
+    /// render, so this is a frame that arrived by another road.
     #[error("a {needed}-byte frame does not fit a {slot_bytes}-byte ring slot")]
     TooBig {
         /// What the frame needs, header included.

--- a/crates/lumit-ofx/src/render.rs
+++ b/crates/lumit-ofx/src/render.rs
@@ -177,6 +177,9 @@ pub struct Rendered {
     /// The clip the plugin said it was a pass-through of, if it said so. When
     /// this is set, no render happened at all.
     pub identity_of: Option<String>,
+    /// The controls the plugin is hiding after this render
+    /// ([`Instance::secret_names`]).
+    pub secret: BTreeSet<String>,
 }
 
 thread_local! {
@@ -361,6 +364,11 @@ pub fn render_with_prefetch(
         first,
         last,
     )?;
+    // What the host changed since the last frame is told now: between
+    // renders, as the note requires, and with the pictures on so the plugin
+    // may look at its clip while it reacts. A plugin that fails the action
+    // still gets its render; the values stand either way.
+    let _ = instance.tell_changes(plugin, request.time);
 
     let outcome = ask(plugin, instance, request, token, prefetch);
 
@@ -389,6 +397,7 @@ pub fn render_with_prefetch(
         region_of_definition: answers.region_of_definition,
         frames_needed: answers.frames_needed,
         identity_of: answers.identity_of,
+        secret: instance.secret_names()?,
     })
 }
 

--- a/crates/lumit-ofx/src/schema.rs
+++ b/crates/lumit-ofx/src/schema.rs
@@ -39,7 +39,8 @@
 //!   a run of rows behind a twirl. A page is the same thing with a flatter
 //!   name — the host advertises `kOfxParamHostPropMaxPages` = 0, so a
 //!   well-behaved plugin uses groups, and a plugin that defines a page anyway
-//!   gets its page drawn as a group rather than dropped.
+//!   gets its page drawn as a group rather than dropped. Rows follow the
+//!   pages' order, then their group's, so a group is drawn once.
 //! * **Traits.** `cost = Heavy`, because a plugin is somebody else's code
 //!   crossing a process boundary and the degradation ordering should give it up
 //!   first; `roi = FullFrame`, because the host advertises no tile support and
@@ -59,6 +60,8 @@
 //! matters. Recorded ceiling: a rescan re-leaks, so the rescan path P6 builds
 //! reuses the schema it already has for an identifier and version it has
 //! already seen.
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use lumit_core::fx::{
     CostClass, EffectSchema, EffectTraits, FxCategory, MatteRole, ParamGroup, ParamId, ParamKind,
@@ -81,18 +84,42 @@ pub fn schema_of(plugin: &PluginDescriptor) -> Result<EffectSchema, Rejection> {
     let groups = group_owners(&plugin.params);
     let pages = page_owners(&plugin.params);
 
-    let mut rows: Vec<ParamSchema> = Vec::new();
-    // The group each row belongs to, in step with `rows`; `None` for a row at
-    // the top level.
-    let mut owners: Vec<Option<Owner>> = Vec::new();
-
+    // Each row with the group it belongs to (`None` at the top level), the
+    // plugin's name for it, and its place in the plugin's order.
+    let mut entries: Vec<(usize, ParamSchema, Option<Owner>, &str)> = Vec::new();
     for param in &plugin.params {
         let owner = owner_of(param, &groups, &pages);
         for row in rows_of(param) {
-            rows.push(row);
-            owners.push(owner.clone());
+            entries.push((entries.len(), row, owner.clone(), param.name.as_str()));
         }
     }
+
+    // Laid out the way Resolve lays them out: by the page that lists the row
+    // or its group, then by group, each group as one run. spektrafilm declares
+    // its groups in stretches, and the panel drew Film and Print twice each.
+    let page_of = page_ranks(&plugin.params);
+    let mut first_seen: BTreeMap<String, usize> = BTreeMap::new();
+    for (index, _, owner, _) in &entries {
+        if let Some(owner) = owner {
+            first_seen.entry(owner.name.clone()).or_insert(*index);
+        }
+    }
+    entries.sort_by_cached_key(|(index, _, owner, name)| {
+        let owner = owner.as_ref().map_or("", |owner| owner.name.as_str());
+        let page = page_of
+            .get(*name)
+            .or_else(|| page_of.get(owner))
+            .copied()
+            .unwrap_or(usize::MAX);
+        // A row with no group keeps its own place; a grouped row joins its
+        // group where the group first appeared.
+        let run = first_seen.get(owner).copied().unwrap_or(*index);
+        (page, run, *index)
+    });
+    let (rows, owners): (Vec<ParamSchema>, Vec<Option<Owner>>) = entries
+        .into_iter()
+        .map(|(_, row, owner, _)| (row, owner))
+        .unzip();
 
     // Two rows under one id is two controls the panel cannot tell apart and one
     // value in the bag. Refuse the effect rather than ship the ambiguity.
@@ -199,6 +226,46 @@ pub fn value_routes(plugin: &PluginDescriptor) -> Vec<ValueRoute> {
     routes
 }
 
+/// Every parameter the plugin marks secret at describe time, by name: the
+/// rows the panel starts without. A plugin hides and shows rows from inside
+/// `instanceChanged` too, so the live set is read after each render
+/// (`Instance::secret_names`) and `OfxEffectDef::hidden_rows` follows it.
+/// The rows stay in the schema either way: a row that starts hidden
+/// (spektrafilm's HDR output) has to be there to appear later.
+#[must_use]
+pub fn secret_names(plugin: &PluginDescriptor) -> BTreeSet<String> {
+    plugin
+        .params
+        .iter()
+        .filter(|param| int_at(&param.props, keys::PARAM_SECRET, 0) == Some(1))
+        .map(|param| param.name.clone())
+        .collect()
+}
+
+/// What each parameter sits inside, by name: its parent group, or the page
+/// that lists it. A group is in here under its own parent too, which is how
+/// a hidden group hides everything down to its last row.
+#[must_use]
+pub fn owner_names(plugin: &PluginDescriptor) -> BTreeMap<String, String> {
+    let mut owners = BTreeMap::new();
+    for page in plugin
+        .params
+        .iter()
+        .filter(|param| param.param_type == param_types::PAGE)
+    {
+        for child in strings(&page.props, keys::PARAM_PAGE_CHILD) {
+            owners.entry(child).or_insert_with(|| page.name.clone());
+        }
+    }
+    for param in &plugin.params {
+        let parent = string_at(&param.props, keys::PARAM_PARENT, 0).unwrap_or_default();
+        if !parent.is_empty() {
+            owners.insert(param.name.clone(), parent);
+        }
+    }
+    owners
+}
+
 /// What a group or page is called, and whether it starts closed.
 #[derive(Clone, PartialEq, Eq)]
 struct Owner {
@@ -227,6 +294,21 @@ fn group_owners(params: &[ParamDescription]) -> Vec<Owner> {
             collapsed: int_at(&group.props, keys::PARAM_GROUP_OPEN, 0) == Some(0),
         })
         .collect()
+}
+
+/// Which page lists each name, as that page's place in the plugin's order.
+fn page_ranks(params: &[ParamDescription]) -> BTreeMap<String, usize> {
+    let mut ranks = BTreeMap::new();
+    for (rank, page) in params
+        .iter()
+        .filter(|param| param.param_type == param_types::PAGE)
+        .enumerate()
+    {
+        for child in strings(&page.props, keys::PARAM_PAGE_CHILD) {
+            ranks.entry(child).or_insert(rank);
+        }
+    }
+    ranks
 }
 
 /// Which page lists each parameter, by parameter name.
@@ -273,9 +355,8 @@ fn owner_of(
 /// then cut the rows into contiguous runs.
 ///
 /// A [`ParamGroup`]'s members must be a contiguous run in schema order, which
-/// is how the panel draws them in place. A plugin that interleaves two groups
-/// gets each stretch as its own run under the same header — the rows keep the
-/// order the plugin gave them, which is the promise that matters.
+/// is how the panel draws them in place. [`schema_of`] has already put each
+/// group's rows together, so one group is one run.
 fn groups_of(rows: &[ParamSchema], owners: &[Option<Owner>]) -> Vec<ParamGroup> {
     let mut groups: Vec<ParamGroup> = Vec::new();
     let mut run: Vec<&'static str> = Vec::new();

--- a/crates/lumit-ofx/src/tests.rs
+++ b/crates/lumit-ofx/src/tests.rs
@@ -1021,6 +1021,8 @@ roi = FullFrame
 temporal = [-1, 0, 1]
 premultiplied = true
 matte = None
+param lutPath | LUT file | File { filter: [], filter_name: \"All files\" } | Raw
+param trigger | Trigger | Action | Raw
 param gain | Gain | Float { default: 0.5, slider: (0.0, 2.0), hard: (Some(0.0), Some(4.0)) } | Raw
 param rotation | Rotation | Angle { default: 45.0, dial_step: 1.0 } | Degrees
 param centre_x | Centre X | Float { default: 0.0, slider: (-100.0, 100.0), hard: (None, None) } | Px
@@ -1035,10 +1037,8 @@ param enabled | Enabled | Bool { default: true } | Raw
 param mode | Mode | Choice { options: [\"Soft\", \"Hard\", \"Wild\"], default: 1, dividers_after: [] } | Raw
 param tint | Tint | Colour { default: [0.25, 0.5, 0.75, 1.0], range: (0.0, 1.0) } | Raw
 param wash | Wash | Colour { default: [1.0, 0.0, 0.0, 1.0], range: (0.0, 1.0) } | Raw
-param lutPath | LUT file | File { filter: [], filter_name: \"All files\" } | Raw
-param trigger | Trigger | Action | Raw
-group Advanced | [\"offset_x\", \"offset_y\", \"offset_z\", \"count\"] | collapsed true
 group Files | [\"lutPath\", \"trigger\"] | collapsed false
+group Advanced | [\"offset_x\", \"offset_y\", \"offset_z\", \"count\"] | collapsed true
 ";
     assert_eq!(render(&full.schema), expected);
 
@@ -2586,6 +2586,7 @@ impl PluginHost for DeadHost {
         Rendering {
             frame: source,
             error: Some("the plugin is disabled for this session".to_owned()),
+            secret: None,
         }
     }
 
@@ -2804,7 +2805,7 @@ fn a_disabled_plugin_renders_identity_byte_for_byte() {
 fn a_pressed_button_brings_back_what_the_plugin_wrote() {
     let _ledger = image_ledger();
     let Some(schema) =
-        a_registered_plugin("a_pressed_button_brings_back", "com.lumitlab.testplug", 2)
+        a_registered_plugin("a_pressed_button_brings_back", "com.lumitlab.testplug", 1)
     else {
         return;
     };
@@ -2868,6 +2869,7 @@ fn a_plugins_memory_reaches_its_render() {
             Rendering {
                 frame: source,
                 error: None,
+                secret: None,
             }
         }
 
@@ -3015,6 +3017,7 @@ fn a_plugin_is_told_its_frame_and_handed_its_neighbours() {
             Rendering {
                 frame: source,
                 error: None,
+                secret: None,
             }
         }
 
@@ -3045,7 +3048,11 @@ fn a_plugin_is_told_its_frame_and_handed_its_neighbours() {
         grouping: String::new(),
         label: "Frame test plugin".to_owned(),
         contexts: vec![Context::Filter],
-        params: Vec::new(),
+        params: vec![crate::describe::ParamDescription {
+            name: "gain".to_owned(),
+            param_type: crate::ffi::param_types::DOUBLE.to_owned(),
+            props: PropertySet::new(),
+        }],
         clips: Vec::new(),
         temporal: true,
         render_thread_safety: None,
@@ -3071,7 +3078,16 @@ fn a_plugin_is_told_its_frame_and_handed_its_neighbours() {
             extra: serde_json::Map::new(),
         },
         enabled: true,
-        params: Vec::new(),
+        // Driven by an expression, so its value is the playhead's, not a
+        // person's, and the plugin is not told when it moves.
+        params: vec![lumit_core::model::EffectParam {
+            id: "gain".to_owned(),
+            value: EffectValue::Float(lumit_core::anim::Property {
+                animation: lumit_core::anim::Animation::Expression("time".to_owned()),
+                extra: serde_json::Map::new(),
+            }),
+            extra: serde_json::Map::new(),
+        }],
         sample_temporally: true,
         custom_name: None,
         linked_pairs: Vec::new(),
@@ -3117,6 +3133,13 @@ fn a_plugin_is_told_its_frame_and_handed_its_neighbours() {
     };
     let mut bag = Vec::new();
     def.resolve_derived(&cx, &mut |id, value| bag.push((id, value)));
+    assert!(
+        bag.contains(&(
+            lumit_core::fx::ParamId::new("derived.quiet.gain"),
+            Value::Bool(true)
+        )),
+        "a moving row is marked quiet in the bag: {bag:?}"
+    );
 
     let mut rgba = vec![0.5_f32; 2 * 2 * 4];
     let previous = vec![0.25_f32; 2 * 2 * 4];
@@ -3201,5 +3224,307 @@ fn a_forgotten_ring_goes_with_its_process() {
         !leaked,
         "the ring file outlived the process that made it: {}",
         path.display()
+    );
+}
+
+/// A parameter the plugin marks secret keeps its row and starts hidden, and
+/// so does everything inside a secret group. After a render the rows follow
+/// what the plugin reports: spektrafilm shows its HDR output rows only once
+/// the output role says HDR, and Resolve draws whatever is not secret now.
+#[test]
+fn a_secret_parameter_is_a_hidden_row_until_the_plugin_says_otherwise() {
+    struct Reporting(std::collections::BTreeSet<String>);
+
+    impl PluginHost for Reporting {
+        fn render(
+            &self,
+            _instance: uuid::Uuid,
+            _time: f64,
+            _params: &ParamSnapshot,
+            source: Frame16,
+            _neighbours: &[(i32, Frame16)],
+        ) -> Rendering {
+            Rendering {
+                frame: source,
+                error: None,
+                secret: Some(self.0.clone()),
+            }
+        }
+
+        fn frames_needed(
+            &self,
+            _instance: uuid::Uuid,
+            _time: f64,
+            _params: &ParamSnapshot,
+        ) -> Option<Vec<i32>> {
+            None
+        }
+
+        fn press(
+            &self,
+            _instance: uuid::Uuid,
+            _time: f64,
+            _params: &ParamSnapshot,
+            _name: &str,
+            _source: Frame16,
+        ) -> Result<ParamSnapshot, String> {
+            Err("not this test".to_owned())
+        }
+    }
+
+    let param = |name: &str, kind: &str, secret: bool, parent: &str| {
+        let mut props = PropertySet::new();
+        props.seed(keys::PARAM_DEFAULT, PropValue::double(0.5));
+        props.seed(keys::PARAM_SECRET, PropValue::int(i32::from(secret)));
+        if !parent.is_empty() {
+            props.seed(
+                keys::PARAM_PARENT,
+                PropValue::string(parent).expect("a name"),
+            );
+        }
+        crate::describe::ParamDescription {
+            name: name.to_owned(),
+            param_type: kind.to_owned(),
+            props,
+        }
+    };
+    let descriptor = PluginDescriptor {
+        identifier: "test.secret".to_owned(),
+        version: (1, 0),
+        grouping: String::new(),
+        label: "Secret test plugin".to_owned(),
+        contexts: vec![Context::Filter],
+        params: vec![
+            param("shown", crate::ffi::param_types::DOUBLE, false, ""),
+            param("hidden", crate::ffi::param_types::DOUBLE, true, ""),
+            param("advanced", crate::ffi::param_types::GROUP, true, ""),
+            param("inside", crate::ffi::param_types::DOUBLE, false, "advanced"),
+            param("deeper", crate::ffi::param_types::GROUP, false, "advanced"),
+            param("nested", crate::ffi::param_types::DOUBLE, false, "deeper"),
+        ],
+        clips: Vec::new(),
+        temporal: false,
+        render_thread_safety: None,
+    };
+    let schema: &'static EffectSchema = Box::leak(Box::new(
+        crate::schema::schema_of(&descriptor).expect("a schema"),
+    ));
+    let ids: Vec<&str> = schema.params.iter().map(|row| row.id).collect();
+    assert_eq!(
+        ids,
+        vec!["shown", "hidden", "inside", "nested"],
+        "every row is in the schema, hidden or not"
+    );
+
+    // The plugin will report the opposite of what it declared.
+    let live = std::collections::BTreeSet::from(["shown".to_owned()]);
+    let host = std::sync::Arc::new(Reporting(live));
+    let def = OfxEffectDef::new(&descriptor, schema, host);
+    let mut inst = lumit_core::model::EffectInstance {
+        id: uuid::Uuid::now_v7(),
+        effect: lumit_core::model::EffectKey {
+            namespace: lumit_core::model::EffectNamespace::Ofx,
+            match_name: schema.match_name.to_owned(),
+            version: 1,
+            extra: serde_json::Map::new(),
+        },
+        enabled: true,
+        params: Vec::new(),
+        sample_temporally: false,
+        custom_name: None,
+        linked_pairs: Vec::new(),
+        plugin_state: None,
+        roto: None,
+        extra: serde_json::Map::new(),
+    };
+    assert_eq!(
+        def.hidden_rows(&inst),
+        vec!["hidden", "inside", "nested"],
+        "before any render, the describe-time flags, groups included"
+    );
+
+    let mut rgba = vec![0.5_f32; 2 * 2 * 4];
+    def.apply_cpu_at(inst.id, 0.0, &mut rgba, 2, 2, Params::EMPTY);
+    assert_eq!(
+        def.hidden_rows(&inst),
+        vec!["shown"],
+        "after a render, what the plugin reported"
+    );
+    inst.id = uuid::Uuid::now_v7();
+    assert_eq!(
+        def.hidden_rows(&inst),
+        vec!["hidden", "inside", "nested"],
+        "another instance has not rendered and starts from describe"
+    );
+}
+
+/// A value the host changes reaches the plugin as `kOfxActionInstanceChanged`,
+/// wrapped, before the next render's first question. A value that has not
+/// changed is not mentioned. A value the instance is created with counts as a
+/// change too, told after the create action, since spektrafilm's stock did
+/// nothing when nothing ever told it the stock had changed, and it ignores a
+/// change to the value it was created with.
+#[test]
+fn a_changed_value_is_told_to_the_plugin_before_the_next_render() {
+    let _ledger = image_ledger();
+    let Some((_root, bundle, report)) = a_described_bundle("a_changed_value_is_told") else {
+        return;
+    };
+    let Some(probe) = a_probe(&bundle) else {
+        skipped("a_changed_value_is_told_to_the_plugin_before_the_next_render");
+        return;
+    };
+    let plugin = plugin_of(&bundle, "com.lumitlab.testplug");
+    let descriptor = &described(&report, "com.lumitlab.testplug").descriptor;
+    let mut values = ParamSnapshot::new();
+    values.set("gain", PropValue::double(0.25));
+    probe_call(&probe, b"LumitTestPlugResetProbes ");
+    let instance =
+        Instance::create(plugin, descriptor, Context::Filter, &values).expect("an instance");
+    let token = Epoch::new().token();
+    let request = RenderRequest::filter(0.0, a_test_frame(4, 4));
+    crate::render::render(plugin, &instance, &request, &token).expect("it rendered");
+    let seen = action_log(&probe);
+    let changed = seen
+        .iter()
+        .position(|action| action == actions::INSTANCE_CHANGED)
+        .expect("the plugin was told");
+    assert_eq!(
+        seen.get(changed.wrapping_sub(1)).map(String::as_str),
+        Some(actions::BEGIN_INSTANCE_CHANGED),
+        "wrapped: {seen:?}"
+    );
+    assert_eq!(
+        seen.get(changed + 1).map(String::as_str),
+        Some(actions::END_INSTANCE_CHANGED),
+        "wrapped: {seen:?}"
+    );
+    let render = seen
+        .iter()
+        .position(|action| action == actions::BEGIN_SEQUENCE_RENDER)
+        .expect("it rendered");
+    assert!(changed < render, "told before the render, never inside it");
+
+    let create = seen
+        .iter()
+        .position(|action| action == actions::CREATE_INSTANCE)
+        .expect("it was created");
+    assert!(create < changed, "told after the create action, not before");
+
+    // The same values again are nothing to tell.
+    instance
+        .set_params(values.clone())
+        .expect("the values went in");
+    probe_call(&probe, b"LumitTestPlugResetProbes ");
+    crate::render::render(plugin, &instance, &request, &token).expect("it rendered");
+    let seen = action_log(&probe);
+    assert!(
+        !seen
+            .iter()
+            .any(|action| action == actions::INSTANCE_CHANGED),
+        "an unchanged value is not a change: {seen:?}"
+    );
+
+    // A new value is.
+    values.set("gain", PropValue::double(0.75));
+    instance
+        .set_params(values.clone())
+        .expect("the values went in");
+    probe_call(&probe, b"LumitTestPlugResetProbes ");
+    crate::render::render(plugin, &instance, &request, &token).expect("it rendered");
+    let seen = action_log(&probe);
+    assert!(
+        seen.iter()
+            .any(|action| action == actions::INSTANCE_CHANGED),
+        "a changed value is told: {seen:?}"
+    );
+
+    // A value that moves with time is the playhead's doing, not a person's.
+    values.set("gain", PropValue::double(0.9));
+    values.quiet.insert("gain".to_owned());
+    instance.set_params(values).expect("the values went in");
+    probe_call(&probe, b"LumitTestPlugResetProbes ");
+    crate::render::render(plugin, &instance, &request, &token).expect("it rendered");
+    let seen = action_log(&probe);
+    assert!(
+        !seen
+            .iter()
+            .any(|action| action == actions::INSTANCE_CHANGED),
+        "an animated value is not told: {seen:?}"
+    );
+    instance.destroy(plugin).expect("it was destroyed");
+}
+
+/// Rows follow the page that lists them or their group, and a group whose
+/// members the plugin declared in stretches is still one run. spektrafilm
+/// declares its parameters that way and the panel drew Film and Print twice.
+#[test]
+fn rows_follow_the_pages_and_a_group_is_one_run() {
+    let param = |name: &str, kind: &str, parent: &str, children: &[&str]| {
+        let mut props = PropertySet::new();
+        props.seed(keys::PARAM_DEFAULT, PropValue::double(0.5));
+        props.seed(keys::LABEL, PropValue::string(name).expect("a label"));
+        if !parent.is_empty() {
+            props.seed(
+                keys::PARAM_PARENT,
+                PropValue::string(parent).expect("a name"),
+            );
+        }
+        if !children.is_empty() {
+            props.seed(
+                keys::PARAM_PAGE_CHILD,
+                PropValue::String(
+                    children
+                        .iter()
+                        .map(|child| std::ffi::CString::new(*child).expect("a name"))
+                        .collect(),
+                ),
+            );
+        }
+        crate::describe::ParamDescription {
+            name: name.to_owned(),
+            param_type: kind.to_owned(),
+            props,
+        }
+    };
+    let descriptor = PluginDescriptor {
+        identifier: "test.pages".to_owned(),
+        version: (1, 0),
+        grouping: String::new(),
+        label: "Pages test plugin".to_owned(),
+        contexts: vec![Context::Filter],
+        params: vec![
+            param("g1", crate::ffi::param_types::GROUP, "", &[]),
+            param("g2", crate::ffi::param_types::GROUP, "", &[]),
+            param("a", crate::ffi::param_types::DOUBLE, "g1", &[]),
+            param("b", crate::ffi::param_types::DOUBLE, "g2", &[]),
+            param("c", crate::ffi::param_types::DOUBLE, "g1", &[]),
+            param("top", crate::ffi::param_types::DOUBLE, "", &[]),
+            param("page", crate::ffi::param_types::PAGE, "", &["g2", "top"]),
+        ],
+        clips: Vec::new(),
+        temporal: false,
+        render_thread_safety: None,
+    };
+    let schema = crate::schema::schema_of(&descriptor).expect("a schema");
+    let ids: Vec<&str> = schema.params.iter().map(|row| row.id).collect();
+    assert_eq!(
+        ids,
+        vec!["b", "top", "a", "c"],
+        "the page first, then the rest"
+    );
+    let groups: Vec<(&str, Vec<&str>)> = schema
+        .groups
+        .iter()
+        .map(|group| (group.label, group.params.to_vec()))
+        .collect();
+    assert_eq!(
+        groups,
+        vec![
+            ("g2", vec!["b"]),
+            ("page", vec!["top"]),
+            ("g1", vec!["a", "c"])
+        ],
+        "a page is drawn as a group for the rows it lists that have none"
     );
 }

--- a/docs/12-PLUGINS.md
+++ b/docs/12-PLUGINS.md
@@ -90,7 +90,10 @@ live in Lumit's property system, are edited in the Timeline and graph editor, se
 into the `.lum` file, and are readable from expressions like any built-in property.
 `paramGetValueAtTime` evaluates the property (including any expression on it) at the
 requested time. Custom parameters carry opaque vendor blobs; Lumit stores and round-trips
-them without interpretation. Parameter pages/groups become the Effect Controls layout.
+them without interpretation. Parameter pages/groups become the Effect Controls layout, rows
+in page order and each group drawn once. A parameter the plugin marks secret is a hidden
+row, and a plugin may hide or show rows from inside `instanceChanged`: the panel follows
+what the instance's last render reported.
 A push button is the plugin's own: pressing it sends `kOfxActionInstanceChanged` with the
 Source frame in place, the plugin may open its own window and stay in it, and whatever it
 wrote comes back into the document, rows as rows and everything no row carries as the

--- a/docs/impl/ofx-host.md
+++ b/docs/impl/ofx-host.md
@@ -79,7 +79,19 @@ transcription; a test records what the plugin observed and compares the two verb
 earlier revisions of this note left them implicit.
 
 Param changed actions (`kOfxActionInstanceChanged`) must fire between renders, wrapped in
-`kOfxActionBeginInstanceChanged/End...` — Sapphire relies on it.
+`kOfxActionBeginInstanceChanged/End...` — Sapphire relies on it. A value the host changed
+since the last frame is told this way before the next render's first question, with the
+pictures already on the instance (`Instance::tell_changes`). An instance is created at the
+plugin's defaults and the document's values are told the same way before its first render,
+the way Resolve restores a project; spektrafilm ignores a change to a value it was created
+with, so a saved stock rendered as the default until this. A value the host has not
+changed is left as the plugin holds it, so a control the plugin writes from inside
+`instanceChanged` (spektrafilm derives its film profile from the stock choice) keeps what
+the plugin wrote until the host has something new for that control. A row that is keyframed
+or driven by an expression is never told: its value is the playhead's, not a person's, and
+the plugin reads it at `paramGetValue` the way every host treats an animated control. The
+resolve walk marks such rows in the bag (`derived.quiet.<row>`) and the snapshot carries the
+set across.
 
 Images: `clipGetImage(clip, time)` returns a property set with data pointer, bounds, row
 bytes, pixel depth, premultiplication state. **Row bytes are always positive: the host hands
@@ -129,12 +141,14 @@ What the built transport pins, beyond the sketch above:
   for good; the child's standard output goes nowhere.
 - **The broker's first word is the protocol version.** A mismatch refuses the broker with
   a sentence rather than deserialising bytes of another shape.
-- **The ring is sized by a byte budget, once per bundle**: 512 MiB, clamped to between
-  three slots (this note's triple buffering, as the floor) and sixty-four. Slot header:
-  bounds, row bytes, premultiplication, payload length, FNV-1a hash — checked on read,
-  because a stale slot is the one failure shared memory has and it is silent. At 1080p
-  that is fifteen slots; at 4K it is the floor of three, so a `t ± 5` prefetch at that
-  size does not fit and is refused — a bigger budget, not a different design.
+- **The ring is sized by a byte budget**: 512 MiB, clamped to between three slots (this
+  note's triple buffering, as the floor) and sixty-four. It is built at the scan's 1080p
+  and regrown, once, the first time a bigger frame is rendered: a new ring at that size,
+  handed to the broker with a second `Open`. Slot header: bounds, row bytes,
+  premultiplication, payload length, FNV-1a hash — checked on read, because a stale slot
+  is the one failure shared memory has and it is silent. At 1080p that is fifteen slots;
+  at 4K it is the floor of three, so a `t ± 5` prefetch at that size does not fit and is
+  refused — a bigger budget, not a different design.
 - Frames cross the ring as fp32 RGBA, tightly packed top-down. The header's row bytes
   describe *the ring*; the flip to OFX's bottom-up layout happens at the plugin boundary
   inside the broker.
@@ -221,8 +235,13 @@ registered into the same catalogue the built-ins live in — the seam
 - **A rescan is guarded by name before any work.** That is what keeps it idempotent and what
   stops the second scan re-leaking a schema — §4a's recorded ceiling, discharged.
 - **The ring is built for 1080p at scan time.** The scan runs before any composition is
-  open, and §4 sizes a ring once per broker. A 4K comp then renders through the three-slot
-  floor; the upgrade is a broker respawned at the comp's size.
+  open. The first frame that does not fit a slot (a 3840 by 1620 clip in a 1080p comp
+  was the report) regrows the ring before the render, §4.
+- **Hidden rows follow the plugin.** The describe-time secret flags are the rows the panel
+  starts without; after every render the broker reports which parameters the instance has
+  flagged secret now, groups and pages included, and `OfxEffectDef::hidden_rows` turns that
+  into row ids the panel skips. spektrafilm shows its HDR output rows only once the output
+  role says HDR.
 - **A bundle's plugins share one broker.** `BrokerHost` holds an `Arc<Mutex<Broker>>`;
   eighty plugins in one bundle are one process, not eighty.
 

--- a/flutter_ui/lib/panels/effect_controls_panel_frb.dart
+++ b/flutter_ui/lib/panels/effect_controls_panel_frb.dart
@@ -1849,13 +1849,23 @@ class _EffectSection extends StatelessWidget {
   /// - two adjacent Float params `foo_x`, `foo_y` fold into one point row
   ///   (with the position dropper for the declared %-of-frame pairs).
   List<Widget> _paramRows(UuidValue id, Map<String, BridgeEffectValue> values) {
-    final params = _rows;
+    // A plugin hides and shows its own rows, and the instance says which
+    // are hidden right now. A group with nothing left to show is not drawn.
+    final hidden = info.hiddenRows.toSet();
+    final params = [
+      for (final p in _rows)
+        if (!hidden.contains(p.id)) p,
+    ];
     final groups = cachedListParameterGroups(info.name);
     final byFirstMember = <String, BridgeParamGroup>{};
     final memberOf = <String, BridgeParamGroup>{};
     for (final g in groups) {
-      if (g.params.isNotEmpty) byFirstMember[g.params.first] = g;
-      for (final m in g.params) {
+      final members = [
+        for (final m in g.params)
+          if (!hidden.contains(m)) m,
+      ];
+      if (members.isNotEmpty) byFirstMember[members.first] = g;
+      for (final m in members) {
         memberOf[m] = g;
       }
     }

--- a/flutter_ui/lib/src/rust/api/effect.dart
+++ b/flutter_ui/lib/src/rust/api/effect.dart
@@ -13,7 +13,7 @@ import 'package:uuid/uuid.dart';
 import 'roto.dart';
 part 'effect.freezed.dart';
 
-// These functions are ignored because they are not marked as `pub`: `animation_at`, `badge_of`, `bridge_param`, `bridge_shader_ty`, `bridge_unit`, `catalogue`, `clamp_animation`, `derived_params_of`, `document_for`, `fill_derived`, `hard_bounds`, `is_audio_match_name`, `param`, `plugin_category_key`, `presets_in`, `read_at`, `read_at`, `read_at`, `read_instance_info`, `read`, `sample_at`, `scan_audio_plugins`, `seconds_of`, `shader_error`, `validated`, `write_at`, `write_at`, `write`
+// These functions are ignored because they are not marked as `pub`: `animation_at`, `badge_of`, `bridge_param`, `bridge_shader_ty`, `bridge_unit`, `catalogue`, `clamp_animation`, `derived_params_of`, `document_for`, `fill_derived`, `hard_bounds`, `hidden_rows_of`, `is_audio_match_name`, `param`, `plugin_category_key`, `presets_in`, `read_at`, `read_at`, `read_at`, `read_instance_info`, `read`, `sample_at`, `scan_audio_plugins`, `seconds_of`, `shader_error`, `validated`, `write_at`, `write_at`, `write`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 // These functions are ignored (category: IgnoreBecauseExplicitAttribute): `get_effects`, `new`
 
@@ -650,6 +650,12 @@ class BridgeEffectInstanceInfo {
   /// [`BridgeEffectInstance::list_parameters`] answers in one piece.
   final List<BridgeParamInfo> derivedParams;
 
+  /// The rows this instance is not showing right now, by id: a plugin's
+  /// own hidden controls, read off its last render (docs/12 §2.2). Empty for
+  /// every built-in. Here for the same reason as the rest: the panel draws
+  /// on every rebuild and may not call.
+  final List<String> hiddenRows;
+
   const BridgeEffectInstanceInfo({
     required this.id,
     required this.name,
@@ -660,6 +666,7 @@ class BridgeEffectInstanceInfo {
     this.badgeReason,
     this.badgeDetail,
     required this.derivedParams,
+    required this.hiddenRows,
   });
 
   @override
@@ -672,7 +679,8 @@ class BridgeEffectInstanceInfo {
       linkedPairs.hashCode ^
       badgeReason.hashCode ^
       badgeDetail.hashCode ^
-      derivedParams.hashCode;
+      derivedParams.hashCode ^
+      hiddenRows.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -687,7 +695,8 @@ class BridgeEffectInstanceInfo {
           linkedPairs == other.linkedPairs &&
           badgeReason == other.badgeReason &&
           badgeDetail == other.badgeDetail &&
-          derivedParams == other.derivedParams;
+          derivedParams == other.derivedParams &&
+          hiddenRows == other.hiddenRows;
 }
 
 @freezed

--- a/flutter_ui/lib/src/rust/frb_generated.dart
+++ b/flutter_ui/lib/src/rust/frb_generated.dart
@@ -13444,8 +13444,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
   BridgeEffectInstanceInfo dco_decode_bridge_effect_instance_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return BridgeEffectInstanceInfo(
       id: dco_decode_Uuid(arr[0]),
       name: dco_decode_String(arr[1]),
@@ -13456,6 +13456,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
       badgeReason: dco_decode_opt_String(arr[6]),
       badgeDetail: dco_decode_opt_String(arr[7]),
       derivedParams: dco_decode_list_bridge_param_info(arr[8]),
+      hiddenRows: dco_decode_list_String(arr[9]),
     );
   }
 
@@ -17200,6 +17201,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     var var_badgeReason = sse_decode_opt_String(deserializer);
     var var_badgeDetail = sse_decode_opt_String(deserializer);
     var var_derivedParams = sse_decode_list_bridge_param_info(deserializer);
+    var var_hiddenRows = sse_decode_list_String(deserializer);
     return BridgeEffectInstanceInfo(
         id: var_id,
         name: var_name,
@@ -17209,7 +17211,8 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
         linkedPairs: var_linkedPairs,
         badgeReason: var_badgeReason,
         badgeDetail: var_badgeDetail,
-        derivedParams: var_derivedParams);
+        derivedParams: var_derivedParams,
+        hiddenRows: var_hiddenRows);
   }
 
   @protected
@@ -21573,6 +21576,7 @@ class BridgeLibApiImpl extends BridgeLibApiImplPlatform
     sse_encode_opt_String(self.badgeReason, serializer);
     sse_encode_opt_String(self.badgeDetail, serializer);
     sse_encode_list_bridge_param_info(self.derivedParams, serializer);
+    sse_encode_list_String(self.hiddenRows, serializer);
   }
 
   @protected

--- a/flutter_ui/test/timeline_rows_test.dart
+++ b/flutter_ui/test/timeline_rows_test.dart
@@ -254,7 +254,8 @@ void main() {
         enabled: true,
         values: const [],
         linkedPairs: const [],
-        derivedParams: const []);
+        derivedParams: const [],
+        hiddenRows: const []);
     // A parameter at its default, with a wire from the node graph on it:
     // nothing has been typed into it and it is not the same at every
     // frame either.


### PR DESCRIPTION
Three OFX fixes from the bug reports.

The frame ring was built for 1080p when plugins were scanned and never grew, so a 3840x1620 clip failed with "does not fit a ring slot". It now grows the first time a bigger frame comes through. Parameters a plugin marks as hidden were drawn anyway, so spektrafilm showed every control instead of the set Resolve shows. Hidden rows now follow the plugin, so a control it shows later turns up when it should, and rows follow the plugin's page order with each group drawn once. Plugins were also never told when a value changed, only when a button was pressed, which is why the film stock did nothing.

To test, put spektrafilm on a 4K or larger clip and check it renders rather than badging the layer, then open the Film twirl, change the stock and see the picture change. The parameter list should be a lot shorter, with Film and Print appearing once each instead of twice.
