### PR TITLE
Speed up the waveform lanes in the Audio workspace

### DIFF
--- a/docs/impl/ui-performance.md
+++ b/docs/impl/ui-performance.md
@@ -698,6 +698,33 @@ not something a test can simply request. It waits on the report (the column's he
 filling in), not on the frame: the Linux runner's DMA-BUF present fails on software
 Vulkan, so the picture never reaches Dart there while the profile does.
 
+### 4.6 A lane's wave is one draw call a band
+
+The Audio workspace opens a waveform lane on every sounding layer, and a lane is as
+wide as the bar it sits in. `WaveformPainter` drew a line at a time, so a lane cost a
+draw call per pixel column per band: ten stacked lanes came to sixty thousand calls a
+frame, on the thread that records them and again on the one that replays them. A
+band's columns go into one `Float32List` and down in one `drawRawPoints` now, so ten
+lanes cost thirty calls. Recording those ten lanes in the test VM: **46.6 ms a frame
+before, 8.0 ms after**. `waveform_test.dart` holds the call count rather than the
+milliseconds, which is the part a headless test can state.
+
+The painter also stops at the edges of the **summary** it was handed rather than at
+the edges of the bar. A summary covers the visible stretch and half a view either
+side, while a bar at a close zoom is dozens of screenfuls, and the columns outside the
+window were walked in order to draw nothing. That is worth ~3% of the figures above at
+ten times zoom, and proportionally more the further in the zoom goes.
+
+And an arriving summary no longer rebuilds the table. The fetch answers off the build,
+and the panel answered each arrival with a `setState` of its own, so opening ten lanes
+or scrolling them cost a panel-wide rebuild per lane per window: the very thing §4.4
+rules out for selection. The lanes listen to `AudioLaneSummaries` for their peaks and
+their spectrograms instead, so an answer repaints the open lanes and touches nothing
+else in the table.
+
+**Not measured on the machine.** §7's manual rule asks for a probe run in the owner's
+conditions whenever a Timeline paint path changes, and this change has not had one.
+
 ## 5. What does not change
 
 - **The two-trees refusal stands** (docs/TODO, "The Timeline's two halves are still

--- a/flutter_ui/lib/panels/spectral_lane_frb.dart
+++ b/flutter_ui/lib/panels/spectral_lane_frb.dart
@@ -130,11 +130,18 @@ class _SpectralLaneState extends State<SpectralLane> {
     // bass to treble, blended across the bins — so the spectrogram and the
     // stack speak the same colour language and a theme owns both.
     final stops = [ramp.low, ramp.mid, ramp.high];
-    final colours = List<Color>.generate(bins, (b) {
+    // The three bytes each bin paints in, worked out per bin rather than per
+    // pixel: the loop under this runs columns times bins, up to a hundred and
+    // sixty thousand times a lane, and a colour's channels are floats.
+    final band = Uint8List(bins * 3);
+    for (var b = 0; b < bins; b++) {
       final at = bins <= 1 ? 0.0 : b / (bins - 1) * (stops.length - 1);
       final i = at.floor().clamp(0, stops.length - 2);
-      return Color.lerp(stops[i], stops[i + 1], at - i)!;
-    });
+      final colour = Color.lerp(stops[i], stops[i + 1], at - i)!;
+      band[b * 3] = (colour.r * 255).round();
+      band[b * 3 + 1] = (colour.g * 255).round();
+      band[b * 3 + 2] = (colour.b * 255).round();
+    }
     final rgba = Uint8List(cols * bins * 4);
     for (var c = 0; c < cols; c++) {
       for (var b = 0; b < bins; b++) {
@@ -143,10 +150,9 @@ class _SpectralLaneState extends State<SpectralLane> {
         // Low band at the bottom of the picture.
         final y = bins - 1 - b;
         final at = (y * cols + c) * 4;
-        final colour = colours[b];
-        rgba[at] = (colour.r * 255).round();
-        rgba[at + 1] = (colour.g * 255).round();
-        rgba[at + 2] = (colour.b * 255).round();
+        rgba[at] = band[b * 3];
+        rgba[at + 1] = band[b * 3 + 1];
+        rgba[at + 2] = band[b * 3 + 2];
         rgba[at + 3] = v;
       }
     }

--- a/flutter_ui/lib/panels/timeline_lane_area_frb.dart
+++ b/flutter_ui/lib/panels/timeline_lane_area_frb.dart
@@ -183,12 +183,10 @@ class LayerArea extends StatelessWidget {
   /// Where the open sequence views sit, so the row seams skip them.
   final List<(double, double)> sequenceBlanks;
 
-  /// Each layer's source peaks, for the waveform lanes.
-  final Map<String, BridgeAudioPeaks> peaks;
-
-  /// Each spectral-mode layer's spectrogram window — the other
-  /// picture, fetched instead of peaks while a lane's chip reads Spectral.
-  final Map<String, BridgeSpectrogram> spectra;
+  /// Every open lane's peaks and spectrograms, listened to by the lanes
+  /// themselves: a summary arriving repaints the lanes and rebuilds no part of
+  /// the table ([AudioLaneSummaries]).
+  final AudioLaneSummaries summaries;
 
   /// How waveforms draw — the lanes' own answer, handed down so
   /// an open Sequence view's clips agree with it.
@@ -320,8 +318,7 @@ class LayerArea extends StatelessWidget {
     this.sequenceBlanks = const [],
     this.hScroll,
     this.onClipPreview,
-    required this.peaks,
-    this.spectra = const {},
+    required this.summaries,
     required this.waveformStyle,
     required this.fps,
     required this.axis,
@@ -1062,7 +1059,9 @@ class LayerArea extends StatelessWidget {
       // The mode store is listened to here, so flipping a chip repaints this
       // lane and nothing else — the toggle never rebuilds the table.
       return ListenableBuilder(
-        listenable: laneModes,
+        // The chip's choice and the summary in hand, both of which change
+        // this lane's picture and nothing else on the table.
+        listenable: Listenable.merge([laneModes, summaries]),
         builder: (context, _) => ValueListenableBuilder<BarDragPreview?>(
         valueListenable: dragPreview,
         builder: (context, preview, _) {
@@ -1094,7 +1093,7 @@ class LayerArea extends StatelessWidget {
                     width: axis.width,
                     height: t.density.laneRow,
                     child: SpectralLane(
-                      grid: spectra[id],
+                      grid: summaries.spectra[id],
                       originSeconds:
                           -startOffset - TimelineAxis.pad * secondsPerPixel,
                       secondsPerPixel: secondsPerPixel,
@@ -1110,7 +1109,7 @@ class LayerArea extends StatelessWidget {
                 key: ValueKey<String>('tl-wave-$id'),
                 size: Size(axis.width, t.density.laneRow),
                 painter: WaveformPainter(
-                  peaks: peaks[id],
+                  peaks: summaries.peaks[id],
                   // Canvas x 0 is the axis's left padding, comp time 0 sits a
                   // padding's width in, and the source's own clock runs from
                   // there less wherever the layer starts it.

--- a/flutter_ui/lib/panels/timeline_panel_frb.dart
+++ b/flutter_ui/lib/panels/timeline_panel_frb.dart
@@ -182,15 +182,17 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
   /// the one nearly every layer uses.
   final Map<String, bool> _hasPicture = {};
 
-  /// Each layer's waveform peaks, by id — the stretch of its source the lanes
-  /// are currently showing, summarised to one bucket per pixel column.
+  /// Each open lane's peaks and spectrogram, by layer id — the stretch of
+  /// source it is currently showing, summarised to one bucket per pixel
+  /// column.
   ///
   /// Refetched when the zoom or the scroll moves the window far enough to
   /// matter, which is what keeps the drawn detail level with the zoom instead
   /// of blocky. Peaks belong to the file, so the painter maps them through the
   /// live in/out/offset and a drag or a trim carries the transients with it
-  /// without asking again.
-  final Map<String, BridgeAudioPeaks> _peaks = {};
+  /// without asking again. The lanes listen to the store for the answers, so
+  /// an arrival never rebuilds the table ([AudioLaneSummaries]).
+  final AudioLaneSummaries _summaries = AudioLaneSummaries();
 
   /// What each layer's peaks were fetched for: the window, the bucket count
   /// and the wave style. Equal keys mean the answer in hand is still the right
@@ -198,12 +200,11 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
   /// same key by design ([WaveformRequest]).
   final Map<String, String> _peakKeys = {};
 
-  /// Each spectral-mode layer's spectrogram window, and what it was
-  /// fetched for — the peaks' own bargain, for the other picture. A layer
-  /// holds one or the other, never both: the mode decides which fetch runs,
-  /// and the loser's entry is dropped so a long session does not keep two
-  /// summaries of every lane it has looked at.
-  final Map<String, BridgeSpectrogram> _spectra = {};
+  /// What each spectral-mode lane's spectrogram was fetched for — the peaks'
+  /// own bargain, for the other picture. A layer holds one summary or the
+  /// other, never both: the mode decides which fetch runs, and the loser's
+  /// entry is dropped so a long session does not keep two summaries of every
+  /// lane it has looked at.
   final Map<String, String> _spectraKeys = {};
 
   /// A lane-mode chip changed: fetch what the new mode needs. No
@@ -313,9 +314,9 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
       if (!_open.contains(waveformPath(id))) {
         // A shut lane keeps nothing: the window it was fetched for is stale by
         // the time it opens again, and the memory is a whole track's summary.
-        _peaks.remove(id);
+        _summaries.peaks.remove(id);
         _peakKeys.remove(id);
-        _spectra.remove(id);
+        _summaries.spectra.remove(id);
         _spectraKeys.remove(id);
         continue;
       }
@@ -338,7 +339,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
       // spectrogram in spectral mode, the peaks otherwise — never both.
       final mode = laneModes.of(id);
       if (mode == LaneMode.spectral) {
-        _peaks.remove(id);
+        _summaries.peaks.remove(id);
         _peakKeys.remove(id);
         final key = '${request.key}$retimed';
         if (_spectraKeys[id] == key) continue;
@@ -351,11 +352,12 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
         )
             .then((grid) {
           if (!mounted || _spectraKeys[id] != key) return;
-          setState(() => _spectra[id] = grid);
+          _summaries.spectra[id] = grid;
+          _summaries.changed();
         });
         continue;
       }
-      _spectra.remove(id);
+      _summaries.spectra.remove(id);
       _spectraKeys.remove(id);
       final bands = mode == LaneMode.stack;
       final key = '${request.key}|$bands$retimed';
@@ -375,7 +377,8 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
         // decoding; the newest ask wins, so an old answer is dropped rather
         // than drawn over a lane that has moved on.
         if (!mounted || _peakKeys[id] != key) return;
-        setState(() => _peaks[id] = peaks);
+        _summaries.peaks[id] = peaks;
+        _summaries.changed();
       });
     }
     _refreshMixPeaks(ui, viewStart, viewEnd);
@@ -435,7 +438,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
   /// `setState` only when an answer actually arrives.
   void _onLaneScroll() {
     if (_peakKeys.isEmpty &&
-        _peaks.isEmpty &&
+        _summaries.peaks.isEmpty &&
         _spectraKeys.isEmpty &&
         !_mixRowShown) {
       return;
@@ -2955,6 +2958,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
     _ui?.selectedEffects.removeListener(_onEffectSelectionChanged);
     _ui?.playheadFrame.removeListener(_edgeFollow);
     _boundTools?.removeListener(_onToolChanged);
+    _summaries.dispose();
     _zoomMotion.dispose();
     _barDrag.dispose();
     _layerDrag.dispose();
@@ -4232,8 +4236,7 @@ class _TimelinePanelFrbState extends State<TimelinePanelFrb>
                         clip: clip.id,
                         retime: BridgeScalar.keyframed(keys),
                       ),
-                      peaks: _peaks,
-                      spectra: _spectra,
+                      summaries: _summaries,
                       waveformStyle: _waveformStyle,
                       fps: ui.model.fps,
                       fpsNum: fpsNum,

--- a/flutter_ui/lib/panels/waveform_frb.dart
+++ b/flutter_ui/lib/panels/waveform_frb.dart
@@ -59,6 +59,8 @@
 // outline or the lane stack moves.
 
 import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:flutter/widgets.dart';
 import 'package:lumit_flutter/src/rust/api/layer.dart';
@@ -150,6 +152,30 @@ int _roundUpToPowerOfTwo(int n) {
     p *= 2;
   }
   return p;
+}
+
+/// What every open lane has been given to draw, and the word the lanes wait
+/// on.
+///
+/// A summary is fetched off the build and arrives whenever it arrives. The
+/// panel used to answer each arrival with a `setState` of its own, so opening
+/// ten lanes, or scrolling them, rebuilt the whole Timeline once per lane per
+/// window — the panel-wide rebuild docs/impl/ui-performance.md §4.4 rules out.
+/// The lanes listen here instead: an answer repaints the open waveform lanes
+/// and touches nothing else in the table.
+///
+/// The maps are written in place and the word is said once at the end of a
+/// pass, because a pass over the layers usually settles several of them.
+class AudioLaneSummaries extends ChangeNotifier {
+  /// Each layer's peaks, by layer id — the stretch of its source the lanes are
+  /// showing, summarised to one bucket per pixel column.
+  final Map<String, BridgeAudioPeaks> peaks = {};
+
+  /// Each spectral-mode lane's spectrogram window, the same bargain for the
+  /// other picture. A layer holds one or the other, never both.
+  final Map<String, BridgeSpectrogram> spectra = {};
+
+  void changed() => notifyListeners();
 }
 
 /// How a waveform is drawn — the two choices Settings offers, together,
@@ -268,8 +294,19 @@ class WaveformPainter extends CustomPainter {
     final held = peaks;
     if (held == null || held.buckets == 0 || held.values.isEmpty) return;
     if (!(held.endSeconds > held.startSeconds)) return;
-    final from = math.max(0.0, left);
-    final to = math.min(size.width, right);
+    // No zoom is no mapping from a column to a moment, so there is no wave to
+    // draw — the spectral lane refuses the same reading.
+    if (!(secondsPerPixel > 0)) return;
+    // Nothing outside the fetched window is drawn, so nothing outside it is
+    // walked either. The summary covers the visible stretch and half a view
+    // each side; the bar it sits in can be dozens of screenfuls wide once the
+    // zoom is in, and walking all of that to fill one screenful is most of the
+    // work a close-in lane was doing.
+    final from = math.max(
+        math.max(0.0, left), (held.startSeconds - originSeconds) / secondsPerPixel);
+    final to = math.min(
+        math.min(size.width, right),
+        (held.endSeconds - originSeconds) / secondsPerPixel);
     if (!(to > from)) return;
 
     final bands = _bandOrder;
@@ -298,6 +335,15 @@ class WaveformPainter extends CustomPainter {
     final buckets = held.buckets;
     final span = held.endSeconds - held.startSeconds;
     final curved = style.sqrtScale;
+    // Every column of a band goes into one list and is drawn in one call.
+    // A line at a time is a draw call per column per band, and a lane is a
+    // couple of thousand columns wide: ten stacked lanes came to sixty
+    // thousand calls a frame, which is what made the Audio workspace crawl.
+    // The picture is the same one, said in a way the rasteriser can take in a
+    // single bite.
+    final room = (to.ceil() - from.floor() + 1) * 4;
+    final bodyLines = Float32List(room);
+    final coreLines = stacked ? null : Float32List(room);
 
     for (var drawn = 0; drawn < bands.length; drawn++) {
       final band = bands[drawn].band;
@@ -314,6 +360,8 @@ class WaveformPainter extends CustomPainter {
       final core = Paint()
         ..color = colour
         ..strokeWidth = 1;
+      var bodyAt = 0;
+      var coreAt = 0;
 
       for (var x = from.floorToDouble(); x < to; x += 1) {
         final seconds = originSeconds + (x + 0.5) * secondsPerPixel;
@@ -326,32 +374,37 @@ class WaveformPainter extends CustomPainter {
         final hi = _level(held.values[base + 1].clamp(-1.0, 1.0), curved);
         final rms = _level(held.values[base + 2].clamp(0.0, 1.0), curved);
         if (lo == 0 && hi == 0 && rms == 0) continue;
+        bodyLines[bodyAt++] = x + 0.5;
         if (style.fromBottom) {
           // Rectified: the column reaches up by how far the signal swung
           // either way, whichever was further.
           final amp = math.max(hi.abs(), lo.abs());
-          canvas.drawLine(
-            Offset(x + 0.5, floor),
-            Offset(x + 0.5, floor - amp * reach),
-            body,
-          );
+          bodyLines[bodyAt++] = floor;
+          bodyLines[bodyAt++] = x + 0.5;
+          bodyLines[bodyAt++] = floor - amp * reach;
         } else {
-          canvas.drawLine(
-            Offset(x + 0.5, floor - hi * reach),
-            Offset(x + 0.5, floor - lo * reach),
-            body,
-          );
+          bodyLines[bodyAt++] = floor - hi * reach;
+          bodyLines[bodyAt++] = x + 0.5;
+          bodyLines[bodyAt++] = floor - lo * reach;
         }
         // The energy inside the envelope: what tells a sustained note from a
         // spike that happens to reach the same height. The stack says that
         // with its own brightness, so only the single wave draws it.
-        if (!stacked && rms > 0) {
-          canvas.drawLine(
-            Offset(x + 0.5, floor - rms * reach),
-            Offset(x + 0.5, style.fromBottom ? floor : floor + rms * reach),
-            core,
-          );
+        if (coreLines != null && rms > 0) {
+          coreLines[coreAt++] = x + 0.5;
+          coreLines[coreAt++] = floor - rms * reach;
+          coreLines[coreAt++] = x + 0.5;
+          coreLines[coreAt++] =
+              style.fromBottom ? floor : floor + rms * reach;
         }
+      }
+      if (bodyAt > 0) {
+        canvas.drawRawPoints(ui.PointMode.lines,
+            Float32List.view(bodyLines.buffer, 0, bodyAt), body);
+      }
+      if (coreLines != null && coreAt > 0) {
+        canvas.drawRawPoints(ui.PointMode.lines,
+            Float32List.view(coreLines.buffer, 0, coreAt), core);
       }
     }
   }

--- a/flutter_ui/test/waveform_test.dart
+++ b/flutter_ui/test/waveform_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:math' as math;
 import 'dart:typed_data';
+import 'dart:ui' show PointMode;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -555,6 +556,30 @@ void main() {
       }
     });
 
+    /// The lane is the widest thing on the table and the Audio workspace opens
+    /// ten of them. A line at a time was a draw call a column a band —
+    /// tens of thousands a frame — so a band goes down in one call now, and
+    /// the wave it draws is the wave it always drew.
+    test('a band is drawn in one call, however many columns it has', () {
+      final canvas = _RecordingCanvas();
+      WaveformPainter(
+        peaks: peaks(
+          start: 0,
+          end: 1,
+          bands: 3,
+          values: [...loud(600), ...loud(600), ...loud(600)],
+        ),
+        originSeconds: 0,
+        secondsPerPixel: 1 / 600,
+        left: 0,
+        right: 600,
+        colours: colours,
+      ).paint(canvas, const Size(600, 30));
+      expect(canvas.lines.length, greaterThan(1500),
+          reason: 'every column of every band is still drawn');
+      expect(canvas.calls, 3, reason: 'one call a band');
+    });
+
     test('no peaks, or empty peaks, draw nothing at all', () {
       for (final held in [
         null,
@@ -586,9 +611,27 @@ class _Stroke {
 class _RecordingCanvas implements Canvas {
   final List<_Stroke> lines = [];
 
+  /// How many times the painter asked the canvas for anything — the number
+  /// the batching is about.
+  int calls = 0;
+
   @override
-  void drawLine(Offset p1, Offset p2, Paint paint) =>
-      lines.add(_Stroke(p1, p2, paint.color));
+  void drawLine(Offset p1, Offset p2, Paint paint) {
+    calls++;
+    lines.add(_Stroke(p1, p2, paint.color));
+  }
+
+  /// The painter batches a band's columns into one call; a pair of points is
+  /// the line it used to draw one at a time, so the recorded list reads the
+  /// same either way.
+  @override
+  void drawRawPoints(PointMode pointMode, Float32List points, Paint paint) {
+    calls++;
+    for (var i = 0; i + 3 < points.length; i += 4) {
+      lines.add(_Stroke(Offset(points[i], points[i + 1]),
+          Offset(points[i + 2], points[i + 3]), paint.color));
+    }
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;


### PR DESCRIPTION
Every lane was a draw call per pixel column per band, so four or five
open waveform lanes started to drag and ten was worse. A band's columns
go down in one call now, the painter walks the summary it was handed
rather than the whole bar, and peaks arriving no longer rebuild the
whole timeline.

To test, open the Audio workspace on a comp with ten or so sounding
layers, twirl the Waveform lanes open and scroll and zoom the lane area.
Try the lane chips as well, the plain wave and the spectrogram should
look exactly as they did.

Recording ten lanes went from 46.6 to 8.0 ms a frame in the test VM. A
probe run in the real conditions is still owed, docs/impl/ui-performance.md
4.6 says so.
